### PR TITLE
Do not run installers when persistence is not configured

### DIFF
--- a/src/SqlPersistence/Config/SqlPersistenceConfig_Enabled.cs
+++ b/src/SqlPersistence/Config/SqlPersistenceConfig_Enabled.cs
@@ -14,25 +14,9 @@ namespace NServiceBus
         public static void DisableInstaller(this PersistenceExtensions<SqlPersistence> configuration)
         {
             Guard.AgainstNull(nameof(configuration), configuration);
-            configuration.GetSettings()
-                .Set("SqlPersistence.DisableInstaller", true);
+
+            var installerSettings = configuration.GetSettings().GetOrCreate<InstallerSettings>();
+            installerSettings.Disabled = true;
         }
-
-        static bool GetDisableInstaller(this ReadOnlySettings settings)
-        {
-            return settings.TryGet("SqlPersistence.DisableInstaller", out bool value) && value;
-        }
-
-        internal static bool ShouldInstall<TFeature>(this ReadOnlySettings settings)
-            where TFeature : Feature
-        {
-            var featureEnabled = settings.IsFeatureActive(typeof(TFeature));
-            var disableInstaller = settings.GetDisableInstaller();
-            return
-                featureEnabled &&
-                !disableInstaller;
-        }
-
-
     }
 }

--- a/src/SqlPersistence/InstallerFeature.cs
+++ b/src/SqlPersistence/InstallerFeature.cs
@@ -1,0 +1,26 @@
+using NServiceBus;
+using NServiceBus.Features;
+
+class InstallerFeature : Feature
+{
+    public InstallerFeature()
+    {
+        Defaults(s => s.SetDefault<InstallerSettings>(new InstallerSettings()));
+    }
+
+    protected override void Setup(FeatureConfigurationContext context)
+    {
+        var settings = context.Settings.Get<InstallerSettings>();
+        if (settings.Disabled)
+        {
+            return;
+        }
+
+        settings.ConnectionBuilder = context.Settings.GetConnectionBuilder();
+        settings.Dialect = context.Settings.GetSqlDialect();
+        settings.ScriptDirectory = ScriptLocation.FindScriptDirectory(context.Settings.GetSqlDialect());
+        settings.TablePrefix = context.Settings.GetTablePrefix();
+
+        settings.Dialect.ValidateTablePrefix(settings.TablePrefix);
+    }
+}

--- a/src/SqlPersistence/InstallerSettings.cs
+++ b/src/SqlPersistence/InstallerSettings.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Data.Common;
+using NServiceBus;
+
+class InstallerSettings
+{
+    public bool Disabled { get; set; }
+    public Func<DbConnection> ConnectionBuilder { get; set; }
+    public SqlDialect Dialect { get; set; }
+    public string ScriptDirectory { get; set; }
+    public string TablePrefix { get; set; }
+}

--- a/src/SqlPersistence/SqlPersistence.cs
+++ b/src/SqlPersistence/SqlPersistence.cs
@@ -33,6 +33,10 @@ namespace NServiceBus.Persistence.Sql
             {
                 s.EnableFeatureByDefault<SqlSubscriptionFeature>();
             });
+            Defaults(s =>
+            {
+                s.EnableFeatureByDefault<InstallerFeature>();
+            });
         }
 
         static void EnableSession(SettingsHolder s)


### PR DESCRIPTION
Fixes #109 

The change introduces an explicit`InstallerSettings` class that is used to pass the parameters to the installers as well as to control if the installer should run. Installer classes are registered automatically by the core so they are executed even if the persistence dll is only present in `bin` but not actually configured properly.

With this change is SQL persistence is referenced but not configured via `EndpointConfiguration` the installer won't run. It will still be registered in the container by the core, but `InstallerSettings` object will not be present in the settings bag because the corresponding feature did not run. The feature is only enabled when user configures the persistence in `EndpointConfiguration`.

Question to reviewers: how do I test it? I have no idea how to test the whole installer machinery. 