### PR TITLE
Reading fields instead of properties for settings attribute

### DIFF
--- a/src/ScriptBuilder/CecilExtentions.cs
+++ b/src/ScriptBuilder/CecilExtentions.cs
@@ -7,16 +7,16 @@ using NServiceBus.Persistence.Sql;
 static class CecilExtentions
 {
 
-    public static string GetStringProperty(this CustomAttribute attribute, string name)
+    public static string GetStringField(this CustomAttribute attribute, string name)
     {
-        return (string)attribute.Properties
+        return (string)attribute.Fields
             .SingleOrDefault(argument => argument.Name == name)
             .Argument.Value;
     }
 
-    public static bool GetBoolProperty(this CustomAttribute attribute, string name)
+    public static bool GetBoolField(this CustomAttribute attribute, string name)
     {
-        var value = attribute.Properties
+        var value = attribute.Fields
             .SingleOrDefault(argument => argument.Name == name)
             .Argument.Value;
         return value != null && (bool)value;

--- a/src/ScriptBuilder/ScriptPromotionPathReader.cs
+++ b/src/ScriptBuilder/ScriptPromotionPathReader.cs
@@ -14,7 +14,7 @@ static class ScriptPromotionPathReader
             return false;
         }
         
-        target = customAttribute.GetStringProperty("ScriptPromotionPath");
+        target = customAttribute.GetStringField("ScriptPromotionPath");
         if (target == null)
         {
             return false;

--- a/src/ScriptBuilder/SqlVariantReader.cs
+++ b/src/ScriptBuilder/SqlVariantReader.cs
@@ -17,13 +17,13 @@ static class SqlVariantReader
             yield break;
         }
 
-        var msSqlServerScripts = attribute.GetBoolProperty("MsSqlServerScripts");
+        var msSqlServerScripts = attribute.GetBoolField("MsSqlServerScripts");
         if (msSqlServerScripts)
         {
             yield return BuildSqlVariant.MsSqlServer;
         }
 
-        var mySqlScripts = attribute.GetBoolProperty("MySqlScripts");
+        var mySqlScripts = attribute.GetBoolField("MySqlScripts");
         if (mySqlScripts)
         {
             yield return BuildSqlVariant.MySql;


### PR DESCRIPTION
The settings attribute reading is broken. The settings attribute reading defines public fields and not properties. Therefore accessing the properties will not return anything. This seems to be broken in latest release as well (in fact it never worked)