### PR TITLE
Tests for custom schemas

### DIFF
--- a/src/SqlPersistence.Tests/APIApprovals.Approve.approved.txt
+++ b/src/SqlPersistence.Tests/APIApprovals.Approve.approved.txt
@@ -8,7 +8,7 @@
 
 namespace NServiceBus.Persistence.Sql
 {
-
+    
     public interface IMessagePropertyMapper
     {
         void ConfigureMapping<TMessage>(System.Linq.Expressions.Expression<System.Func<TMessage, object>> messageProperty);

--- a/src/SqlPersistence.Tests/Outbox/MySqlOutboxPersisterTests.cs
+++ b/src/SqlPersistence.Tests/Outbox/MySqlOutboxPersisterTests.cs
@@ -10,6 +10,8 @@ public class MySqlOutboxPersisterTests : OutboxPersisterTests
     {
     }
 
+    protected override bool SupportsSchemas() => false;
+
     protected override Func<DbConnection> GetConnection()
     {
         return MySqlConnectionBuilder.Build;

--- a/src/SqlPersistence.Tests/Outbox/OracleOutboxPersisterTests.cs
+++ b/src/SqlPersistence.Tests/Outbox/OracleOutboxPersisterTests.cs
@@ -10,6 +10,8 @@ public class OracleOutboxPersisterTests : OutboxPersisterTests
     {
     }
 
+    protected override bool SupportsSchemas() => false;
+
     protected override Func<DbConnection> GetConnection()
     {
         return OracleConnectionBuilder.Build;
@@ -23,12 +25,5 @@ public class OracleOutboxPersisterTests : OutboxPersisterTests
     protected override string GetTableSuffix()
     {
         return "_OD";
-    }
-
-    protected override string BuildOperationsFromMessageIdCommand(string messageId)
-    {
-        return $@"select Operations
-from ""{GetTablePrefix()}{GetTableSuffix()}""
-where MessageId = '{messageId}'";
     }
 }

--- a/src/SqlPersistence.Tests/Outbox/OutboxPersisterTests.StoreDispatchAndGet.approved.txt
+++ b/src/SqlPersistence.Tests/Outbox/OutboxPersisterTests.StoreDispatchAndGet.approved.txt
@@ -1,4 +1,21 @@
 ﻿{
-  "MessageId": "a",
-  "TransportOperations": []
+  "Item1": {
+    "MessageId": "a",
+    "TransportOperations": [
+      {
+        "MessageId": "Id1",
+        "Options": {
+          "OptionKey1": "OptionValue1"
+        },
+        "Body": "ICE=",
+        "Headers": {
+          "HeaderKey1": "HeaderValue1"
+        }
+      }
+    ]
+  },
+  "Item2": {
+    "MessageId": "a",
+    "TransportOperations": []
+  }
 }

--- a/src/SqlPersistence.Tests/Outbox/PostgreSqlOutboxPersisterTests.cs
+++ b/src/SqlPersistence.Tests/Outbox/PostgreSqlOutboxPersisterTests.cs
@@ -6,19 +6,12 @@ using NUnit.Framework;
 [TestFixture]
 public class PostgreSqlOutboxPersisterTests : OutboxPersisterTests
 {
-    public PostgreSqlOutboxPersisterTests() : base(BuildSqlDialect.PostgreSql, null)
+    public PostgreSqlOutboxPersisterTests() : base(BuildSqlDialect.PostgreSql, "SchemaName")
     {
     }
 
     protected override Func<DbConnection> GetConnection()
     {
         return PostgreSqlConnectionBuilder.Build;
-    }
-    protected override string BuildOperationsFromMessageIdCommand(string messageId)
-    {
-        return $@"
-select ""Operations""
-from ""{GetTablePrefix()}{GetTableSuffix()}""
-where ""MessageId"" = '{messageId}'";
     }
 }

--- a/src/SqlPersistence.Tests/Saga/MySqlSagaPersisterTests.cs
+++ b/src/SqlPersistence.Tests/Saga/MySqlSagaPersisterTests.cs
@@ -13,6 +13,8 @@ public class MySqlSagaPersisterTests: SagaPersisterTests
     {
     }
 
+    protected override bool SupportsSchemas() => false;
+
     protected override Func<DbConnection> GetConnection()
     {
         return () =>

--- a/src/SqlPersistence.Tests/Saga/OracleSagaPersisterTests.cs
+++ b/src/SqlPersistence.Tests/Saga/OracleSagaPersisterTests.cs
@@ -10,6 +10,8 @@ public class OracleSagaPersisterTests : SagaPersisterTests
     {
     }
 
+    protected override bool SupportsSchemas() => false;
+
     protected override Func<DbConnection> GetConnection()
     {
         return () =>

--- a/src/SqlPersistence.Tests/Saga/PostgreSqlSagaPersisterTests.cs
+++ b/src/SqlPersistence.Tests/Saga/PostgreSqlSagaPersisterTests.cs
@@ -4,7 +4,7 @@ using NServiceBus.Persistence.Sql.ScriptBuilder;
 
 public class PostgreSqlSagaPersisterTests : SagaPersisterTests
 {
-    public PostgreSqlSagaPersisterTests() : base(BuildSqlDialect.PostgreSql, null)
+    public PostgreSqlSagaPersisterTests() : base(BuildSqlDialect.PostgreSql, "SchemaName")
     {
     }
 

--- a/src/SqlPersistence.Tests/SetUpFixture.cs
+++ b/src/SqlPersistence.Tests/SetUpFixture.cs
@@ -24,6 +24,15 @@ exec('create schema schema_name');";
                 command.ExecuteNonQuery();
             }
         }
+        using (var connection = PostgreSqlConnectionBuilder.Build())
+        {
+            connection.Open();
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = @"create schema if not exists ""SchemaName"";";
+                command.ExecuteNonQuery();
+            }
+        }
     }
 
     void FixCurrentDirectory([CallerFilePath] string callerFilePath="")

--- a/src/SqlPersistence.Tests/SqlDialectConverter.cs
+++ b/src/SqlPersistence.Tests/SqlDialectConverter.cs
@@ -35,14 +35,16 @@ public static class SqlDialectConverter
         switch (sqlDialect)
         {
             case BuildSqlDialect.MsSqlServer:
-                return new SqlDialect.MsSqlServer
+                var sqlServer = new SqlDialect.MsSqlServer();
+                if (schema != null)
                 {
-                    Schema = schema
-                };
+                    sqlServer.Schema = schema;
+                }
+                return sqlServer;
             case BuildSqlDialect.MySql:
                 return new SqlDialect.MySql();
             case BuildSqlDialect.PostgreSql:
-                return new SqlDialect.PostgreSql
+                var postgreSql = new SqlDialect.PostgreSql
                 {
                     JsonBParameterModifier = parameter =>
                     {
@@ -50,8 +52,14 @@ public static class SqlDialectConverter
                         npgsqlParameter.NpgsqlDbType = NpgsqlDbType.Jsonb;
                     }
                 };
+                if (schema != null)
+                {
+                    postgreSql.Schema = schema;
+                }
+                return postgreSql;
             case BuildSqlDialect.Oracle:
-                return new SqlDialect.Oracle();
+                var oracle = new SqlDialect.Oracle();
+                return oracle;
             default:
                 throw new Exception($"Unknown BuildSqlDialect: {sqlDialect}.");
         }

--- a/src/SqlPersistence.Tests/Subscription/MySqlServerSubscriptionPersisterTests.cs
+++ b/src/SqlPersistence.Tests/Subscription/MySqlServerSubscriptionPersisterTests.cs
@@ -10,6 +10,8 @@ public class MySqlServerSubscriptionPersisterTests : SubscriptionPersisterTests
     {
     }
 
+    protected override bool SupportsSchemas() => false;
+
     protected override Func<DbConnection> GetConnection()
     {
         return MySqlConnectionBuilder.Build;

--- a/src/SqlPersistence.Tests/Subscription/OracleSubscriptionPersisterTests.cs
+++ b/src/SqlPersistence.Tests/Subscription/OracleSubscriptionPersisterTests.cs
@@ -10,6 +10,8 @@ public class OracleSubscriptionPersisterTests : SubscriptionPersisterTests
     {
     }
 
+    protected override bool SupportsSchemas() => false;
+
     protected override Func<DbConnection> GetConnection()
     {
         return OracleConnectionBuilder.Build;

--- a/src/SqlPersistence.Tests/Subscription/PostgreSqlSubscriptionPersisterTests.cs
+++ b/src/SqlPersistence.Tests/Subscription/PostgreSqlSubscriptionPersisterTests.cs
@@ -6,7 +6,7 @@ using NUnit.Framework;
 [TestFixture]
 public class PostgreSqlSubscriptionPersisterTests : SubscriptionPersisterTests
 {
-    public PostgreSqlSubscriptionPersisterTests() : base(BuildSqlDialect.PostgreSql, null)
+    public PostgreSqlSubscriptionPersisterTests() : base(BuildSqlDialect.PostgreSql, "SchemaName")
     {
     }
 

--- a/src/SqlPersistence.Tests/Timeout/MySqlServerTimeoutPersisterTests.cs
+++ b/src/SqlPersistence.Tests/Timeout/MySqlServerTimeoutPersisterTests.cs
@@ -10,6 +10,8 @@ public class MySqlServerTimeoutPersisterTests : TimeoutPersisterTests
     {
     }
 
+    protected override bool SupportsSchemas() => false;
+
     protected override Func<DbConnection> GetConnection()
     {
         return MySqlConnectionBuilder.Build;

--- a/src/SqlPersistence.Tests/Timeout/OracleTimeoutPersisterTests.cs
+++ b/src/SqlPersistence.Tests/Timeout/OracleTimeoutPersisterTests.cs
@@ -10,6 +10,8 @@ public class OracleTimeoutPersisterTests : TimeoutPersisterTests
     {
     }
 
+    protected override bool SupportsSchemas() => false;
+
     protected override Func<DbConnection> GetConnection()
     {
         return OracleConnectionBuilder.Build;

--- a/src/SqlPersistence.Tests/Timeout/PostgreSqlTimeoutPersisterTests.cs
+++ b/src/SqlPersistence.Tests/Timeout/PostgreSqlTimeoutPersisterTests.cs
@@ -6,7 +6,7 @@ using NUnit.Framework;
 [TestFixture]
 public class PostgreSqlTimeoutPersisterTests : TimeoutPersisterTests
 {
-    public PostgreSqlTimeoutPersisterTests() : base(BuildSqlDialect.PostgreSql, null)
+    public PostgreSqlTimeoutPersisterTests() : base(BuildSqlDialect.PostgreSql, "SchemaName")
     {
     }
 


### PR DESCRIPTION
Added `UseCustomSchema` tests to all persister tests that verify that data written to a default schema cannot be loaded via a persister configured with custom schema.

MySQL is excuded.
Oracle is temporarily excluded until we rebase/merge.