### PR TITLE
Subscription messages are rejected with error (instead of be ignored) if there is already a subscription entry for this same type, endpoint and address.

### DIFF
--- a/src/SqlPersistence.Tests/Subscription/SubscriptionPersisterTests.cs
+++ b/src/SqlPersistence.Tests/Subscription/SubscriptionPersisterTests.cs
@@ -80,6 +80,17 @@ public abstract class SubscriptionPersisterTests
     }
 
     [Test]
+    public void Subscribe_multiple_with_no_endpoint()
+    {
+        var type = new MessageType("type", new Version(0, 0, 0, 0));
+        persister.Subscribe(new Subscriber("e@machine1", null), type, null).Await();
+        // Ensuring that MSSQL's handling of = null vs. is null doesn't cause a PK violation here
+        persister.Subscribe(new Subscriber("e@machine1", null), type, null).Await();
+        var result = persister.GetSubscribers(type).Result.OrderBy(s => s.TransportAddress);
+        Assert.AreEqual(1, result.Count());
+    }
+
+    [Test]
     public async Task Cached_get_should_be_faster()
     {
         var type = new MessageType("type1", new Version(0, 0, 0, 0));

--- a/src/SqlPersistence/Subscription/SubscriptionCommandBuilder.cs
+++ b/src/SqlPersistence/Subscription/SubscriptionCommandBuilder.cs
@@ -67,14 +67,11 @@ where MessageType in (";
             {
                 case SqlVariant.MsSqlServer:
                     return $@"
-declare @dummy int;
 merge {tableName} with (holdlock) as target
 using(select @Endpoint as Endpoint, @Subscriber as Subscriber, @MessageType as MessageType) as source
-on target.Endpoint = source.Endpoint and
-   target.Subscriber = source.Subscriber and
-   target.MessageType = source.MessageType
-when matched then
-    update set @dummy = 0
+on target.Subscriber = source.Subscriber and
+   target.MessageType = source.MessageType and
+   ((target.Endpoint = source.Endpoint) or (target.Endpoint is null and source.endpoint is null))
 when not matched then
 insert
 (


### PR DESCRIPTION
### Who's affected

Users who use message-driven pub/sub transports and SQL Server database for subscription persistence

### Symptoms

Subscription messages are rejected with error (instead of be ignored) if there is already a subscription entry for this same type, endpoint and address.

Fixes #117