### PR TITLE
Make sure dependencies included in NuGet package

### DIFF
--- a/src/SqlPersistence/SqlPersistence.csproj
+++ b/src/SqlPersistence/SqlPersistence.csproj
@@ -41,4 +41,11 @@
   <Target Name="WritePackageVersionForIntegration" BeforeTargets="GenerateNuspec">
     <WriteLinesToFile Lines="&lt;Project&gt;&lt;PropertyGroup&gt;&lt;IntegrationVersion&gt;$(PackageVersion)&lt;/IntegrationVersion&gt;&lt;/PropertyGroup&gt;&lt;/Project&gt;" File="..\Integration\Directory.Build.props" Overwrite="true" />
   </Target>
+  
+  <!--Workaround for https://github.com/dotnet/sdk/issues/1469 -->
+  <PropertyGroup>
+    <DisableLockFileFrameworks>true</DisableLockFileFrameworks>
+  </PropertyGroup>
+  <!-- End Workaround -->
+  
 </Project>


### PR DESCRIPTION
Because of this bug: https://github.com/dotnet/sdk/issues/1469

The SqlPersistence dependency on System.Transactions for .NET 4.5.2 is not being included in the generated package metadata, so it looks like this in NuGet Package Explorer:

![image](https://user-images.githubusercontent.com/427110/31458873-f35709ba-ae86-11e7-88b5-fb3956153c66.png)

With this workaround it is properly included:

![image](https://user-images.githubusercontent.com/427110/31458894-ff87eb28-ae86-11e7-84f5-61aaa05e7cb2.png)

NServiceBus (on which SqlP depends) already has this so it's not important enough to generate a new beta, but should be included before RC.