### PR TITLE
Cleanup followup

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -64,11 +64,6 @@
 *.bat text eol=crlf
 
 # Custom for Visual Studio
-*.csproj merge=union
-*.vbproj merge=union
-*.fsproj merge=union
-*.dbproj merge=union 
-*.sln text eol=crlf merge=union
 *.suo 	-text -diff
 *.snk 	-text -diff
 *.cub 	-text -diff

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,10 +1,7 @@
 assembly-versioning-scheme: Major
-next-version: 3.1
+next-version: 3.0
 branches:
   develop:
     tag: alpha
   release:
     tag: beta
-  postgresql:
-    regex: postgresql
-    tag: alpha

--- a/src/Integration.sln
+++ b/src/Integration.sln
@@ -1,7 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.27004.2009
-VisualStudioVersion = 15.0.27004.2002
 MinimumVisualStudioVersion = 15.0.26403.0
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Shared", "Integration\Shared\Shared.csproj", "{595E1284-D95D-47ED-8A59-43BB17123BE3}"
 EndProject

--- a/src/Integration/PostgreSqlSample/PostgreSqlSample.csproj
+++ b/src/Integration/PostgreSqlSample/PostgreSqlSample.csproj
@@ -1,15 +1,16 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFramework>net452</TargetFramework>
     <OutputType>exe</OutputType>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(SolutionDir)Integration\Shared\Shared.csproj" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Npgsql" Version="3.*" />
-    <PackageReference Include="NServiceBus" Version="7.0.0-*" />
-    <PackageReference Include="NServiceBus.Persistence.Sql" Version="$(IntegrationVersion)" />
-    <ProjectReference Include="$(SolutionDir)Integration\Shared\Shared.csproj" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
+
 </Project>

--- a/src/MsSqlAcceptanceTests/MsSqlAcceptanceTests.csproj
+++ b/src/MsSqlAcceptanceTests/MsSqlAcceptanceTests.csproj
@@ -19,9 +19,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="NServiceBus.AcceptanceTesting" Version="7.0.0-beta0012" />
     <PackageReference Include="NServiceBus.SqlServer" Version="4.0.0-beta0005" />
-    <PackageReference Include="NServiceBus" Version="7.0.0-*" />
-    <PackageReference Include="NServiceBus.SqlServer" Version="4.0.0-beta*" />
-    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="7.0.0-*" />
     <PackageReference Include="NUnit" Version="3.7.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
   </ItemGroup>

--- a/src/MySqlAcceptanceTests/MySqlAcceptanceTests.csproj
+++ b/src/MySqlAcceptanceTests/MySqlAcceptanceTests.csproj
@@ -24,20 +24,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MySql.Data" Version="6.*" />
-    <PackageReference Include="NServiceBus" Version="7.0.0-beta0012" />
-    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="7.0.0-beta0012" />
-    <PackageReference Include="NServiceBus.Transport.Msmq" Version="1.0.0-beta0005" />
-    <PackageReference Include="NUnit" Version="3.7.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.*" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" PrivateAssets="All" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Messaging" />
-    <Reference Include="System.Transactions" />
-    <Reference Include="System.Configuration" />
-    <ProjectReference Include="..\AcceptanceTestHelper\AcceptanceTestHelper.csproj" />
-    <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
-    <ProjectReference Include="..\SqlPersistence\SqlPersistence.csproj" />
     <Compile Include="$(SolutionDir)\AcceptanceTestsHolder\App_Packages\**\*.cs" />
     <Compile Include="$(SolutionDir)\AcceptanceTestsHolder\Partials\*.cs" />
   </ItemGroup>

--- a/src/NServiceBus.Persistence.Sql.sln
+++ b/src/NServiceBus.Persistence.Sql.sln
@@ -1,7 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.27004.2008
-VisualStudioVersion = 15.0.26730.16
 MinimumVisualStudioVersion = 15.0.26403.0
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SqlPersistence", "SqlPersistence\SqlPersistence.csproj", "{E3CF4CB1-9F87-4F81-B6B0-B599035C1BCE}"
 EndProject

--- a/src/NServiceBus.Persistence.Sql.sln
+++ b/src/NServiceBus.Persistence.Sql.sln
@@ -30,12 +30,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OracleAcceptanceTests", "Or
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AcceptanceTestsHolder", "AcceptanceTestsHolder\AcceptanceTestsHolder.csproj", "{8B2246AB-4FAA-481D-AC1B-0A3F24E48CC8}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PostgreSqlAcceptanceTests", "PostgreSqlAcceptanceTests\PostgreSqlAcceptanceTests.csproj", "{2247EC45-45DE-4D00-9343-C0FBC3C8EFB4}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{FB898D09-ADF0-49D4-8089-D743F1A31D12}"
 	ProjectSection(SolutionItems) = preProject
 		Directory.Build.props = Directory.Build.props
 		..\GitVersion.yml = ..\GitVersion.yml
 	EndProjectSection
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PostgreSqlAcceptanceTests", "PostgreSqlAcceptanceTests\PostgreSqlAcceptanceTests.csproj", "{2247EC45-45DE-4D00-9343-C0FBC3C8EFB4}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/OracleAcceptanceTests/OracleAcceptanceTests.csproj
+++ b/src/OracleAcceptanceTests/OracleAcceptanceTests.csproj
@@ -18,25 +18,11 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="NServiceBus.AcceptanceTesting" Version="7.0.0-beta0012" />
     <PackageReference Include="NServiceBus.Transport.Msmq" Version="1.0.0-beta0005" />
-    <PackageReference Include="NServiceBus" Version="7.0.0-*" />
-    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="7.0.0-*" />
-    <PackageReference Include="NServiceBus.Transport.Msmq" Version="1.0.0-*" />
     <PackageReference Include="NUnit" Version="3.7.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.*" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" PrivateAssets="All" />
-    <PackageReference Include="Oracle.ManagedDataAccess" Version="12.*" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Messaging" />
-    <Reference Include="System.Transactions" />
-    <Reference Include="System.Configuration" />
-    <ProjectReference Include="..\AcceptanceTestHelper\AcceptanceTestHelper.csproj" />
-    <ProjectReference Include="..\ScriptBuilder\ScriptBuilder.csproj" />
-    <ProjectReference Include="..\SqlPersistence\SqlPersistence.csproj" />
-    <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
     <Compile Include="$(SolutionDir)\AcceptanceTestsHolder\App_Packages\**\*.cs" />
     <Compile Include="$(SolutionDir)\AcceptanceTestsHolder\Partials\*.cs" />
   </ItemGroup>

--- a/src/PostgreSqlAcceptanceTests/PostgreSqlAcceptanceTests.csproj
+++ b/src/PostgreSqlAcceptanceTests/PostgreSqlAcceptanceTests.csproj
@@ -1,5 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
@@ -7,25 +7,25 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\AcceptanceTestHelper\AcceptanceTestHelper.csproj" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Transactions" />
-    <Reference Include="System.Configuration" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Npgsql" Version="3.*" />
-    <PackageReference Include="NServiceBus" Version="7.0.0-*" />
-    <PackageReference Include="NServiceBus.SqlServer" Version="4.0.0-beta*" />
-    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="7.0.0-*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="7.0.0-beta0012" />
+    <PackageReference Include="NServiceBus.SqlServer" Version="4.0.0-beta0005" />
     <PackageReference Include="NUnit" Version="3.7.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.*" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" PrivateAssets="All" />
-    <ProjectReference Include="..\AcceptanceTestHelper\AcceptanceTestHelper.csproj" />
-    <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
-    <ProjectReference Include="..\ScriptBuilder\ScriptBuilder.csproj" />
-    <ProjectReference Include="..\SqlPersistence\SqlPersistence.csproj" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Include="$(SolutionDir)\AcceptanceTestsHolder\App_Packages\**\*.cs" Exclude="$(SolutionDir)\AcceptanceTestsHolder\App_Packages\**\ConfigureEndpointMsmqTransport.cs" />
     <Compile Include="$(SolutionDir)\AcceptanceTestsHolder\Partials\*.cs" />
   </ItemGroup>
+
 </Project>

--- a/src/ScriptBuilder.Tests/ScriptBuilder.Tests.csproj
+++ b/src/ScriptBuilder.Tests/ScriptBuilder.Tests.csproj
@@ -9,12 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.*" />
-    <PackageReference Include="NServiceBus" Version="7.0.0-beta0012" />
-    <PackageReference Include="NUnit" Version="3.7.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.*" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" PrivateAssets="All" />
-    <PackageReference Include="Mono.Cecil" Version="0.10.0-*" />
     <ProjectReference Include="..\ScriptBuilder\ScriptBuilder.csproj" />
     <ProjectReference Include="..\SqlPersistence\SqlPersistence.csproj" />
   </ItemGroup>

--- a/src/ScriptBuilderTask.Tests/ScriptBuilderTask.Tests.csproj
+++ b/src/ScriptBuilderTask.Tests/ScriptBuilderTask.Tests.csproj
@@ -9,11 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.*" />
-    <PackageReference Include="NUnit" Version="3.7.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.*" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" PrivateAssets="All" />
-    <ProjectReference Include="..\ScriptBuilderTask.Tests.Target\ScriptBuilderTask.Tests.Target.csproj" />
     <ProjectReference Include="..\ScriptBuilderTask\ScriptBuilderTask.csproj" />
     <ProjectReference Include="..\ScriptBuilderTask.Tests.Target\ScriptBuilderTask.Tests.Target.csproj" />
   </ItemGroup>

--- a/src/SqlPersistence.Tests/Outbox/CommandTests/OutboxCommandTests.cs
+++ b/src/SqlPersistence.Tests/Outbox/CommandTests/OutboxCommandTests.cs
@@ -1,3 +1,4 @@
+#if NET452
 #pragma warning disable 618
 using ApprovalTests;
 using ApprovalTests.Namers;
@@ -93,3 +94,4 @@ public abstract class OutboxCommandTests
         }
     }
 }
+#endif

--- a/src/SqlPersistence.Tests/Saga/CommandTests/SagaCommandTests.cs
+++ b/src/SqlPersistence.Tests/Saga/CommandTests/SagaCommandTests.cs
@@ -1,3 +1,4 @@
+#if NET452
 #pragma warning disable 618
 using ApprovalTests;
 using ApprovalTests.Namers;
@@ -106,3 +107,4 @@ public abstract class SagaCommandTests
         }
     }
 }
+#endif

--- a/src/SqlPersistence.Tests/SqlPersistence.Tests.csproj
+++ b/src/SqlPersistence.Tests/SqlPersistence.Tests.csproj
@@ -8,29 +8,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
-    <Compile Remove="Saga\MySqlSagaPersisterTests.cs" />
-    <Compile Remove="Saga\OracleSagaPersisterTests.cs" />
-    <Compile Remove="Outbox\MySqlOutboxPersisterTests.cs" />
-    <Compile Remove="Outbox\OracleOutboxPersisterTests.cs" />
-    <Compile Remove="Timeout\MySqlServerTimeoutPersisterTests.cs" />
-    <Compile Remove="Timeout\OracleTimeoutPersisterTests.cs" />
-    <Compile Remove="Subscription\MySqlServerSubscriptionPersisterTests.cs" />
-    <Compile Remove="Subscription\OracleSubscriptionPersisterTests.cs" />
-    <Compile Remove="Saga\CommandTests\SagaCommandTests.cs" />
-    <Compile Remove="Outbox\CommandTests\OutboxCommandTests.cs" />
-    <Compile Remove="Subscription\CommandTests\SubscriptionCommandTests.cs" />
-    <Compile Remove="Timeout\CommandTests\TimeoutCommandTests.cs" />
-  </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Npgsql " Version="3.*" />
-    <PackageReference Include="Mono.Cecil" Version="0.10.0-*" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.*" />
-    <PackageReference Include="NServiceBus" Version="7.0.0-beta0012" />
-    <PackageReference Include="NServiceBus.SqlServer" Version="4.0.0-beta0005" />
-    <PackageReference Include="NUnit" Version="3.7.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.*" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" PrivateAssets="All" />
     <ProjectReference Include="..\ScriptBuilder\ScriptBuilder.csproj" />
     <ProjectReference Include="..\SqlPersistence\SqlPersistence.csproj" />
     <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
@@ -46,6 +24,13 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
     <PackageReference Include="ObjectApproval" Version="1.*" />
     <PackageReference Include="PublicApiGenerator" Version="6.*" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
+    <Compile Remove="Saga\CommandTests\SagaCommandTests.cs" />
+    <Compile Remove="Outbox\CommandTests\OutboxCommandTests.cs" />
+    <Compile Remove="Subscription\CommandTests\SubscriptionCommandTests.cs" />
+    <Compile Remove="Timeout\CommandTests\TimeoutCommandTests.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">

--- a/src/SqlPersistence.Tests/SqlPersistence.Tests.csproj
+++ b/src/SqlPersistence.Tests/SqlPersistence.Tests.csproj
@@ -27,13 +27,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
-    <Compile Remove="Saga\CommandTests\SagaCommandTests.cs" />
-    <Compile Remove="Outbox\CommandTests\OutboxCommandTests.cs" />
-    <Compile Remove="Subscription\CommandTests\SubscriptionCommandTests.cs" />
-    <Compile Remove="Timeout\CommandTests\TimeoutCommandTests.cs" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
     <Compile Remove="Saga\MySqlSagaPersisterTests.cs" />
     <Compile Remove="Outbox\MySqlOutboxPersisterTests.cs" />
     <Compile Remove="Timeout\MySqlServerTimeoutPersisterTests.cs" />

--- a/src/SqlPersistence.Tests/Subscription/CommandTests/SubscriptionCommandTests.cs
+++ b/src/SqlPersistence.Tests/Subscription/CommandTests/SubscriptionCommandTests.cs
@@ -1,3 +1,4 @@
+#if NET452
 #pragma warning disable 618
 using ApprovalTests;
 using ApprovalTests.Namers;
@@ -83,3 +84,4 @@ public abstract class SubscriptionCommandTests
         }
     }
 }
+#endif

--- a/src/SqlPersistence.Tests/Timeout/CommandTests/TimeoutCommandTests.cs
+++ b/src/SqlPersistence.Tests/Timeout/CommandTests/TimeoutCommandTests.cs
@@ -1,3 +1,4 @@
+#if NET452
 #pragma warning disable 618
 using ApprovalTests;
 using ApprovalTests.Namers;
@@ -113,3 +114,4 @@ public abstract class TimeoutCommandTests
         }
     }
 }
+#endif

--- a/src/SqlPersistence/SqlPersistence.csproj
+++ b/src/SqlPersistence/SqlPersistence.csproj
@@ -35,12 +35,6 @@
     <Description>Sql persistence for NServiceBus</Description>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net452|AnyCPU'">
-    <Optimize>false</Optimize>
-    <DebugType>full</DebugType>
-    <DebugSymbols>true</DebugSymbols>
-  </PropertyGroup>
-
   <Target Name="PreparePackagesForIntegrationSolution" BeforeTargets="GenerateNuspec">
     <RemoveDir Directories="$(NuGetPackageRoot)NServiceBus.Persistence.Sql\$(PackageVersion)" ContinueOnError="WarnAndContinue" />
     <RemoveDir Directories="$(NuGetPackageRoot)NServiceBus.Persistence.Sql.MsBuild\$(PackageVersion)" ContinueOnError="WarnAndContinue" />

--- a/src/SqlPersistence/SqlPersistenceSettingsAttribute.cs
+++ b/src/SqlPersistence/SqlPersistenceSettingsAttribute.cs
@@ -1,4 +1,5 @@
-﻿namespace NServiceBus.Persistence.Sql
+﻿// ReSharper disable AutoPropertyCanBeMadeGetOnly.Global
+namespace NServiceBus.Persistence.Sql
 {
     using System;
 

--- a/src/TestHelper/TestHelper.csproj
+++ b/src/TestHelper/TestHelper.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Npgsql " Version="3.*" />
   </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
     <PackageReference Include="Oracle.ManagedDataAccess" Version="12.*" />
     <PackageReference Include="MySql.Data" Version="6.*" ExcludeAssets="contentFiles" />


### PR DESCRIPTION
Because of some bad gitattributes settings, the merge of the postgres support didn't correctly mark some files as conflicting and instead just merged in the changes on both sides. I've got through and fixed up everything.

I also cleaned up the two new project files to match the others.

One last thing I did was to change how the new command tests are prevented from running on netcoreapp2.0. I switched to conditional compilation because if either oracle or mysql started working on .NET Core, those tests would still need to be excluded because they use ApprovalTests.