### PR TITLE
Do not run installer when not enabled

### DIFF
--- a/src/SqlPersistence/Installer.cs
+++ b/src/SqlPersistence/Installer.cs
@@ -20,6 +20,15 @@ class Installer : INeedToInstallSomething
 
     public async Task Install(string identity)
     {
+        //If neither of the features is configured then do not even attempt to validate config
+        if (!settings.ShouldInstall<SqlOutboxFeature>()
+            && !settings.ShouldInstall<SqlSubscriptionFeature>()
+            && !settings.ShouldInstall<SqlTimeoutFeature>()
+            && !settings.ShouldInstall<SqlSagaFeature>())
+        {
+            return;
+        }
+
         var connectionBuilder = settings.GetConnectionBuilder();
         var sqlDialect = settings.GetSqlDialect();
         var scriptDirectory = ScriptLocation.FindScriptDirectory(sqlDialect);


### PR DESCRIPTION
Otherwise the `Installer` class blows whenever SQL persistence dll is reference but not used (e.g. in acceptance tests project where various tests use various persistences)