### PR TITLE
Allow statement-bodied properties in sagas

### DIFF
--- a/src/ScriptBuilder.Tests/Saga/SagaDefinitionReaderTest.WithStatementBodyProperty.approved.txt
+++ b/src/ScriptBuilder.Tests/Saga/SagaDefinitionReaderTest.WithStatementBodyProperty.approved.txt
@@ -1,0 +1,6 @@
+﻿{
+  "TableSuffix": "WithStatementBodyPropertySaga",
+  "CorrelationProperty": null,
+  "TransitionalCorrelationProperty": null,
+  "Name": "SagaDefinitionReaderTest/WithStatementBodyPropertySaga"
+}

--- a/src/ScriptBuilder.Tests/Saga/SagaDefinitionReaderTest.cs
+++ b/src/ScriptBuilder.Tests/Saga/SagaDefinitionReaderTest.cs
@@ -203,6 +203,31 @@ public class SagaDefinitionReaderTest: IDisposable
         }
     }
 
+    [Test]
+    public void WithStatementBodyProperty()
+    {
+        var sagaType = module.GetTypeDefinition<WithStatementBodyPropertySaga>();
+        SagaDefinitionReader.TryGetSqlSagaDefinition(sagaType, out var definition);
+        ObjectApprover.VerifyWithJson(definition);
+    }
+
+    public class WithStatementBodyPropertySaga : SqlSaga<WithStatementBodyPropertySaga.SagaData>
+    {
+        public class SagaData : ContainSagaData
+        {
+        }
+
+        protected override string CorrelationPropertyName
+        {
+            //Explicitly not use expression body
+            get { return null; }
+        }
+
+        protected override void ConfigureMapping(IMessagePropertyMapper mapper)
+        {
+        }
+    }
+
     public void Dispose()
     {
         module?.Dispose();


### PR DESCRIPTION
For languages without support for expression-bodied members such as VB 😢 