### PR TITLE
When dispatched empty Outbox operations to free up storage

### DIFF
--- a/src/SqlPersistence/Outbox/OutboxCommandBuilder.cs
+++ b/src/SqlPersistence/Outbox/OutboxCommandBuilder.cs
@@ -34,7 +34,8 @@ where MessageId = @MessageId";
 update {tableName}
 set
     Dispatched = 1,
-    DispatchedAt = @DispatchedAt
+    DispatchedAt = @DispatchedAt,
+    Operations = '[]'
 where MessageId = @MessageId";
             return new OutboxCommands(
                 store: storeCommandText,


### PR DESCRIPTION
When the Outbox document is marked as dispatched, the outgoing transport operations are no longer needed. This update will clear the transport operations at that point, saving space in the database, and making it more efficient to remove Outbox records that have expired.