### PR TITLE
Throws when new transaction scope is created in the pipeline

### DIFF
--- a/src/MsSqlAcceptanceTests/MsSqlAcceptanceTests.csproj
+++ b/src/MsSqlAcceptanceTests/MsSqlAcceptanceTests.csproj
@@ -251,9 +251,11 @@
     <Compile Include="App_Packages\NSB.AcceptanceTests.6.2.0\Tx\When_sending_within_an_ambient_transaction.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.6.2.0\Versioning\When_multiple_versions_of_a_message_is_published.cs" />
     <Compile Include="TestSuiteConstraints.cs" />
+    <Compile Include="When_creating_transaction_scope_in_the_pipeline.cs" />
     <Compile Include="When_custom_finder_returns_existing_saga.cs" />
     <Compile Include="When_all_messages_have_finders.cs" />
     <Compile Include="ConfigureEndpointSqlPersistence.cs" />
+    <Compile Include="When_creating_new_transaction_scope_in_the_pipeline.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AcceptanceTestHelper\AcceptanceTestHelper.csproj">

--- a/src/MsSqlAcceptanceTests/When_creating_new_transaction_scope_in_the_pipeline.cs
+++ b/src/MsSqlAcceptanceTests/When_creating_new_transaction_scope_in_the_pipeline.cs
@@ -1,0 +1,111 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using System.Transactions;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NServiceBus.Pipeline;
+    using NUnit.Framework;
+    using Persistence.Sql;
+
+    public class When_creating_new_transaction_scope_in_the_pipeline : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_fail_when_creating_synchronized_storage_session()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Endpoint>(b => b
+                    .When(async session =>
+                    {
+                        var id = Guid.NewGuid();
+                        await session.SendLocal(new StartSagaMessage
+                        {
+                            SomeId = id
+                        });
+                    }).DoNotFailOnErrorMessages())
+                .Done(c => c.FailedMessages.Any())
+                .Run();
+
+            var exceptionMessage = context.FailedMessages.First().Value.First().Exception.Message;
+            StringAssert.StartsWith("A TransctionScope has been opened in the current context overriding the one created by the transport.", exceptionMessage);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool SecondMessageReceived { get; set; }
+            public Guid FirstSagaId { get; set; }
+            public Guid SecondSagaId { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.Pipeline.Register(new TransactionScopeBehavior(), "Creates a new transaction scope");
+                    c.Pipeline.Register(new SimulateFailureBehavior(), "Simulates failure before committing transport transaction");
+                });
+            }
+
+            class TransactionScopeBehavior : Behavior<IIncomingLogicalMessageContext>
+            {
+                public override async Task Invoke(IIncomingLogicalMessageContext context, Func<Task> next)
+                {
+                    using (var scope = new TransactionScope(TransactionScopeOption.RequiresNew, TransactionScopeAsyncFlowOption.Enabled))
+                    {
+                        await next().ConfigureAwait(false);
+                        scope.Complete();
+                    }
+                }
+            }
+
+            class SimulateFailureBehavior : Behavior<IIncomingPhysicalMessageContext>
+            {
+                public override async Task Invoke(IIncomingPhysicalMessageContext context, Func<Task> next)
+                {
+                    await next().ConfigureAwait(false);
+                    throw new SimulatedException();
+                }
+            }
+
+            public class TestSaga12 : SqlSaga<TestSagaData12>, IAmStartedByMessages<StartSagaMessage>
+            {
+                protected override string CorrelationPropertyName => nameof(TestSagaData12.SomeId);
+
+                public Context TestContext { get; set; }
+
+                public Task Handle(StartSagaMessage message, IMessageHandlerContext context)
+                {
+                    Data.Counter++;
+                    return Task.FromResult(0);
+                }
+
+                protected override void ConfigureMapping(IMessagePropertyMapper mapper)
+                {
+                    mapper.ConfigureMapping<StartSagaMessage>(m => m.SomeId);
+                }
+            }
+
+            public class TestSagaData12 : IContainSagaData
+            {
+                public virtual Guid SomeId { get; set; }
+                public virtual Guid Id { get; set; }
+                public virtual string Originator { get; set; }
+                public virtual string OriginalMessageId { get; set; }
+                public virtual int Counter { get; set; }
+            }
+        }
+
+        public class StartSagaMessage : ICommand
+        {
+            public Guid SomeId { get; set; }
+
+            public bool SecondMessage { get; set; }
+
+            public int Counter { get; set; }
+        }
+    }
+}

--- a/src/MsSqlAcceptanceTests/When_creating_new_transaction_scope_in_the_pipeline.cs
+++ b/src/MsSqlAcceptanceTests/When_creating_new_transaction_scope_in_the_pipeline.cs
@@ -34,9 +34,6 @@
 
         public class Context : ScenarioContext
         {
-            public bool SecondMessageReceived { get; set; }
-            public Guid FirstSagaId { get; set; }
-            public Guid SecondSagaId { get; set; }
         }
 
         public class Endpoint : EndpointConfigurationBuilder
@@ -79,7 +76,6 @@
 
                 public Task Handle(StartSagaMessage message, IMessageHandlerContext context)
                 {
-                    Data.Counter++;
                     return Task.FromResult(0);
                 }
 
@@ -89,13 +85,9 @@
                 }
             }
 
-            public class TestSagaData12 : IContainSagaData
+            public class TestSagaData12 : ContainSagaData
             {
-                public virtual Guid SomeId { get; set; }
-                public virtual Guid Id { get; set; }
-                public virtual string Originator { get; set; }
-                public virtual string OriginalMessageId { get; set; }
-                public virtual int Counter { get; set; }
+                public Guid SomeId { get; set; }
             }
         }
 
@@ -104,8 +96,6 @@
             public Guid SomeId { get; set; }
 
             public bool SecondMessage { get; set; }
-
-            public int Counter { get; set; }
         }
     }
 }

--- a/src/MsSqlAcceptanceTests/When_creating_new_transaction_scope_in_the_pipeline.cs
+++ b/src/MsSqlAcceptanceTests/When_creating_new_transaction_scope_in_the_pipeline.cs
@@ -87,7 +87,7 @@
 
             public class TestSagaData12 : ContainSagaData
             {
-                public Guid SomeId { get; set; }
+                public virtual Guid SomeId { get; set; }
             }
         }
 

--- a/src/MsSqlAcceptanceTests/When_creating_new_transaction_scope_in_the_pipeline.cs
+++ b/src/MsSqlAcceptanceTests/When_creating_new_transaction_scope_in_the_pipeline.cs
@@ -29,7 +29,7 @@
                 .Run();
 
             var exceptionMessage = context.FailedMessages.First().Value.First().Exception.Message;
-            StringAssert.StartsWith("A TransctionScope has been opened in the current context overriding the one created by the transport.", exceptionMessage);
+            StringAssert.StartsWith("A TransactionScope has been opened in the current context overriding the one created by the transport.", exceptionMessage);
         }
 
         public class Context : ScenarioContext

--- a/src/MsSqlAcceptanceTests/When_creating_transaction_scope_in_the_pipeline.cs
+++ b/src/MsSqlAcceptanceTests/When_creating_transaction_scope_in_the_pipeline.cs
@@ -99,13 +99,10 @@
                 }
             }
 
-            public class TestSagaData13 : IContainSagaData
+            public class TestSagaData13 : ContainSagaData
             {
-                public virtual Guid SomeId { get; set; }
-                public virtual Guid Id { get; set; }
-                public virtual string Originator { get; set; }
-                public virtual string OriginalMessageId { get; set; }
-                public virtual int Counter { get; set; }
+                public Guid SomeId { get; set; }
+                public int Counter { get; set; }
             }
         }
 

--- a/src/MsSqlAcceptanceTests/When_creating_transaction_scope_in_the_pipeline.cs
+++ b/src/MsSqlAcceptanceTests/When_creating_transaction_scope_in_the_pipeline.cs
@@ -1,0 +1,117 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using System.Threading.Tasks;
+    using System.Transactions;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NServiceBus.Pipeline;
+    using NUnit.Framework;
+    using Persistence.Sql;
+
+    public class When_creating_transaction_scope_in_the_pipeline : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_adapt_that_scope_when_creating_synchronized_session_if_transport_is_in_native_mode()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Endpoint>(b => b
+                    .When(async session =>
+                    {
+                        var id = Guid.NewGuid();
+                        await session.SendLocal(new StartSagaMessage
+                        {
+                            SomeId = id
+                        });
+                        await session.SendLocal(new StartSagaMessage
+                        {
+                            SomeId = id
+                        });
+                        await session.SendLocal(new StartSagaMessage
+                        {
+                            SomeId = id
+                        });
+                    }).DoNotFailOnErrorMessages())
+                .Done(c => c.SagaDataPersisted)
+                .Run();
+
+            Assert.IsTrue(context.SagaDataPersisted);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool SagaDataPersisted { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.UseTransport<MsmqTransport>().Transactions(TransportTransactionMode.SendsAtomicWithReceive);
+                    c.LimitMessageProcessingConcurrencyTo(1);
+                    c.Pipeline.Register(new TransactionScopeBehavior(), "Creates a new transaction scope");
+                    c.Pipeline.Register(new SimulateFailureBehavior(), "Simulates failure before committing transport transaction");
+                });
+            }
+
+            class TransactionScopeBehavior : Behavior<IIncomingLogicalMessageContext>
+            {
+                public override async Task Invoke(IIncomingLogicalMessageContext context, Func<Task> next)
+                {
+                    using (var scope = new TransactionScope(TransactionScopeOption.RequiresNew, TransactionScopeAsyncFlowOption.Enabled))
+                    {
+                        await next().ConfigureAwait(false);
+                        scope.Complete();
+                    }
+                }
+            }
+
+            class SimulateFailureBehavior : Behavior<IIncomingPhysicalMessageContext>
+            {
+                public override async Task Invoke(IIncomingPhysicalMessageContext context, Func<Task> next)
+                {
+                    await next().ConfigureAwait(false);
+                    throw new SimulatedException();
+                }
+            }
+
+            public class TestSaga13 : SqlSaga<TestSagaData13>, IAmStartedByMessages<StartSagaMessage>
+            {
+                protected override string CorrelationPropertyName => nameof(TestSagaData13.SomeId);
+
+                public Context TestContext { get; set; }
+
+                public Task Handle(StartSagaMessage message, IMessageHandlerContext context)
+                {
+                    Data.Counter++;
+                    if (Data.Counter == 3)
+                    {
+                        TestContext.SagaDataPersisted = true;
+                    }
+                    return Task.FromResult(0);
+                }
+
+                protected override void ConfigureMapping(IMessagePropertyMapper mapper)
+                {
+                    mapper.ConfigureMapping<StartSagaMessage>(m => m.SomeId);
+                }
+            }
+
+            public class TestSagaData13 : IContainSagaData
+            {
+                public virtual Guid SomeId { get; set; }
+                public virtual Guid Id { get; set; }
+                public virtual string Originator { get; set; }
+                public virtual string OriginalMessageId { get; set; }
+                public virtual int Counter { get; set; }
+            }
+        }
+
+        public class StartSagaMessage : ICommand
+        {
+            public Guid SomeId { get; set; }
+        }
+    }
+}

--- a/src/MsSqlAcceptanceTests/When_creating_transaction_scope_in_the_pipeline.cs
+++ b/src/MsSqlAcceptanceTests/When_creating_transaction_scope_in_the_pipeline.cs
@@ -101,8 +101,8 @@
 
             public class TestSagaData13 : ContainSagaData
             {
-                public Guid SomeId { get; set; }
-                public int Counter { get; set; }
+                public virtual Guid SomeId { get; set; }
+                public virtual int Counter { get; set; }
             }
         }
 

--- a/src/MySqlAcceptanceTests/App_Packages/NSB.AcceptanceTests.6.2.0/ConfigureEndpointMsmqTransport.cs
+++ b/src/MySqlAcceptanceTests/App_Packages/NSB.AcceptanceTests.6.2.0/ConfigureEndpointMsmqTransport.cs
@@ -20,7 +20,7 @@ public class ConfigureEndpointMsmqTransport : IConfigureEndpointTestExecution
             EnvironmentHelper.GetEnvironmentVariable($"{nameof(MsmqTransport)}.ConnectionString")
             ?? DefaultConnectionString;
         var transportConfig = configuration.UseTransport<MsmqTransport>();
-
+        transportConfig.Transactions(TransportTransactionMode.SendsAtomicWithReceive);
         transportConfig.ConnectionString(connectionString);
 
         var routingConfig = transportConfig.Routing();

--- a/src/SqlPersistence/SynchronizedStorage/StorageAdapter.cs
+++ b/src/SqlPersistence/SynchronizedStorage/StorageAdapter.cs
@@ -3,6 +3,7 @@ using System.Data.Common;
 using System.Data.SqlClient;
 using System.Threading.Tasks;
 using System.Transactions;
+using NServiceBus;
 using NServiceBus.Extensibility;
 using NServiceBus.Outbox;
 using NServiceBus.Persistence;
@@ -51,7 +52,7 @@ class StorageAdapter : ISynchronizedStorageAdapter
             throw new Exception("A TransctionScope has been opened in the current context overriding the one created by the transport. " 
                 + "This setup can result in insonsistent data because operations done via connections enlisted in the context scope won't be committed "
                 + "atomically with the receive transaction. If you wish to manually control the TransactionScope in the pipeline switch the transport transaction mode "
-                + "to values lower than 'TransactionScope'.");
+                + $"to values lower than '{nameof(TransportTransactionMode.TransactionScope)}'.");
         }
         var ambientTransaction = transportTx ?? Transaction.Current;
         if (ambientTransaction != null)


### PR DESCRIPTION
As discussed with Daniel, the adapter throws if both transport and custom TS are present. Otherwise it uses the one scope that is present. It also explicitly enlists the created connection in the ambient scope in case enlisting is not enable in connection string.

One thing that I am not sure is if all the database drivers we want to target support enlisting and do they do it. Surely not all support DTC-managed transactions.