### PR TITLE
Memory optimized saga serialization

### DIFF
--- a/src/SqlPersistence.Tests/CharArrayTextWriterPerformanceTests.cs
+++ b/src/SqlPersistence.Tests/CharArrayTextWriterPerformanceTests.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using NServiceBus;
+using NServiceBus.Persistence.Sql;
+using NServiceBus.Sagas;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+
+[Explicit("This is a long running performance test")]
+public class CharArrayTextWriterPerformanceTests
+{
+    [TestCaseSource(nameof(Dialects))]
+    public void PerfTest(SqlDialect dialect)
+    {
+        var sagaInfo = BuildSagaInfo<S,S.SagaData>(dialect);
+        var data = new S.SagaData
+        {
+            StringProperty = "Some bigger test",
+            GuidProperty = Guid.NewGuid(),
+            OriginalMessageId = Guid.NewGuid().ToString(),
+            Originator = "originator",
+            IntProperty = 5,
+            Id = Guid.NewGuid()
+        };
+
+        // warm up
+        using (var cmd = new CommandWrapper(null, dialect))
+        {
+            Console.WriteLine(dialect.BuildSagaData(cmd, sagaInfo, data));
+        }
+
+        var sw = Stopwatch.StartNew();
+        for (var i = 0; i < 1000000; i++)
+        {
+            using (var cmd = new CommandWrapper(null, dialect))
+            {
+                dialect.BuildSagaData(cmd, sagaInfo, data);
+            }
+        }
+        Console.WriteLine($"Test took: '{sw.Elapsed}'");
+    }
+
+    public class S :
+        SqlSaga<S.SagaData>,
+        IAmStartedByMessages<AMessage>
+    {
+        public class SagaData : ContainSagaData
+        {
+            public string StringProperty { get; set; }
+            public int IntProperty { get; set; }
+            public Guid GuidProperty { get; set; }
+        }
+
+        protected override string CorrelationPropertyName => nameof(SagaData.StringProperty);
+
+        protected override string TableSuffix => "TableSuffix";
+
+        protected override void ConfigureMapping(IMessagePropertyMapper mapper)
+        {
+            mapper.ConfigureMapping<AMessage>(_ => _.StringId);
+        }
+
+        public Task Handle(AMessage message, IMessageHandlerContext context)
+        {
+            return Task.FromResult(0);
+        }
+    }
+
+    public class AMessage : IMessage
+    {
+        public string StringId { get; set; }
+    }
+
+    public static IEnumerable<ITestCaseData> Dialects()
+    {
+        yield return new TestCaseData(new SqlDialect.MsSqlServer()).SetName(nameof(SqlDialect.MsSqlServer));
+        yield return new TestCaseData(new SqlDialect.MySql()).SetName(nameof(SqlDialect.MySql));
+    }
+
+    static RuntimeSagaInfo BuildSagaInfo<TSaga, TSagaData>(SqlDialect dialect)
+        where TSaga : SqlSaga<TSagaData>
+        where TSagaData : IContainSagaData, new()
+    {
+        var sagaMetadataCollection = new SagaMetadataCollection();
+        sagaMetadataCollection.Initialize(new[]
+        {
+            typeof(TSaga)
+        });
+
+        var infoCache = new SagaInfoCache(
+            null,
+            Serializer.JsonSerializer,
+#pragma warning disable 618
+            commandBuilder: new SagaCommandBuilder(dialect),
+#pragma warning restore 618
+            readerCreator: reader => new JsonTextReader(reader),
+            writerCreator: writer => new JsonTextWriter(writer),
+            tablePrefix: "some",
+            sqlDialect: dialect,
+            metadataCollection: sagaMetadataCollection,
+            nameFilter: sagaName => sagaName);
+        return infoCache.GetInfo(typeof(TSagaData));
+    }
+}

--- a/src/SqlPersistence.Tests/CharArrayTextWriterPerformanceTests.cs
+++ b/src/SqlPersistence.Tests/CharArrayTextWriterPerformanceTests.cs
@@ -33,7 +33,7 @@ public class CharArrayTextWriterPerformanceTests
         }
 
         var sw = Stopwatch.StartNew();
-        for (var i = 0; i < 1000000; i++)
+        for (var i = 0; i < 10_000_000; i++)
         {
             using (var cmd = new CommandWrapper(null, dialect))
             {

--- a/src/SqlPersistence.Tests/CharArrayTextWriterTests.cs
+++ b/src/SqlPersistence.Tests/CharArrayTextWriterTests.cs
@@ -1,0 +1,83 @@
+﻿using System.Linq;
+using NUnit.Framework;
+
+public class CharArrayTextWriterTests
+{
+    [Test]
+    public void WritingSingleChar()
+    {
+        var writer = new CharArrayTextWriter();
+
+        writer.Write('z');
+
+        var written = writer.ToCharSegment();
+
+        CollectionAssert.AreEqual('z'.ToString(), written);
+    }
+
+    [Test]
+    public void WritingCharArray()
+    {
+        var writer = new CharArrayTextWriter();
+
+        var chars = new[] { 'a', 'b', 'c', 'd', 'e', 'f' };
+
+        const int offset = 5;
+        const int take = 1;
+
+        writer.Write(chars, offset, take);
+        var written = writer.ToCharSegment();
+
+        CollectionAssert.AreEqual(chars.Skip(offset).Take(take), written);
+    }
+
+    [Test]
+    public void WritingString()
+    {
+        var writer = new CharArrayTextWriter();
+
+        writer.Write("test");
+
+        var written = writer.ToCharSegment();
+
+        CollectionAssert.AreEqual("test", written);
+    }
+
+    [Test]
+    public void WritingCharsBeyondLimit()
+    {
+        var writer = new CharArrayTextWriter();
+
+        var s = new string('a', CharArrayTextWriter.InitialSize) + "b";
+
+        writer.Write(s);
+
+        var written = writer.ToCharSegment();
+
+        CollectionAssert.AreEqual(s, written);
+    }
+
+    [Test]
+    public void WritingCharsMuchBeyondLimit()
+    {
+        var writer = new CharArrayTextWriter();
+
+        var s = new string('a', CharArrayTextWriter.InitialSize * 8);
+
+        writer.Write(s);
+
+        var written = writer.ToCharSegment();
+
+        CollectionAssert.AreEqual(s, written);
+    }
+
+    [Test]
+    public void HasOffsetResetWhenReleased()
+    {
+        var writer = CharArrayTextWriter.Lease();
+        writer.Write('a');
+        writer.Release();
+
+        Assert.AreEqual(0, writer.Size);
+    }
+}

--- a/src/SqlPersistence/CharArrayTextWriter.cs
+++ b/src/SqlPersistence/CharArrayTextWriter.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 sealed class CharArrayTextWriter : TextWriter
 {
-    const int InitialSize = 4096;
+    internal const int InitialSize = 4096;
     static readonly Encoding EncodingValue = new UnicodeEncoding(false, false);
     char[] _chars = new char[InitialSize];
     int _next;
@@ -120,4 +120,6 @@ sealed class CharArrayTextWriter : TextWriter
     {
         _next = 0;
     }
+
+    public int Size => _next;
 }

--- a/src/SqlPersistence/CharArrayTextWriter.cs
+++ b/src/SqlPersistence/CharArrayTextWriter.cs
@@ -1,0 +1,123 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+sealed class CharArrayTextWriter : TextWriter
+{
+    const int InitialSize = 4096;
+    static readonly Encoding EncodingValue = new UnicodeEncoding(false, false);
+    char[] _chars = new char[InitialSize];
+    int _next;
+    int _length = InitialSize;
+
+    public override Encoding Encoding => EncodingValue;
+
+    public override void Write(char value)
+    {
+        Ensure(1);
+        _chars[_next] = value;
+        _next += 1;
+    }
+
+    void Ensure(int i)
+    {
+        var required = _next + i;
+        if (required < _length)
+        {
+            return;
+        }
+
+        while (required >= _length)
+        {
+            _length *= 2;
+        }
+        Array.Resize(ref _chars, _length);
+    }
+
+    public override void Write(char[] buffer, int index, int count)
+    {
+        Ensure(count);
+        Array.Copy(buffer, index, _chars, _next, count);
+        _next += count;
+    }
+
+    public override void Write(string value)
+    {
+        var length = value.Length;
+        Ensure(length);
+        value.CopyTo(0, _chars, _next, length);
+        _next += length;
+    }
+
+    public override Task WriteAsync(char value)
+    {
+        Write(value);
+        return CompletedTask;
+    }
+
+    public override Task WriteAsync(string value)
+    {
+        Write(value);
+        return CompletedTask;
+    }
+
+    public override Task WriteAsync(char[] buffer, int index, int count)
+    {
+        Write(buffer, index, count);
+        return CompletedTask;
+    }
+
+    public override Task WriteLineAsync(char value)
+    {
+        WriteLine(value);
+        return CompletedTask;
+    }
+
+    public override Task WriteLineAsync(string value)
+    {
+        WriteLine(value);
+        return CompletedTask;
+    }
+
+    public override Task WriteLineAsync(char[] buffer, int index, int count)
+    {
+        WriteLine(buffer, index, count);
+        return CompletedTask;
+    }
+
+    public override Task FlushAsync()
+    {
+        return CompletedTask;
+    }
+
+    public void Release()
+    {
+        Clear();
+        pool.Push(this);
+    }
+
+    static readonly ConcurrentStack<CharArrayTextWriter> pool = new ConcurrentStack<CharArrayTextWriter>();
+    static readonly Task CompletedTask = Task.FromResult(true);
+
+    public static CharArrayTextWriter Lease()
+    {
+        if (pool.TryPop(out var writer))
+        {
+            return writer;
+        }
+
+        return new CharArrayTextWriter();
+    }
+
+    public ArraySegment<char> ToCharSegment()
+    {
+        return new ArraySegment<char>(_chars, 0, _next);
+    }
+
+    void Clear()
+    {
+        _next = 0;
+    }
+}

--- a/src/SqlPersistence/Config/SqlDialect_MsSqlServer.cs
+++ b/src/SqlPersistence/Config/SqlDialect_MsSqlServer.cs
@@ -1,6 +1,8 @@
 namespace NServiceBus
 {
+    using System;
     using System.Data.Common;
+    using System.Data.SqlClient;
 
     public abstract partial class SqlDialect
     {
@@ -24,8 +26,21 @@ namespace NServiceBus
 
             internal override void FillParameter(DbParameter parameter, string paramName, object value)
             {
-                parameter.ParameterName = paramName;
-                parameter.Value = value;
+                if (value is ArraySegment<char>)
+                {
+                    var charSegment = (ArraySegment<char>)value;
+                    var sqlParameter = (SqlParameter)parameter;
+
+                    sqlParameter.ParameterName = paramName;
+                    sqlParameter.Value = charSegment.Array;
+                    sqlParameter.Offset = charSegment.Offset;
+                    sqlParameter.Size = charSegment.Count;
+                }
+                else
+                {
+                    parameter.ParameterName = paramName;
+                    parameter.Value = value;
+                }
             }
 
             internal override CommandWrapper CreateCommand(DbConnection connection)

--- a/src/SqlPersistence/Config/SqlDialect_MsSqlServer.cs
+++ b/src/SqlPersistence/Config/SqlDialect_MsSqlServer.cs
@@ -26,9 +26,8 @@ namespace NServiceBus
 
             internal override void FillParameter(DbParameter parameter, string paramName, object value)
             {
-                if (value is ArraySegment<char>)
+                if (value is ArraySegment<char> charSegment)
                 {
-                    var charSegment = (ArraySegment<char>)value;
                     var sqlParameter = (SqlParameter)parameter;
 
                     sqlParameter.ParameterName = paramName;

--- a/src/SqlPersistence/Saga/SagaPersister_Save.cs
+++ b/src/SqlPersistence/Saga/SagaPersister_Save.cs
@@ -32,7 +32,7 @@ partial class SagaPersister
                 metadata.Add("Originator", sagaData.Originator);
             }
             command.AddParameter("Metadata", Serializer.Serialize(metadata));
-            command.AddParameter("Data", sagaInfo.ToJson(sagaData));
+            command.AddParameter("Data", sqlDialect.BuildSagaData(command, sagaInfo, sagaData));
             command.AddParameter("PersistenceVersion", StaticVersions.PersistenceVersion);
             command.AddParameter("SagaTypeVersion", sagaInfo.CurrentVersion);
             if (correlationId != null)

--- a/src/SqlPersistence/Saga/SagaPersister_Update.cs
+++ b/src/SqlPersistence/Saga/SagaPersister_Update.cs
@@ -23,7 +23,7 @@ partial class SagaPersister
             command.AddParameter("Id", sagaData.Id);
             command.AddParameter("PersistenceVersion", StaticVersions.PersistenceVersion);
             command.AddParameter("SagaTypeVersion", sagaInfo.CurrentVersion);
-            command.AddParameter("Data", sagaInfo.ToJson(sagaData));
+            command.AddParameter("Data", sqlDialect.BuildSagaData(command, sagaInfo, sagaData));
             command.AddParameter("Concurrency", concurrency);
             AddTransitionalParameter(sagaData, sagaInfo, command);
             var affected = await command.ExecuteNonQueryAsync().ConfigureAwait(false);

--- a/src/SqlPersistence/Saga/SqlDialect.cs
+++ b/src/SqlPersistence/Saga/SqlDialect.cs
@@ -6,5 +6,10 @@
         internal abstract string QuoteSagaTableName(string tableName);
         internal abstract string GetSagaCorrelationPropertyName(string propertyName);
         internal abstract string GetSagaParameterName(string parameterName);
+
+        internal virtual object BuildSagaData(CommandWrapper command, RuntimeSagaInfo sagaInfo, IContainSagaData sagaData)
+        {
+            return sagaInfo.ToJson(sagaData);
+        }
     }
 }

--- a/src/SqlPersistence/Saga/SqlDialect_MsSqlServer.cs
+++ b/src/SqlPersistence/Saga/SqlDialect_MsSqlServer.cs
@@ -23,6 +23,11 @@
             {
                 return "@" + parameterName;
             }
+
+            internal override object BuildSagaData(CommandWrapper command, RuntimeSagaInfo sagaInfo, IContainSagaData sagaData)
+            {
+                return sagaInfo.ToJson(sagaData);
+            }
         }
     }
 }

--- a/src/SqlPersistence/Saga/SqlDialect_MsSqlServer.cs
+++ b/src/SqlPersistence/Saga/SqlDialect_MsSqlServer.cs
@@ -26,7 +26,9 @@
 
             internal override object BuildSagaData(CommandWrapper command, RuntimeSagaInfo sagaInfo, IContainSagaData sagaData)
             {
-                return sagaInfo.ToJson(sagaData);
+                var writer = command.LeaseWriter();
+                sagaInfo.ToJson(sagaData,writer);
+                return writer.ToCharSegment();
             }
         }
     }


### PR DESCRIPTION
This PR introduces a memory optimizee saga serialization for Update and Save operations, capable of using custom pooled `TextWriter` objects.

### Implementation details

This PR introduces a pooled `TextWriter` that enables efficient passing of serialized sagas to `MsSqlServer` dialect using `.Offset` and `.Size` of `SqlParameter`, effectively enabling working with `ArraySegment<byte>` and `ArraySegment<char>` without additional allocations. 

The memory efficiency of this PR is a result of removal of `StringBuilder.ToString` that allocates a string every time it's called. `StringBuilder` uses internally some kind of pooling, but still, the result string needs to be allocated. By writing directly to a custom `TextWriter` and accessing its internal storage `ArraySegment<char>` we can use the mechanism described above and skip the final allocation.

One could argue about a possible leakage of this pool, but as both, a concurrency of an endpoint and the number of sagas handling a specific message type is limited, I'd say it's safe to leave the pool as unbounded and growing when needed.

### Bechmarking

Benchmarking was done using a dummy loop over sagas to be stored, that contained following data:

```c#
var data = new SagaData
{
    StringProperty = "Some bigger test",
    GuidProperty = Guid.NewGuid(),
    OriginalMessageId = Guid.NewGuid().ToString(),
    Originator = "originator",
    IntProperty = 5,
    Id = Guid.NewGuid()
};
```

Results:

Number of serializations: 10 mln

| Dialect   | Time  |
|---|---|
| MsSqlServer | 00:00:18.7940289 |
| MySql | 00:00:21.0636780

Observations:
- the bigger saga, the bigger gain
- benchmarkdotnet could be useful
- as always time spending on allocations adds up

### TODO:
- [x] `CharArrayTextWriter` requires testing
- [x] a potential benchmark comparing JSONization with these approaches

Addresses #157 