### PR TITLE
port hotfix 2.2.1

### DIFF
--- a/packaging/nuget/NServiceBus.Persistence.Sql.MsBuild.targets
+++ b/packaging/nuget/NServiceBus.Persistence.Sql.MsBuild.targets
@@ -1,39 +1,27 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <ScriptDirectory>$(ProjectDir)$(IntermediateOutputPath)NServiceBus.Persistence.Sql\</ScriptDirectory>
-  </PropertyGroup>
-
-  <UsingTask
-      TaskName="NServiceBus.Persistence.Sql.SqlPersistenceScriptBuilderTask"
-      AssemblyFile="$(MSBuildThisFileDirectory)..\NServiceBus.Persistence.Sql.ScriptBuilderTask.dll" />
-
-  <Target
-      AfterTargets="AfterCompile"
-      Name="SqlPersistenceScriptBuilder">
-    <SqlPersistenceScriptBuilderTask
-          AssemblyPath="$(ProjectDir)@(IntermediateAssembly)"
-          IntermediateDirectory="$(ProjectDir)$(IntermediateOutputPath)"/>
-  </Target>
-  
-  <Target
-      BeforeTargets="GetCopyToOutputDirectoryItems"
-      Name="AddScriptsToGetCopyToOutputDirectoryItems">
-    <ItemGroup>
-      <Scripts Include="$(ScriptDirectory)**\*.sql" />
-    </ItemGroup>
-    <!--<Message Text="SqlScripts: @(Scripts)"/>-->
-    <CreateItem Include="@(Scripts)" AdditionalMetadata="CopyToOutputDirectory=PreserveNewest;TargetPath=NServiceBus.Persistence.Sql\%(RecursiveDir)%(Filename)%(Extension)">
-      <Output TaskParameter="Include" ItemName="_SourceItemsToCopyToOutputDirectoryAlways" />
-    </CreateItem>
-    <CreateItem Include="@(Scripts)" AdditionalMetadata="CopyToOutputDirectory=PreserveNewest;TargetPath=NServiceBus.Persistence.Sql\%(RecursiveDir)%(Filename)%(Extension)">
-      <Output TaskParameter="Include" ItemName="AllItemsFullPathWithTargetPath" />
-    </CreateItem>
-  </Target>
-
-  <!--Support for ncrunch-->
-  <ItemGroup  Condition="'$(NCrunch)' == '1'">
-    <None Include="$(MSBuildThisFileDirectory)..\*.*" />
-  </ItemGroup>
-
+﻿<Project>
+	<PropertyGroup>
+		<ScriptDirectory>
+			$(ProjectDir)$(IntermediateOutputPath)NServiceBus.Persistence.Sql\
+		</ScriptDirectory>
+	</PropertyGroup>
+	<UsingTask TaskName="NServiceBus.Persistence.Sql.SqlPersistenceScriptBuilderTask" AssemblyFile="$(MSBuildThisFileDirectory)..\NServiceBus.Persistence.Sql.ScriptBuilderTask.dll" />
+	<Target Name="SqlPersistenceScriptBuilder" AfterTargets="AfterCompile" Condition="('$(UsingMicrosoftNETSdk)' == 'true' AND '$(DesignTimeBuild)' != 'true') OR ('$(UsingMicrosoftNETSdk)' != 'true' AND '$(BuildingProject)' == 'true')">
+		<SqlPersistenceScriptBuilderTask AssemblyPath="$(ProjectDir)@(IntermediateAssembly)" IntermediateDirectory="$(ProjectDir)$(IntermediateOutputPath)" />
+	</Target>
+	<Target Name="AddSqlPersistenceScriptsToGetCopyToOutputDirectoryItems" BeforeTargets="GetCopyToOutputDirectoryItems" Condition="('$(UsingMicrosoftNETSdk)' == 'true' AND '$(DesignTimeBuild)' != 'true') OR ('$(UsingMicrosoftNETSdk)' != 'true' AND '$(BuildingProject)' == 'true')">
+		<ItemGroup>
+			<SqlPersistenceScripts Include="$(ScriptDirectory)**\*.sql" />
+		</ItemGroup>
+		<!-- <Message Text="SqlScripts: @(Scripts)"/> -->
+		<CreateItem Include="@(SqlPersistenceScripts)" AdditionalMetadata="CopyToOutputDirectory=PreserveNewest;TargetPath=NServiceBus.Persistence.Sql\%(RecursiveDir)%(Filename)%(Extension)">
+			<Output TaskParameter="Include" ItemName="_SourceItemsToCopyToOutputDirectoryAlways" />
+		</CreateItem>
+		<CreateItem Include="@(SqlPersistenceScripts)" AdditionalMetadata="CopyToOutputDirectory=PreserveNewest;TargetPath=NServiceBus.Persistence.Sql\%(RecursiveDir)%(Filename)%(Extension)">
+			<Output TaskParameter="Include" ItemName="AllItemsFullPathWithTargetPath" />
+		</CreateItem>
+	</Target>
+	<!-- Support for ncrunch -->
+	<ItemGroup Condition="'$(NCrunch)' == '1'">
+		<None Include="$(MSBuildThisFileDirectory)..\*.*" />
+	</ItemGroup>
 </Project>

--- a/packaging/nuget/NServiceBus.Persistence.Sql.MsBuild.targets
+++ b/packaging/nuget/NServiceBus.Persistence.Sql.MsBuild.targets
@@ -22,7 +22,7 @@
 		<ItemGroup>
 			<SqlPersistenceScripts Include="$(SqlPersistenceScriptDirectory)**\*.sql" />
 		</ItemGroup>
-		<!-- <Message Text="SqlScripts: @(Scripts)"/> -->
+		<!-- <Message Text="SqlScripts: @(SqlPersistenceScripts)"/> -->
 		<CreateItem Include="@(SqlPersistenceScripts)" AdditionalMetadata="CopyToOutputDirectory=PreserveNewest;TargetPath=NServiceBus.Persistence.Sql\%(RecursiveDir)%(Filename)%(Extension)">
 			<Output TaskParameter="Include" ItemName="_SourceItemsToCopyToOutputDirectoryAlways" />
 		</CreateItem>

--- a/packaging/nuget/NServiceBus.Persistence.Sql.MsBuild.targets
+++ b/packaging/nuget/NServiceBus.Persistence.Sql.MsBuild.targets
@@ -1,8 +1,8 @@
 ﻿<Project>
 	<PropertyGroup>
-		<ScriptDirectory>
+		<SqlPersistenceScriptDirectory>
 			$(ProjectDir)$(IntermediateOutputPath)NServiceBus.Persistence.Sql\
-		</ScriptDirectory>
+		</SqlPersistenceScriptDirectory>
 	</PropertyGroup>
 	<UsingTask TaskName="NServiceBus.Persistence.Sql.SqlPersistenceScriptBuilderTask" AssemblyFile="$(MSBuildThisFileDirectory)..\NServiceBus.Persistence.Sql.ScriptBuilderTask.dll" />
 	<Target Name="SqlPersistenceScriptBuilder" AfterTargets="AfterCompile" Condition="('$(UsingMicrosoftNETSdk)' == 'true' AND '$(DesignTimeBuild)' != 'true') OR ('$(UsingMicrosoftNETSdk)' != 'true' AND '$(BuildingProject)' == 'true')">
@@ -10,7 +10,7 @@
 	</Target>
 	<Target Name="AddSqlPersistenceScriptsToGetCopyToOutputDirectoryItems" BeforeTargets="GetCopyToOutputDirectoryItems" Condition="('$(UsingMicrosoftNETSdk)' == 'true' AND '$(DesignTimeBuild)' != 'true') OR ('$(UsingMicrosoftNETSdk)' != 'true' AND '$(BuildingProject)' == 'true')">
 		<ItemGroup>
-			<SqlPersistenceScripts Include="$(ScriptDirectory)**\*.sql" />
+			<SqlPersistenceScripts Include="$(SqlPersistenceScriptDirectory)**\*.sql" />
 		</ItemGroup>
 		<!-- <Message Text="SqlScripts: @(Scripts)"/> -->
 		<CreateItem Include="@(SqlPersistenceScripts)" AdditionalMetadata="CopyToOutputDirectory=PreserveNewest;TargetPath=NServiceBus.Persistence.Sql\%(RecursiveDir)%(Filename)%(Extension)">

--- a/packaging/nuget/NServiceBus.Persistence.Sql.MsBuild.targets
+++ b/packaging/nuget/NServiceBus.Persistence.Sql.MsBuild.targets
@@ -4,11 +4,21 @@
 			$(ProjectDir)$(IntermediateOutputPath)NServiceBus.Persistence.Sql\
 		</SqlPersistenceScriptDirectory>
 	</PropertyGroup>
-	<UsingTask TaskName="NServiceBus.Persistence.Sql.SqlPersistenceScriptBuilderTask" AssemblyFile="$(MSBuildThisFileDirectory)..\NServiceBus.Persistence.Sql.ScriptBuilderTask.dll" />
-	<Target Name="SqlPersistenceScriptBuilder" AfterTargets="AfterCompile" Condition="('$(UsingMicrosoftNETSdk)' == 'true' AND '$(DesignTimeBuild)' != 'true') OR ('$(UsingMicrosoftNETSdk)' != 'true' AND '$(BuildingProject)' == 'true')">
-		<SqlPersistenceScriptBuilderTask AssemblyPath="$(ProjectDir)@(IntermediateAssembly)" IntermediateDirectory="$(ProjectDir)$(IntermediateOutputPath)" />
+	<UsingTask 
+      TaskName="NServiceBus.Persistence.Sql.SqlPersistenceScriptBuilderTask" 
+      AssemblyFile="$(MSBuildThisFileDirectory)..\NServiceBus.Persistence.Sql.ScriptBuilderTask.dll" />
+	<Target 
+      Name="SqlPersistenceScriptBuilder" 
+      AfterTargets="AfterCompile" 
+      Condition="('$(UsingMicrosoftNETSdk)' == 'true' AND '$(DesignTimeBuild)' != 'true') OR ('$(UsingMicrosoftNETSdk)' != 'true' AND '$(BuildingProject)' == 'true')">
+		<SqlPersistenceScriptBuilderTask 
+      AssemblyPath="$(ProjectDir)@(IntermediateAssembly)" 
+      IntermediateDirectory="$(ProjectDir)$(IntermediateOutputPath)" />
 	</Target>
-	<Target Name="AddSqlPersistenceScriptsToGetCopyToOutputDirectoryItems" BeforeTargets="GetCopyToOutputDirectoryItems" Condition="('$(UsingMicrosoftNETSdk)' == 'true' AND '$(DesignTimeBuild)' != 'true') OR ('$(UsingMicrosoftNETSdk)' != 'true' AND '$(BuildingProject)' == 'true')">
+	<Target 
+      Name="AddSqlPersistenceScriptsToGetCopyToOutputDirectoryItems" 
+      BeforeTargets="GetCopyToOutputDirectoryItems" 
+      Condition="('$(UsingMicrosoftNETSdk)' == 'true' AND '$(DesignTimeBuild)' != 'true') OR ('$(UsingMicrosoftNETSdk)' != 'true' AND '$(BuildingProject)' == 'true')">
 		<ItemGroup>
 			<SqlPersistenceScripts Include="$(SqlPersistenceScriptDirectory)**\*.sql" />
 		</ItemGroup>


### PR DESCRIPTION
- Added conditions for targets to disable running scripts during design-time builds
- Renamed "ScriptDirectory" to "SqlPersistenceScriptDirectory"
- Renamed "Scripts" to "SqlPersistenceScripts"
- Renamed "AddScriptsToGetCopyToOutputDirectoryItems" to "AddSqlPersistenceScriptsToGetCopyToOutputDirectoryItems"