### PR TITLE
Fix for not disposing connection if open fails

### DIFF
--- a/src/SqlPersistence/Extensions.cs
+++ b/src/SqlPersistence/Extensions.cs
@@ -17,8 +17,16 @@ static class Extensions
     public static async Task<DbConnection> OpenConnection(this Func<DbConnection> connectionBuilder)
     {
         var connection = connectionBuilder();
-        await connection.OpenAsync().ConfigureAwait(false);
-        return connection;
+        try
+        {
+            await connection.OpenAsync().ConfigureAwait(false);
+            return connection;
+        }
+        catch
+        {
+            connection.Dispose();
+            throw;
+        }
     }
 
     public static void AddParameter(this DbCommand command, string name, Version value)


### PR DESCRIPTION
When the `OpenAsync` fails the connection created isn't disposed. This is because this helper is invoked before the connection is passed to the dispose scope thus Dispose will not be called as no instance has been assigned yet.

Example:

https://github.com/Particular/NServiceBus.Persistence.Sql/blob/master/src/SqlPersistence/Timeout/TimeoutPersister.cs#L86

```c#
using (var connection = await connectionBuilder
    .OpenConnection() // <--- Can fail
    .ConfigureAwait(false)
    )
using (var command = commandBuilder.CreateCommand(connection))
{
     // ...
}
```