### PR TITLE
Validate PostgreSql DB object names (PostgreSQL can handle 63 chars)

### DIFF
--- a/src/ScriptBuilder/Saga/Writers/PostgreSqlSagaScriptWriter.cs
+++ b/src/ScriptBuilder/Saga/Writers/PostgreSqlSagaScriptWriter.cs
@@ -18,7 +18,7 @@ class PostgreSqlSagaScriptWriter : ISagaScriptWriter
          */
         if (saga.TableSuffix.Length > 43)
         {
-            throw new Exception($"Saga '{saga.TableSuffix}' contains more than 43 characters, which is not supported by SQL persistence using Oracle. Either disable PostgreSQL script generation using the SqlPersistenceSettings assembly attribute, shorten the name of the saga, or specify an alternate table name by overriding the SqlSaga's TableSuffix property.");
+            throw new Exception($"Saga '{saga.TableSuffix}' contains more than 43 characters, which is not supported by SQL persistence using PostgreSQL. Either disable PostgreSQL script generation using the SqlPersistenceSettings assembly attribute, shorten the name of the saga, or specify an alternate table name by overriding the SqlSaga's TableSuffix property.");
         }
         writer = textWriter;
         this.saga = saga;

--- a/src/ScriptBuilder/Saga/Writers/PostgreSqlSagaScriptWriter.cs
+++ b/src/ScriptBuilder/Saga/Writers/PostgreSqlSagaScriptWriter.cs
@@ -154,7 +154,7 @@ select pg_temp.drop_saga_table_{sagaName}(@tablePrefix);
         using (var sha1 = SHA1.Create())
         {
             var hashBytes = sha1.ComputeHash(clearText);
-            for (var i = 0; i < 30; i++)
+            for (var i = 0; i < 20; i++)
             {
                 sb.Append(hashBytes[i].ToString("X2"));
             }

--- a/src/ScriptBuilder/Timeout/Create_PostgreSql.sql
+++ b/src/ScriptBuilder/Timeout/Create_PostgreSql.sql
@@ -2,11 +2,15 @@
   returns integer as
   $body$
     declare
-      tableNameNonQuoted varchar;
+      tableName varchar;
+      timeIndexName varchar;
+      sagaIndexName varchar;
       createTable text;
     begin
-        tableNameNonQuoted := tablePrefix || 'TimeoutData';
-        createTable = 'create table if not exists public."' || tableNameNonQuoted || '"
+        tableName := tablePrefix || 'TimeoutData';
+        timeIndexName := tableName || '_TimeIdx';
+        sagaIndexName := tableName || '_SagaIdx';
+        createTable = 'create table if not exists public."' || tableName || '"
     (
         "Id" uuid not null,
         "Destination" character varying(200),
@@ -17,8 +21,8 @@
         "PersistenceVersion" character varying(23),
         primary key ("Id")
     );
-    create index if not exists "Time_Idx" on public."' || tableNameNonQuoted || '" using btree ("Time" asc nulls last);
-    create index if not exists "SagaId_Idx" on public."' || tableNameNonQuoted || '" using btree ("SagaId" asc nulls last);
+    create index if not exists "' || timeIndexName || '" on public."' || tableName || '" using btree ("Time" asc nulls last);
+    create index if not exists "' || sagaIndexName || '" on public."' || tableName || '" using btree ("SagaId" asc nulls last);
 ';
         execute createTable;
         return 0;

--- a/src/SqlPersistence/Config/SqlDialect_PostgreSql.cs
+++ b/src/SqlPersistence/Config/SqlDialect_PostgreSql.cs
@@ -28,6 +28,14 @@ namespace NServiceBus
             }
 
             internal Action<DbParameter> JsonBParameterModifier { get; set; }
+
+            internal override void ValidateTablePrefix(string tablePrefix)
+            {
+                if (tablePrefix.Length > 20)
+                {
+                    throw new Exception($"Table prefix '{tablePrefix}' contains more than 20 characters, which is not supported by SQL persistence using PostgreSQL. Shorten the endpoint name or specify a custom tablePrefix using endpointConfiguration.{nameof(SqlPersistenceConfig.TablePrefix)}(tablePrefix).");
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
 * Limit prefix to 20
 * Limit saga suffix to 43
 * Make timeout index names unique
 * Extend the saga correlation prop hash to full 20 bytes