### PR TITLE
Remove conditional dependency on SqlClient

### DIFF
--- a/src/SqlPersistence/SqlPersistence.csproj
+++ b/src/SqlPersistence/SqlPersistence.csproj
@@ -15,10 +15,7 @@
     <PackageReference Include="Fody" Version="2.1.2" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="4.3.2" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="0.1.0" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.4.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TestHelper/TestHelper.csproj
+++ b/src/TestHelper/TestHelper.csproj
@@ -8,15 +8,12 @@
 
   <ItemGroup>
     <PackageReference Include="Npgsql " Version="3.*" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.*" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
     <PackageReference Include="Oracle.ManagedDataAccess" Version="12.*" />
     <PackageReference Include="MySql.Data" Version="6.*" ExcludeAssets="contentFiles" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
-    <PackageReference Include="System.Data.SqlClient" Version="4.*" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This prevents the conditional dependency from causing a problem if the transport package is used from a .NET Standard library.

This also bumps to latest patch version.