### PR TITLE
ScriptBuilderTask task cannot be loaded from assembly

### DIFF
--- a/packaging/nuget/NServiceBus.Persistence.Sql.MsBuild.targets
+++ b/packaging/nuget/NServiceBus.Persistence.Sql.MsBuild.targets
@@ -1,51 +1,44 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Choose>
-    <When Condition="'$(MSBuildRuntimeType)' == 'Core'">
-      <PropertyGroup>
-        <ScriptBuilderTaskPath>$(MSBuildThisFileDirectory)..\netstandard\NServiceBus.Persistence.Sql.ScriptBuilderTask.dll</ScriptBuilderTaskPath>
-      </PropertyGroup>
-    </When>
-    <Otherwise>
-      <PropertyGroup>
-        <ScriptBuilderTaskPath>$(MSBuildThisFileDirectory)..\netclassic\NServiceBus.Persistence.Sql.ScriptBuilderTask.dll</ScriptBuilderTaskPath>
-      </PropertyGroup>
-    </Otherwise>
-  </Choose>
-  <UsingTask
-      TaskName="NServiceBus.Persistence.Sql.SqlPersistenceScriptBuilderTask"
-      AssemblyFile="$(ScriptBuilderTaskPath)" />
+﻿<Project>
 
-  <Target
-      AfterTargets="AfterCompile"
-      Name="SqlPersistenceScriptBuilder">
+  <PropertyGroup>
+    <SqlPersistenceScriptBuilderTaskPath Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\netstandard\NServiceBus.Persistence.Sql.ScriptBuilderTask.dll</SqlPersistenceScriptBuilderTaskPath>
+    <SqlPersistenceScriptBuilderTaskPath Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\netclassic\NServiceBus.Persistence.Sql.ScriptBuilderTask.dll</SqlPersistenceScriptBuilderTaskPath>
+  </PropertyGroup>
+
+  <UsingTask
+    TaskName="NServiceBus.Persistence.Sql.SqlPersistenceScriptBuilderTask"
+    AssemblyFile="$(SqlPersistenceScriptBuilderTaskPath)" />
+
+  <Target Name="SqlPersistenceScriptBuilder" AfterTargets="AfterCompile">
+
     <SqlPersistenceScriptBuilderTask
-          AssemblyPath="$(ProjectDir)@(IntermediateAssembly)"
-          IntermediateDirectory="$(ProjectDir)$(IntermediateOutputPath)"
-          ProjectDirectory="$(ProjectDir)"
-          SolutionDirectory="$(SolutionDir)"/>
+      AssemblyPath="$(ProjectDir)@(IntermediateAssembly)"
+      IntermediateDirectory="$(ProjectDir)$(IntermediateOutputPath)"
+      ProjectDirectory="$(ProjectDir)"
+      SolutionDirectory="$(SolutionDir)"/>
+
   </Target>
 
-  <Target
-      BeforeTargets="GetCopyToOutputDirectoryItems"
-      Name="AddScriptsToGetCopyToOutputDirectoryItems">
+  <Target Name="AddSqlPersistenceScriptsToGetCopyToOutputDirectoryItems" BeforeTargets="GetCopyToOutputDirectoryItems">
+
     <PropertyGroup>
-      <ScriptDirectory>$(ProjectDir)$(IntermediateOutputPath)NServiceBus.Persistence.Sql\</ScriptDirectory>
+      <SqlPersistenceScriptDirectory>$(ProjectDir)$(IntermediateOutputPath)NServiceBus.Persistence.Sql\</SqlPersistenceScriptDirectory>
     </PropertyGroup>
+
     <ItemGroup>
-      <Scripts Include="$(ScriptDirectory)**\*.sql" />
+      <SqlPersistenceScripts Include="$(SqlPersistenceScriptDirectory)**\*.sql" />
     </ItemGroup>
 
-    <CreateItem Include="@(Scripts)"
+    <CreateItem Include="@(SqlPersistenceScripts)"
                 AdditionalMetadata="CopyToOutputDirectory=PreserveNewest;TargetPath=NServiceBus.Persistence.Sql\%(RecursiveDir)%(Filename)%(Extension)">
-      <Output TaskParameter="Include"
-              ItemName="_SourceItemsToCopyToOutputDirectoryAlways" />
+      <Output TaskParameter="Include" ItemName="_SourceItemsToCopyToOutputDirectoryAlways" />
     </CreateItem>
-    <CreateItem Include="@(Scripts)"
+
+    <CreateItem Include="@(SqlPersistenceScripts)"
                 AdditionalMetadata="CopyToOutputDirectory=PreserveNewest;TargetPath=NServiceBus.Persistence.Sql\%(RecursiveDir)%(Filename)%(Extension)">
-      <Output TaskParameter="Include"
-              ItemName="AllItemsFullPathWithTargetPath" />
+      <Output TaskParameter="Include" ItemName="AllItemsFullPathWithTargetPath" />
     </CreateItem>
+
   </Target>
 
   <!--Support for ncrunch-->

--- a/packaging/nuget/NServiceBus.Persistence.Sql.MsBuild.targets
+++ b/packaging/nuget/NServiceBus.Persistence.Sql.MsBuild.targets
@@ -9,7 +9,9 @@
     TaskName="NServiceBus.Persistence.Sql.SqlPersistenceScriptBuilderTask"
     AssemblyFile="$(SqlPersistenceScriptBuilderTaskPath)" />
 
-  <Target Name="SqlPersistenceScriptBuilder" AfterTargets="AfterCompile">
+  <Target Name="SqlPersistenceScriptBuilder"
+          AfterTargets="AfterCompile"
+          Condition="('$(UsingMicrosoftNETSdk)' == 'true' AND '$(DesignTimeBuild)' != 'true') OR ('$(UsingMicrosoftNETSdk)' != 'true' AND '$(BuildingProject)' == 'true')">
 
     <SqlPersistenceScriptBuilderTask
       AssemblyPath="$(ProjectDir)@(IntermediateAssembly)"
@@ -19,7 +21,9 @@
 
   </Target>
 
-  <Target Name="AddSqlPersistenceScriptsToGetCopyToOutputDirectoryItems" BeforeTargets="GetCopyToOutputDirectoryItems">
+  <Target Name="AddSqlPersistenceScriptsToGetCopyToOutputDirectoryItems"
+          BeforeTargets="GetCopyToOutputDirectoryItems"
+          Condition="('$(UsingMicrosoftNETSdk)' == 'true' AND '$(DesignTimeBuild)' != 'true') OR ('$(UsingMicrosoftNETSdk)' != 'true' AND '$(BuildingProject)' == 'true')">
 
     <PropertyGroup>
       <SqlPersistenceScriptDirectory>$(ProjectDir)$(IntermediateOutputPath)NServiceBus.Persistence.Sql\</SqlPersistenceScriptDirectory>


### PR DESCRIPTION
This is the complete fix to #220. All targets and properties now have a unique name, so they will not conflict with any other ScriptBuilder targets files.

This also adds a property to condition to the targets to make sure they don't run during Visual Studio's design-time builds.

The condition will work when the package is installed in both a legacy project and an SDK-style project when at least the 2.0.0 SDK is used. Because of how the legacy property works, there's no good way to make it work with with the 1.0 SDK as well, but we're no worse off then we already were in that scenario.

### Symptoms

Due to a naming clash, a compile error occurs saying a ScriptBuilderTask task can't be loaded from an assembly, either in SQL Persistence, or in Performance Counters.

### Who's affected

Users attempting to use the `NServiceBus.Persistence.Sql.MsBuild` package together with `NServiceBus.Metrics.PerformanceCounters.MsBuild`.

### (Release Notes) Notes

@DavidBoike: As #220 is already on the 2.2.0 milestone I'm treating this as the "bug issue" for the purposes of release notes, where other backports will be linked from.

### Backported to:

* 2.2.1 - this pull request
* 1.0.7 - *Not yet released*