### PR TITLE
[SPIKE] Infer correlation property from ConfigureMapping IL if possible

### DIFF
--- a/src/ScriptBuilder.Tests/Saga/InferCorrelationIdTests.DualMapping.approved.txt
+++ b/src/ScriptBuilder.Tests/Saga/InferCorrelationIdTests.DualMapping.approved.txt
@@ -1,0 +1,9 @@
+﻿{
+  "TableSuffix": "DualMappingSaga",
+  "CorrelationProperty": {
+    "Type": "String",
+    "Name": "Correlation"
+  },
+  "TransitionalCorrelationProperty": null,
+  "Name": "InferCorrelationIdTests/DualMappingSaga"
+}

--- a/src/ScriptBuilder.Tests/Saga/InferCorrelationIdTests.SingleMapping.approved.txt
+++ b/src/ScriptBuilder.Tests/Saga/InferCorrelationIdTests.SingleMapping.approved.txt
@@ -1,0 +1,9 @@
+﻿{
+  "TableSuffix": "SingleMappingSaga",
+  "CorrelationProperty": {
+    "Type": "String",
+    "Name": "Correlation"
+  },
+  "TransitionalCorrelationProperty": null,
+  "Name": "InferCorrelationIdTests/SingleMappingSaga"
+}

--- a/src/ScriptBuilder.Tests/Saga/InferCorrelationIdTests.SingleMappingValueType.approved.txt
+++ b/src/ScriptBuilder.Tests/Saga/InferCorrelationIdTests.SingleMappingValueType.approved.txt
@@ -1,0 +1,9 @@
+﻿{
+  "TableSuffix": "SingleMappingValueTypeSaga",
+  "CorrelationProperty": {
+    "Type": "Int",
+    "Name": "Correlation"
+  },
+  "TransitionalCorrelationProperty": null,
+  "Name": "InferCorrelationIdTests/SingleMappingValueTypeSaga"
+}

--- a/src/ScriptBuilder.Tests/Saga/InferCorrelationIdTests.cs
+++ b/src/ScriptBuilder.Tests/Saga/InferCorrelationIdTests.cs
@@ -42,6 +42,28 @@ public class InferCorrelationIdTests
     }
 
     [Test]
+    public void SingleMappingValueType()
+    {
+        var dataType = module.GetTypeDefinition<SingleMappingValueTypeSaga>();
+        SagaDefinition definition;
+        SagaDefinitionReader.TryGetSqlSagaDefinition(dataType, out definition);
+        ObjectApprover.VerifyWithJson(definition);
+    }
+
+    public class SingleMappingValueTypeSaga : Saga<SingleMappingValueTypeSaga.SagaData>
+    {
+        public class SagaData : ContainSagaData
+        {
+            public int Correlation { get; set; }
+        }
+
+        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+        {
+            mapper.ConfigureMapping<MessageA>(msg => msg.Correlation).ToSaga(saga => saga.Correlation);
+        }
+    }
+
+    [Test]
     public void DualMapping()
     {
         var dataType = module.GetTypeDefinition<DualMappingSaga>();

--- a/src/ScriptBuilder.Tests/Saga/InferCorrelationIdTests.cs
+++ b/src/ScriptBuilder.Tests/Saga/InferCorrelationIdTests.cs
@@ -1,0 +1,284 @@
+﻿using System;
+using System.IO;
+using Mono.Cecil;
+using NServiceBus;
+using NServiceBus.Persistence.Sql;
+using NServiceBus.Persistence.Sql.ScriptBuilder;
+using NUnit.Framework;
+using ObjectApproval;
+
+[TestFixture]
+public class InferCorrelationIdTests
+{
+    ModuleDefinition module;
+
+    public InferCorrelationIdTests()
+    {
+        var path = Path.Combine(TestContext.CurrentContext.TestDirectory, "ScriptBuilder.Tests.dll");
+        var readerParameters = new ReaderParameters(ReadingMode.Deferred);
+        module = ModuleDefinition.ReadModule(path, readerParameters);
+    }
+
+    [Test]
+    public void SingleMapping()
+    {
+        var dataType = module.GetTypeDefinition<SingleMappingSaga>();
+        SagaDefinition definition;
+        SagaDefinitionReader.TryGetSqlSagaDefinition(dataType, out definition);
+        ObjectApprover.VerifyWithJson(definition);
+    }
+
+    public class SingleMappingSaga : Saga<SingleMappingSaga.SagaData>
+    {
+        public class SagaData : ContainSagaData
+        {
+            public string Correlation { get; set; }
+        }
+
+        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+        {
+            mapper.ConfigureMapping<MessageA>(msg => msg.Correlation).ToSaga(saga => saga.Correlation);
+        }
+    }
+
+    [Test]
+    public void DualMapping()
+    {
+        var dataType = module.GetTypeDefinition<DualMappingSaga>();
+        SagaDefinition definition;
+        SagaDefinitionReader.TryGetSqlSagaDefinition(dataType, out definition);
+        ObjectApprover.VerifyWithJson(definition);
+    }
+
+    public class DualMappingSaga : Saga<DualMappingSaga.SagaData>
+    {
+        public class SagaData : ContainSagaData
+        {
+            public string Correlation { get; set; }
+        }
+
+        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+        {
+            mapper.ConfigureMapping<MessageA>(msg => msg.Correlation).ToSaga(saga => saga.Correlation);
+            mapper.ConfigureMapping<MessageB>(msg => msg.Correlation).ToSaga(saga => saga.Correlation);
+        }
+    }
+
+    [Test]
+    public void DontMapWithIntermediateBase()
+    {
+        var dataType = module.GetTypeDefinition<HasBaseSagaClass>();
+        SagaDefinition definition;
+        SagaDefinitionReader.TryGetSqlSagaDefinition(dataType, out definition);
+        Assert.IsNull(definition);
+    }
+
+    public class HasBaseSagaClass : BaseSaga<HasBaseSagaClass.SagaData>
+    {
+        public class SagaData : ContainSagaData
+        {
+            public string Correlation { get; set; }
+        }
+
+        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+        {
+            base.ConfigureHowToFindSaga(mapper);
+            mapper.ConfigureMapping<MessageA>(msg => msg.Correlation).ToSaga(saga => saga.Correlation);
+        }
+    }
+
+    public class BaseSaga<TSaga> : Saga<TSaga>
+        where TSaga : IContainSagaData, new()
+    {
+        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TSaga> mapper)
+        {
+
+        }
+    }
+
+    [Test]
+    public void DontAllowMethodCallInMapping()
+    {
+        var dataType = module.GetTypeDefinition<MethodCallInMappingSaga>();
+        Assert.Throws<ErrorsException>(() =>
+        {
+            SagaDefinition definition;
+            SagaDefinitionReader.TryGetSqlSagaDefinition(dataType, out definition);
+        });
+
+    }
+
+    public class MethodCallInMappingSaga : Saga<MethodCallInMappingSaga.SagaData>
+    {
+        public class SagaData : ContainSagaData
+        {
+            public string Correlation { get; set; }
+        }
+
+        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+        {
+            mapper.ConfigureMapping<MessageA>(msg => msg.Correlation).ToSaga(saga => MapInMethod(saga));
+        }
+
+        static object MapInMethod(SagaData data)
+        {
+            return data.Correlation;
+        }
+    }
+
+    [Test]
+    public void DontAllowPassingMapper()
+    {
+        var dataType = module.GetTypeDefinition<PassingMapperSaga>();
+        Assert.Throws<ErrorsException>(() =>
+        {
+            SagaDefinition definition;
+            SagaDefinitionReader.TryGetSqlSagaDefinition(dataType, out definition);
+        });
+
+    }
+
+    public class PassingMapperSaga : Saga<PassingMapperSaga.SagaData>
+    {
+        public class SagaData : ContainSagaData
+        {
+            public string Correlation { get; set; }
+        }
+
+        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+        {
+            PassTheMapper(mapper);
+        }
+
+        static void PassTheMapper(SagaPropertyMapper<SagaData> mapper)
+        {
+            mapper.ConfigureMapping<MessageA>(msg => msg.Correlation).ToSaga(saga => saga.Correlation);
+        }
+    }
+
+    [Test]
+    public void DontMapConflictingCorrelationIds()
+    {
+        var dataType = module.GetTypeDefinition<ConflictingCorrelationSaga>();
+        Assert.Throws<ErrorsException>(() =>
+        {
+            SagaDefinition definition;
+            SagaDefinitionReader.TryGetSqlSagaDefinition(dataType, out definition);
+        });
+
+    }
+
+    public class ConflictingCorrelationSaga : Saga<ConflictingCorrelationSaga.SagaData>
+    {
+        public class SagaData : ContainSagaData
+        {
+            public string Correlation { get; set; }
+            public string OtherProperty { get; set; }
+        }
+
+        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+        {
+            mapper.ConfigureMapping<MessageA>(msg => msg.Correlation).ToSaga(saga => saga.Correlation);
+            mapper.ConfigureMapping<MessageB>(msg => msg.Correlation).ToSaga(saga => saga.OtherProperty);
+        }
+    }
+
+    [Test]
+    public void DontMapSwitchingLogic()
+    {
+        var dataType = module.GetTypeDefinition<SwitchingLogicSaga>();
+        Assert.Throws<ErrorsException>(() =>
+        {
+            SagaDefinition definition;
+            SagaDefinitionReader.TryGetSqlSagaDefinition(dataType, out definition);
+        });
+
+    }
+
+    public class SwitchingLogicSaga : Saga<SwitchingLogicSaga.SagaData>
+    {
+        int number = 0;
+
+        public class SagaData : ContainSagaData
+        {
+            public string Correlation { get; set; }
+            public string OtherProperty { get; set; }
+        }
+
+        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+        {
+            if (number > 0)
+            {
+                mapper.ConfigureMapping<MessageA>(msg => msg.Correlation).ToSaga(saga => saga.Correlation);
+            }
+            else
+            {
+                mapper.ConfigureMapping<MessageB>(msg => msg.Correlation).ToSaga(saga => saga.Correlation);
+            }
+        }
+    }
+
+    [Test]
+    public void DontMapDelegateCalls()
+    {
+        var dataType = module.GetTypeDefinition<DelegateCallingSaga>();
+        Assert.Throws<ErrorsException>(() =>
+        {
+            SagaDefinition definition;
+            SagaDefinitionReader.TryGetSqlSagaDefinition(dataType, out definition);
+        });
+
+    }
+
+    public class DelegateCallingSaga : Saga<DelegateCallingSaga.SagaData>
+    {
+        public class SagaData : ContainSagaData
+        {
+            public string Correlation { get; set; }
+        }
+
+        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+        {
+            Action action = () => mapper.ConfigureMapping<MessageA>(msg => msg.Correlation).ToSaga(saga => saga.Correlation);
+            action();
+        }
+    }
+    [Test]
+    public void DontAllowLooping()
+    {
+        var dataType = module.GetTypeDefinition<LoopingSaga>();
+        Assert.Throws<ErrorsException>(() =>
+        {
+            SagaDefinition definition;
+            SagaDefinitionReader.TryGetSqlSagaDefinition(dataType, out definition);
+        });
+
+    }
+
+    public class LoopingSaga : Saga<LoopingSaga.SagaData>
+    {
+        public class SagaData : ContainSagaData
+        {
+            public string Correlation { get; set; }
+        }
+
+        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+        {
+            for (var i = 0; i < 3; i++)
+            {
+                mapper.ConfigureMapping<MessageA>(msg => msg.Correlation).ToSaga(saga => saga.Correlation);
+            }
+        }
+    }
+
+    public class MessageA : ICommand
+    {
+        public string Correlation { get; set; }
+    }
+
+    public class MessageB : ICommand
+    {
+        public string Correlation { get; set; }
+    }
+
+}

--- a/src/ScriptBuilder.Tests/ScriptBuilder.Tests.csproj
+++ b/src/ScriptBuilder.Tests/ScriptBuilder.Tests.csproj
@@ -98,6 +98,7 @@
     <Compile Include="AssemblySqlPersistenceSettingsAttribute.cs" />
     <Compile Include="ApprovalTestConfig.cs" />
     <Compile Include="Extensions.cs" />
+    <Compile Include="Saga\InferCorrelationIdTests.cs" />
     <Compile Include="SqlAttributeParametersReadersTest.cs" />
     <Compile Include="Saga\SagaDefinitionReaderTest.cs" />
     <Compile Include="Saga\SagaDefinitionValidatorTest.cs" />


### PR DESCRIPTION
I had this half done locally before #40 was closed, and I think I succeeded.

It's based upon being very conservative and assuming the user will stay within well-established conventions for the ConfigureHowToFindSaga method, and bails out (deferring to the attribute) if anything is out of place.

This is the flow:

* Attempt to access the attribute first, it is always overriding
* Bail out if the saga class does not directly inherit NServiceBus.Saga<T> so that nothing funky can happen in an intermediate base class
* Within the IL of the ConfigureHowToFindSaga method, we should be OK if there is no branching logic and we don't call into any method or delegate that isn't specifically allowed
  * Bail out if any branching OpCode is encountered
  * Inspect every Call/Calli/Callvirt OpCode, bailing out if any unknown method is called
    * Attempt to optimize perf by performing string equality operations before StartsWith operations for generic types
  * Inspect Ldtoken OpCodes where the declaring type is the saga data type, as these identify the `saga.Correlation` portion of the `.ToSaga(saga => saga.Correlation)` calls.
    * Ensure that all these calls within the method point to the same property, otherwise bail out

I have tests for:

* Mapping a single message type
* Mapping two message types
* Mapping with an int CorrelationId to cover boxing instructions
* Failure cases for:
  * Saga with a non-abstract intermediate base class
  * Method is called within the .ToSaga() expression
  * SagaPropertyMapper is passed to another method
  * Two messages mapped with conflicting correlation ids
  * If/then branching logic used in mapping method
  * ConfigureMapping called within an Action delegate
  * Looping used in mapping method

@SimonCropp @danielmarbach 