### PR TITLE
schema support added for Oracle

### DIFF
--- a/src/SqlPersistence/Outbox/OutboxCommandBuilder.cs
+++ b/src/SqlPersistence/Outbox/OutboxCommandBuilder.cs
@@ -22,7 +22,7 @@ namespace NServiceBus.Persistence.Sql
                     tableName = $"`{tablePrefix}OutboxData`";
                     break;
                 case SqlVariant.Oracle:
-                    tableName = $"{tablePrefix.ToUpper()}OD";
+                    tableName = string.IsNullOrEmpty(schema) ? $"\"{tablePrefix.ToUpper()}OD\"" : $"\"{schema}\".\"{tablePrefix.ToUpper()}OD\"";
                     break;
                 default:
                     throw new Exception($"Unknown SqlVariant: {sqlVariant}");
@@ -58,7 +58,7 @@ set
 where MessageId = @MessageId";
                 case SqlVariant.Oracle:
                     return $@"
-update ""{tableName}""
+update {tableName}
 set
     Dispatched = 1,
     DispatchedAt = :DispatchedAt,
@@ -86,7 +86,7 @@ where MessageId = @MessageId";
 select
     Dispatched,
     Operations
-from ""{tableName}""
+from {tableName}
 where MessageId = :MessageId";
                 default:
                     throw new Exception($"Unknown SqlVariant: {sqlVariant}");
@@ -114,7 +114,7 @@ values
 )";
                 case SqlVariant.Oracle:
                     return $@"
-insert into ""{tableName}""
+insert into {tableName}
 (
     MessageId,
     Operations,
@@ -149,7 +149,7 @@ where Dispatched = true
 limit @BatchSize";
                 case SqlVariant.Oracle:
                     return $@"
-delete from ""{tableName}""
+delete from {tableName}
 where Dispatched = 1
     and DispatchedAt < :DispatchedBefore
     and rownum <= :BatchSize";

--- a/src/SqlPersistence/Saga/RuntimeSagaInfo.cs
+++ b/src/SqlPersistence/Saga/RuntimeSagaInfo.cs
@@ -82,7 +82,7 @@ class RuntimeSagaInfo
                 {
                     throw new Exception($"Saga '{tableSuffix}' contains non-ASCII characters, which is not supported by SQL persistence using Oracle. Either disable Oracle script generation using the SqlPersistenceSettings assembly attribute, change the name of the saga, or specify an alternate table name by overriding the SqlSaga's TableSuffix property.");
                 }
-                TableName = tableSuffix.ToUpper();
+                TableName = string.IsNullOrEmpty(schema) ? tableSuffix.ToUpper() : $"\"{schema.ToUpper()}\".\"{TableName.ToUpper()}\"";
                 FillParameter = ParameterFiller.OracleFill;
                 break;
             default:
@@ -137,14 +137,14 @@ class RuntimeSagaInfo
             using (var stringWriter = new StringWriter(builder))
             using (var writer = writerCreator(stringWriter))
             {
-                 try
-                 {
-                     jsonSerializer.Serialize(writer, sagaData);
-                 }
-                 catch (Exception exception)
-                 {
-                     throw new SerializationException(exception);
-                 }
+                try
+                {
+                    jsonSerializer.Serialize(writer, sagaData);
+                }
+                catch (Exception exception)
+                {
+                    throw new SerializationException(exception);
+                }
             }
             return builder.ToString();
         }

--- a/src/SqlPersistence/Saga/SagaCommandBuilder.cs
+++ b/src/SqlPersistence/Saga/SagaCommandBuilder.cs
@@ -147,8 +147,6 @@ from {TableName(tableName)}
         {
             switch (sqlVariant)
             {
-                    case SqlVariant.Oracle:
-                        return $"\"{name.ToUpper()}\"";
                     default:
                         return name;
             }

--- a/src/SqlPersistence/Subscription/SubscriptionCommandBuilder.cs
+++ b/src/SqlPersistence/Subscription/SubscriptionCommandBuilder.cs
@@ -29,7 +29,7 @@ namespace NServiceBus.Persistence.Sql
                     break;
 
                 case SqlVariant.Oracle:
-                    tableName = $"{tablePrefix.ToUpper()}SS";
+                    tableName = string.IsNullOrEmpty(schema) ? $"\"{tablePrefix.ToUpper()}SS\"" : $"\"{schema}\".\"{tablePrefix.ToUpper()}SS\"";
                     break;
 
                 default:
@@ -96,7 +96,7 @@ on duplicate key update
                 case SqlVariant.Oracle:
                     return $@"
 begin
-    insert into ""{tableName}""
+    insert into {tableName}
     (
         MessageType,
         Subscriber,
@@ -128,7 +128,7 @@ end;
             {
                 case SqlVariant.Oracle:
                     return $@"
-delete from ""{tableName}""
+delete from {tableName}
 where
     Subscriber = :Subscriber and
     MessageType = :MessageType";
@@ -150,7 +150,7 @@ where
 
                     var getSubscribersPrefixOracle = $@"
 select distinct Subscriber, Endpoint
-from ""{tableName}""
+from {tableName}
 where MessageType in (";
 
                     return messageTypes =>

--- a/src/SqlPersistence/Timeout/TimeoutCommandBuilder.cs
+++ b/src/SqlPersistence/Timeout/TimeoutCommandBuilder.cs
@@ -19,7 +19,7 @@ namespace NServiceBus.Persistence.Sql
                 case SqlVariant.MsSqlServer:
                     return BuildSqlServerCommands($"[{schema}].[{tablePrefix}TimeoutData]");
                 case SqlVariant.Oracle:
-                    return BuildOracleCommands($"{tablePrefix.ToUpper()}TO");
+                    return string.IsNullOrEmpty(schema) ? BuildOracleCommands($"\"{tablePrefix.ToUpper()}TO\"") : BuildOracleCommands($"\"{schema}\".\"{tablePrefix.ToUpper()}TO\"");
                 default:
                     throw new Exception($"Unknown SqlVariant: {sqlVariant}.");
             }
@@ -155,7 +155,7 @@ order by Time";
         static TimeoutCommands BuildOracleCommands(string tableName)
         {
             var insertCommandText = $@"
-insert into ""{tableName}""
+insert into {tableName}
 (
     Id,
     Destination,
@@ -177,12 +177,12 @@ values
 )";
 
             var removeByIdCommandText = $@"
-delete from ""{tableName}""
+delete from {tableName}
 where Id = :Id";
 
 
             var removeBySagaIdCommandText = $@"
-delete from ""{tableName}""
+delete from {tableName}
 where SagaId = :SagaId";
 
             var selectByIdCommandText = $@"
@@ -192,19 +192,19 @@ select
     State,
     ExpireTime,
     Headers
-from ""{tableName}""
+from {tableName}
 where Id = :Id";
 
             var rangeCommandText = $@"
 select Id, ExpireTime
-from ""{tableName}""
+from {tableName}
 where ExpireTime > :StartTime and ExpireTime <= :EndTime";
 
             var nextCommandText = $@"
 select ExpireTime
 from
 (
-    select ExpireTime from ""{tableName}""
+    select ExpireTime from {tableName}
     where ExpireTime > :EndTime
     order by ExpireTime
 ) subquery


### PR DESCRIPTION
Schema supported for oracle. I've only tested it with timeout, but I've also changed the others in the same way.
I've preserved the original behaviour. If no schema or an empty schema is set, we use the original behaviour. If the schema is set, the table name is generated like this:
select * from "SCHEMA"."TABLE"
I did not change the scriptbuilder as I've created all the tables manually.