### PR TITLE
Enable periodic cleanup of expired outbox records

### DIFF
--- a/src/SqlPersistence.Tests/Outbox/OutboxPersisterTests.cs
+++ b/src/SqlPersistence.Tests/Outbox/OutboxPersisterTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data.Common;
+using System.Threading;
 using System.Threading.Tasks;
 using NServiceBus.Outbox;
 using NServiceBus.Persistence.Sql.ScriptBuilder;
@@ -148,4 +149,63 @@ where MessageId = '{result.MessageId}'";
         return await persister.Get(messageId, null);
     }
 
+    [Test]
+    public async Task StoreAndCleanup()
+    {
+        using (var connection = await dbConnection.OpenConnection())
+        {
+            for (var i = 0; i < 13; i++)
+            {
+                await Store(i, connection);
+            }
+        }
+
+        await Task.Delay(1000);
+        var dateTime = DateTime.UtcNow;
+        await Task.Delay(1000);
+        using (var connection = await dbConnection.OpenConnection())
+        {
+            await Store(13, connection);
+        }
+
+        await persister.RemoveEntriesOlderThan(dateTime, CancellationToken.None);
+        Assert.IsNull(await persister.Get("MessageId1", null));
+        Assert.IsNull(await persister.Get("MessageId12", null));
+        Assert.IsNotNull(await persister.Get("MessageId13", null));
+    }
+
+    async Task Store(int i, DbConnection connection)
+    {
+        var operations = new[]
+        {
+            new TransportOperation(
+                messageId: "OperationId" + i,
+                options: new Dictionary<string, string>
+                {
+                    {
+                        "OptionKey1", "OptionValue1"
+                    }
+                },
+                body: new byte[]
+                {
+                    0x20
+                },
+                headers: new Dictionary<string, string>
+                {
+                    {
+                        "HeaderKey1", "HeaderValue1"
+                    }
+                }
+            )
+        };
+        var messageId = "MessageId" + i;
+        var outboxMessage = new OutboxMessage(messageId, operations);
+
+        using (var transaction = connection.BeginTransaction())
+        {
+            await persister.Store(outboxMessage, transaction, connection);
+            transaction.Commit();
+        }
+        await persister.SetAsDispatched(messageId, null);
+    }
 }

--- a/src/SqlPersistence/Outbox/OutboxCleaner.cs
+++ b/src/SqlPersistence/Outbox/OutboxCleaner.cs
@@ -71,5 +71,5 @@ class OutboxCleaner : FeatureStartupTask
     Task task;
     CancellationTokenSource tokenSource;
 
-    static ILog log = NServiceBus.Logging.LogManager.GetLogger<OutboxCleaner>();
+    static ILog log = LogManager.GetLogger<OutboxCleaner>();
 }

--- a/src/SqlPersistence/Outbox/OutboxCleaner.cs
+++ b/src/SqlPersistence/Outbox/OutboxCleaner.cs
@@ -36,13 +36,13 @@ class OutboxCleaner : FeatureStartupTask
                 {
                     // noop
                 }
-                catch (Exception ex)
+                catch (Exception exception)
                 {
-                    log.Error("Error cleaning outbox data", ex);
+                    log.Error("Error cleaning outbox data", exception);
                     cleanupFailures++;
                     if (cleanupFailures >= 10)
                     {
-                        criticalError.Raise("Failed to clean expired Outbox records after 10 consecutive unsuccessful attempts. The most likely cause of this is connectivity issues with your database.", ex);
+                        criticalError.Raise("Failed to clean expired Outbox records after 10 consecutive unsuccessful attempts. The most likely cause of this is connectivity issues with the database.", exception);
                         cleanupFailures = 0;
                     }
                 }

--- a/src/SqlPersistence/Outbox/OutboxCleaner.cs
+++ b/src/SqlPersistence/Outbox/OutboxCleaner.cs
@@ -3,41 +3,73 @@ using System.Threading;
 using System.Threading.Tasks;
 using NServiceBus;
 using NServiceBus.Features;
+using NServiceBus.Logging;
 
 class OutboxCleaner : FeatureStartupTask
 {
-    OutboxPersister outboxPersister;
-
-    public OutboxCleaner(OutboxPersister outboxPersister, TimeSpan timeToKeepDeduplicationData, TimeSpan frequencyToRunCleanup)
+    public OutboxCleaner(OutboxPersister outboxPersister, CriticalError criticalError, TimeSpan timeToKeepDeduplicationData, TimeSpan frequencyToRunCleanup)
     {
-        cancellationTokenSource = new CancellationTokenSource();
         this.timeToKeepDeduplicationData = timeToKeepDeduplicationData;
         this.frequencyToRunCleanup = frequencyToRunCleanup;
         this.outboxPersister = outboxPersister;
+        this.criticalError = criticalError;
     }
 
-    protected override async Task OnStart(IMessageSession session)
+    protected override Task OnStart(IMessageSession session)
     {
-        await Task.Delay(TimeSpan.FromMinutes(1));
-        while (true)
+        tokenSource = new CancellationTokenSource();
+        var token = tokenSource.Token;
+
+        task = Task.Run(async () =>
         {
-            await Task.Delay(frequencyToRunCleanup, cancellationTokenSource.Token);
-            if (cancellationTokenSource.IsCancellationRequested)
+            var cleanupFailures = 0;
+            while (!token.IsCancellationRequested)
             {
-                break;
+                try
+                {
+                    var dateTime = DateTime.UtcNow - timeToKeepDeduplicationData;
+                    await Task.Delay(frequencyToRunCleanup, token);
+                    await outboxPersister.RemoveEntriesOlderThan(dateTime, token);
+                    cleanupFailures = 0;
+                }
+                catch (OperationCanceledException)
+                {
+                    // noop
+                }
+                catch (Exception ex)
+                {
+                    log.Error("Error cleaning outbox data", ex);
+                    cleanupFailures++;
+                    if (cleanupFailures >= 10)
+                    {
+                        criticalError.Raise("Failed to clean expired Outbox records after 10 consecutive unsuccessful attempts. The most likely cause of this is connectivity issues with your database.", ex);
+                        cleanupFailures = 0;
+                    }
+                }
             }
-            var dateTime = DateTime.UtcNow - timeToKeepDeduplicationData;
-            await outboxPersister.RemoveEntriesOlderThan(dateTime, cancellationTokenSource.Token);
-        }
+        }, CancellationToken.None);
+        return Task.FromResult(0);
     }
 
     protected override Task OnStop(IMessageSession session)
     {
-        cancellationTokenSource.Cancel();
-        return Task.FromResult(true);
+        if (tokenSource == null)
+        {
+            return Task.FromResult(0);
+        }
+
+        tokenSource.Cancel();
+        tokenSource.Dispose();
+
+        return task ?? Task.FromResult(0);
     }
 
+    OutboxPersister outboxPersister;
+    CriticalError criticalError;
     TimeSpan timeToKeepDeduplicationData;
     TimeSpan frequencyToRunCleanup;
-    CancellationTokenSource cancellationTokenSource;
+    Task task;
+    CancellationTokenSource tokenSource;
+
+    static ILog log = NServiceBus.Logging.LogManager.GetLogger<OutboxCleaner>();
 }

--- a/src/SqlPersistence/Outbox/OutboxCommandBuilder.cs
+++ b/src/SqlPersistence/Outbox/OutboxCommandBuilder.cs
@@ -27,7 +27,7 @@ values
 )";
 
             string cleanupCommandText = $@"
-delete from {tableName} where Dispatched = true And DispatchedAt < @Date";
+delete from {tableName} where Dispatched = 1 And DispatchedAt < @Date";
 
             string getCommandText = $@"
 select

--- a/src/SqlPersistence/Outbox/OutboxPersister.cs
+++ b/src/SqlPersistence/Outbox/OutboxPersister.cs
@@ -110,13 +110,10 @@ class OutboxPersister : IOutboxStorage
 
     public async Task RemoveEntriesOlderThan(DateTime dateTime, CancellationToken cancellationToken)
     {
-        using (new TransactionScope(TransactionScopeOption.Suppress))
         using (var connection = await connectionBuilder.OpenConnection())
-        using (var transaction = connection.BeginTransaction(IsolationLevel.ReadCommitted))
         using (var command = connection.CreateCommand())
         {
             command.CommandText = outboxCommands.Cleanup;
-            command.Transaction = transaction;
             command.AddParameter("Date", dateTime);
             await command.ExecuteNonQueryEx(cancellationToken);
         }

--- a/src/SqlPersistence/Outbox/SqlOutboxFeature.cs
+++ b/src/SqlPersistence/Outbox/SqlOutboxFeature.cs
@@ -19,7 +19,6 @@ class SqlOutboxFeature : Feature
         var endpointName = settings.GetTablePrefix();
         var outboxPersister = new OutboxPersister(sqlVariant, connectionBuilder, endpointName);
         context.Container.ConfigureComponent(b => outboxPersister, DependencyLifecycle.InstancePerCall);
-        var cleanerTask = new OutboxCleaner(outboxPersister, TimeSpan.FromDays(7), TimeSpan.FromMinutes(1)); //Default values from NHibernate persister
-        context.RegisterStartupTask(cleanerTask);
+        context.RegisterStartupTask(b => new OutboxCleaner(outboxPersister, b.Build<CriticalError>(), TimeSpan.FromDays(7), TimeSpan.FromMinutes(1)));
     }
 }

--- a/src/SqlPersistence/Outbox/SqlOutboxFeature.cs
+++ b/src/SqlPersistence/Outbox/SqlOutboxFeature.cs
@@ -1,4 +1,5 @@
-﻿using NServiceBus;
+﻿using System;
+using NServiceBus;
 using NServiceBus.Features;
 using NServiceBus.Persistence;
 
@@ -18,5 +19,7 @@ class SqlOutboxFeature : Feature
         var endpointName = settings.GetTablePrefix();
         var outboxPersister = new OutboxPersister(sqlVariant, connectionBuilder, endpointName);
         context.Container.ConfigureComponent(b => outboxPersister, DependencyLifecycle.InstancePerCall);
+        var cleanerTask = new OutboxCleaner(outboxPersister, TimeSpan.FromDays(7), TimeSpan.FromMinutes(1)); //Default values from NHibernate persister
+        context.RegisterStartupTask(cleanerTask);
     }
 }


### PR DESCRIPTION
Wires up the outbox cleaner task using the defaults same as in NHibernate persister:
 * Cleanup interval 1 minute
 * Outbox record life 7 days