### PR TITLE
Script generation targets file is missing an XML namespace causing VisualStudio 2015 build to fail

### DIFF
--- a/packaging/nuget/NServiceBus.Persistence.Sql.MsBuild.targets
+++ b/packaging/nuget/NServiceBus.Persistence.Sql.MsBuild.targets
@@ -1,4 +1,4 @@
-﻿<Project>
+﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
     <SqlPersistenceScriptBuilderTaskPath Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\netstandard\NServiceBus.Persistence.Sql.ScriptBuilderTask.dll</SqlPersistenceScriptBuilderTaskPath>


### PR DESCRIPTION
This is a hotfix PR. Do not merge in github

This is a 2.2.x fix for issue https://github.com/Particular/NServiceBus.Persistence.Sql/issues/239