### PR TITLE
remove saga attribute

### DIFF
--- a/src/ScriptBuilder.Tests/Saga/SagaDefinitionReaderTest.cs
+++ b/src/ScriptBuilder.Tests/Saga/SagaDefinitionReaderTest.cs
@@ -98,9 +98,6 @@ public class SagaDefinitionReaderTest
         ObjectApprover.VerifyWithJson(definition);
     }
 
-    [SqlSaga(
-        TransitionalCorrelationProperty = nameof(SagaData.Transitional)
-    )]
     public class SimpleSaga : SqlSaga<SimpleSaga.SagaData>
     {
         public class SagaData : ContainSagaData
@@ -108,6 +105,8 @@ public class SagaDefinitionReaderTest
             public string Correlation { get; set; }
             public string Transitional { get; set; }
         }
+
+        protected override string TransitionalCorrelationPropertyName => nameof(SagaData.Transitional);
 
         protected override string CorrelationPropertyName => nameof(SagaData.Correlation);
 
@@ -174,9 +173,6 @@ public class SagaDefinitionReaderTest
         ObjectApprover.VerifyWithJson(definition);
     }
 
-    [SqlSaga(
-        TableSuffix = "TheTableSuffix"
-    )]
     public class TableSuffixSaga : SqlSaga<TableSuffixSaga.SagaData>
     {
         public class SagaData : ContainSagaData
@@ -184,6 +180,7 @@ public class SagaDefinitionReaderTest
             public string Correlation { get; set; }
         }
 
+        protected override string TableSuffix => "TheTableSuffix";
         protected override string CorrelationPropertyName => nameof(SagaData.Correlation);
 
         protected override void ConfigureMapping(IMessagePropertyMapper mapper)
@@ -200,7 +197,6 @@ public class SagaDefinitionReaderTest
         ObjectApprover.VerifyWithJson(definition);
     }
 
-    [SqlSaga]
     public class WithNoCorrelationSaga : SqlSaga<WithNoCorrelationSaga.SagaData>
     {
         public class SagaData : ContainSagaData

--- a/src/ScriptBuilder/CecilExtentions.cs
+++ b/src/ScriptBuilder/CecilExtentions.cs
@@ -29,7 +29,7 @@ static class CecilExtentions
         {
             return property;
         }
-        throw new ErrorsException($@"Expected to to find a property a property named '{propertyName}' on '{type.FullName}'.");
+        throw new ErrorsException($@"Expected to find a property named '{propertyName}' on '{type.FullName}'.");
     }
 
     public static bool TryGetProperty(this TypeDefinition type, string propertyName, out PropertyDefinition property)

--- a/src/ScriptBuilder/CecilExtentions.cs
+++ b/src/ScriptBuilder/CecilExtentions.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using Mono.Cecil;
+using Mono.Cecil.Cil;
+using NServiceBus.Persistence.Sql;
 
 static class CecilExtentions
 {
@@ -18,6 +20,47 @@ static class CecilExtentions
             .SingleOrDefault(argument => argument.Name == name)
             .Argument.Value;
         return value != null && (bool)value;
+    }
+
+    public static PropertyDefinition GetProperty(this TypeDefinition type, string propertyName)
+    {
+        var property = type.Properties.SingleOrDefault(_ => _.Name == propertyName);
+        if (property != null)
+        {
+            return property;
+        }
+        throw new ErrorsException($@"Expected to to find a property a property named '{propertyName}' on '{type.FullName}'.");
+    }
+
+    public static bool TryGetProperty(this TypeDefinition type, string propertyName, out PropertyDefinition property)
+    {
+        property = type.Properties.SingleOrDefault(_ => _.Name == propertyName);
+        return property != null;
+    }
+
+    public static bool TryGetPropertyAssignment(this PropertyDefinition property, out string value)
+    {
+        value = null;
+        var instructions = property.GetMethod.Body.Instructions;
+        if (instructions.Count != 2)
+        {
+            return false;
+        }
+        if (instructions[1].OpCode != OpCodes.Ret)
+        {
+            return false;
+        }
+        var first = instructions[0];
+        if (first.OpCode == OpCodes.Ldstr)
+        {
+            value = (string)first.Operand;
+            return true;
+        }
+        if (first.OpCode == OpCodes.Ldnull)
+        {
+            return true;
+        }
+        return false;
     }
 
     public static CustomAttribute GetSingleAttribute(this TypeDefinition type, string attributeName)

--- a/src/SqlPersistence.Tests/APIApprovals.Approve.approved.txt
+++ b/src/SqlPersistence.Tests/APIApprovals.Approve.approved.txt
@@ -75,17 +75,16 @@
         protected SqlSaga() { }
         protected abstract string CorrelationPropertyName { get; }
         public TSagaData Data { get; set; }
+        protected virtual string TableSuffix { get; }
+        protected virtual string TransitionalCorrelationPropertyName { get; }
         protected override void ConfigureHowToFindSaga(NServiceBus.IConfigureHowToFindSagaWithMessage mapper) { }
         protected abstract void ConfigureMapping(NServiceBus.Persistence.Sql.IMessagePropertyMapper mapper);
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.All, Inherited=false)]
+    [System.ObsoleteAttribute(@"Replaced by overrides on SqlSaga.\r\n * For correlationProperty override CorrelationPropertyName on the saga implementing SqlSaga<T>.\r\n * For transitionalCorrelationProperty override TransitionalCorrelationPropertyName on the saga implementing SqlSaga<T>\r\n * For tableSuffix override TableSuffix on the saga implementing SqlSaga<T>. Will be removed in version 3.0.0.", true)]
     public sealed class SqlSagaAttribute : System.Attribute
     {
-        [System.ObsoleteAttribute(@"This constructor is obsolete.\r\n * For correlationProperty override CorrelationPropertyName on the saga implementing SqlSaga<T>.\r\n * For transitionalCorrelationProperty use the property SqlSagaAttribute.TransitionalCorrelationProperty\r\n * For tableSuffix use the property SqlSagaAttribute.TableSuffix. Will be removed in version 3.0.0.", true)]
         public SqlSagaAttribute(string correlationProperty = null, string transitionalCorrelationProperty = null, string tableSuffix = null) { }
-        public SqlSagaAttribute() { }
-        public string TableSuffix { get; set; }
-        public string TransitionalCorrelationProperty { get; set; }
     }
     public enum SqlVariant
     {

--- a/src/SqlPersistence.Tests/Saga/SagaPersisterTests.cs
+++ b/src/SqlPersistence.Tests/Saga/SagaPersisterTests.cs
@@ -342,9 +342,6 @@ public abstract class SagaPersisterTests
         }
     }
 
-    [SqlSaga(
-        TransitionalCorrelationProperty = nameof(SagaData.TransitionalCorrelationProperty)
-    )]
     public class SagaWithCorrelationAndTransitional : SqlSaga<SagaWithCorrelationAndTransitional.SagaData>
     {
         public class SagaData : ContainSagaData
@@ -355,6 +352,7 @@ public abstract class SagaPersisterTests
         }
 
         protected override string CorrelationPropertyName => nameof(SagaData.CorrelationProperty);
+        protected override string TransitionalCorrelationPropertyName => nameof(SagaData.TransitionalCorrelationProperty);
 
         protected override void ConfigureMapping(IMessagePropertyMapper mapper)
         {

--- a/src/SqlPersistence/Saga/SqlSaga.cs
+++ b/src/SqlPersistence/Saga/SqlSaga.cs
@@ -41,6 +41,18 @@ namespace NServiceBus.Persistence.Sql
         protected abstract string CorrelationPropertyName { get; }
 
         /// <summary>
+        /// Gets the name of the transitional property for <typeparamref name="TSagaData"/>.
+        /// Used to transition between different properties for saga correlation.
+        /// </summary>
+        protected virtual string TransitionalCorrelationPropertyName { get; }
+
+        /// <summary>
+        /// The name of the table to use when storing the current <see cref="SqlSaga{TSagaData}"/>. 
+        /// Will be appended to the value specified in <see cref="SqlPersistenceConfig.TablePrefix"/>.
+        /// </summary>
+        protected virtual string TableSuffix { get; }
+
+        /// <summary>
         /// The saga's strongly typed data. Wraps <see cref="Saga.Entity" />.
         /// </summary>
         public TSagaData Data

--- a/src/SqlPersistence/Saga/SqlSagaAttribute.cs
+++ b/src/SqlPersistence/Saga/SqlSagaAttribute.cs
@@ -1,45 +1,23 @@
 ﻿using System;
+#pragma warning disable 1591
 
 namespace NServiceBus.Persistence.Sql
 {
-    /// <summary>
-    /// Exposes extra configuration options for <see cref="SqlSaga{TSagaData}"/>.
-    /// </summary>
+    [ObsoleteEx(
+        Message = @"Replaced by overrides on SqlSaga.
+ * For correlationProperty override CorrelationPropertyName on the saga implementing SqlSaga<T>.
+ * For transitionalCorrelationProperty override TransitionalCorrelationPropertyName on the saga implementing SqlSaga<T>
+ * For tableSuffix override TableSuffix on the saga implementing SqlSaga<T>",
+        RemoveInVersion = "3.0",
+        TreatAsErrorFromVersion = "2.0")]
     [AttributeUsage(AttributeTargets.Class, Inherited = false)]
     public sealed class SqlSagaAttribute : Attribute
     {
-        /// <summary>
-        /// Obsolete
-        /// </summary>
-        [ObsoleteEx(
-            Message= @"This constructor is obsolete.
- * For correlationProperty override CorrelationPropertyName on the saga implementing SqlSaga<T>.
- * For transitionalCorrelationProperty use the property " + nameof(SqlSagaAttribute) + "." + nameof(TransitionalCorrelationProperty) + @"
- * For tableSuffix use the property " + nameof(SqlSagaAttribute) + "." + nameof(TableSuffix) ,
-            RemoveInVersion = "3.0",
-            TreatAsErrorFromVersion = "2.0")]
         public SqlSagaAttribute(
             string correlationProperty = null,
             string transitionalCorrelationProperty = null,
-            string tableSuffix = null) { }
-
-        /// <summary>
-        /// Initializes a new instance of <see cref="SqlSagaAttribute"/>.
-        /// </summary>
-        public SqlSagaAttribute()
+            string tableSuffix = null)
         {
-            
         }
-
-        /// <summary>
-        /// Used to transition between different properties for saga correlation.
-        /// </summary>
-        public string TransitionalCorrelationProperty;
-
-        /// <summary>
-        /// The name of the tabe to use when storing the current <see cref="SqlSaga{TSagaData}"/>. 
-        /// Will be appended to the value specified in <see cref="SqlPersistenceConfig.TablePrefix"/>.
-        /// </summary>
-        public string TableSuffix;
     }
 }

--- a/src/SqlPersistence/Saga/SqlSagaTypeDataReader.cs
+++ b/src/SqlPersistence/Saga/SqlSagaTypeDataReader.cs
@@ -1,37 +1,56 @@
 ﻿using System;
 using System.Reflection;
 using System.Runtime.Serialization;
-using NServiceBus.Persistence.Sql;
 
 static class SqlSagaTypeDataReader
 {
     public static SqlSagaTypeData GetTypeData(Type sagaType)
     {
-        var attribute = sagaType.GetCustomAttribute<SqlSagaAttribute>(false);
-        string tableName = null;
-        string transitionalCorrelationProperty = null;
-        if (attribute != null)
+        var instance = FormatterServices.GetUninitializedObject(sagaType);
+
+        string transitionalCorrelationPropertyName = null;
+        var transitionalCorrelationProperty = GetProperty(sagaType, "TransitionalCorrelationPropertyName");
+        if (transitionalCorrelationProperty != null)
         {
-            tableName = attribute.TableSuffix;
-            transitionalCorrelationProperty = attribute.TransitionalCorrelationProperty;
+            transitionalCorrelationPropertyName = GetPropertyValue(transitionalCorrelationProperty, instance);
         }
-        if (tableName == null)
+
+        string tableName;
+        var tableNameProperty = GetProperty(sagaType, "TableSuffix");
+        if (tableNameProperty == null)
         {
             tableName = sagaType.Name;
         }
-        var instance = FormatterServices.GetUninitializedObject(sagaType);
-        var correlationProperty = GetCorrelationProperty(sagaType);
-        correlationProperty.GetMethod.Invoke(instance, null);
+        else
+        {
+            tableName = GetPropertyValue(tableNameProperty, instance);
+        }
+
+        var correlationProperty = GetProperty(sagaType, "CorrelationPropertyName");
         return new SqlSagaTypeData
         {
             TableSuffix = tableName,
-            CorrelationProperty = (string) correlationProperty.GetMethod.Invoke(instance, null),
-            TransitionalCorrelationProperty = transitionalCorrelationProperty
+            CorrelationProperty = GetPropertyValue(correlationProperty, instance),
+            TransitionalCorrelationProperty = transitionalCorrelationPropertyName
         };
     }
 
-    static PropertyInfo GetCorrelationProperty(Type sagaType)
+    static string GetPropertyValue(PropertyInfo property, object instance)
     {
-        return sagaType.GetProperty("CorrelationPropertyName", BindingFlags.Instance | BindingFlags.GetProperty | BindingFlags.NonPublic | BindingFlags.Public);
+        property.GetMethod.Invoke(instance, null);
+        return (string) property.GetMethod.Invoke(instance, null);
+    }
+
+    static PropertyInfo GetProperty(Type sagaType, string propertyName)
+    {
+        var propertyInfo = sagaType.GetProperty(propertyName, BindingFlags.Instance | BindingFlags.GetProperty | BindingFlags.NonPublic | BindingFlags.Public);
+        if (propertyInfo != null)
+        {
+            if (propertyInfo.DeclaringType != sagaType)
+            {
+                return null;
+            }
+        }
+        return propertyInfo;
     }
 }

--- a/src/SqlPersistence/Saga/SqlSagaTypeDataReader.cs
+++ b/src/SqlPersistence/Saga/SqlSagaTypeDataReader.cs
@@ -37,19 +37,19 @@ static class SqlSagaTypeDataReader
 
     static string GetPropertyValue(PropertyInfo property, object instance)
     {
-        property.GetMethod.Invoke(instance, null);
         return (string) property.GetMethod.Invoke(instance, null);
     }
 
     static PropertyInfo GetProperty(Type sagaType, string propertyName)
     {
         var propertyInfo = sagaType.GetProperty(propertyName, BindingFlags.Instance | BindingFlags.GetProperty | BindingFlags.NonPublic | BindingFlags.Public);
-        if (propertyInfo != null)
+        if (propertyInfo == null)
         {
-            if (propertyInfo.DeclaringType != sagaType)
-            {
-                return null;
-            }
+            return null;
+        }
+        if (propertyInfo.DeclaringType != sagaType)
+        {
+            return null;
         }
         return propertyInfo;
     }


### PR DESCRIPTION
Removes the requirement for the `[SqlSagaAttribute]`

In 2.0 we have already pushed Correlation Property into a abstract property on the `SqlSaga<T>` https://docs.particular.net/nservicebus/upgrades/sqlpersistence-1to2#correlation-property

Given that i think it would be sensible to push both table suffix and Transitional Correlation Property into virtual properties on  `SqlSaga<T>`. and hence remove any requirement for `[SqlSagaAttribute]`