### PR TITLE
Re-subscribe fails after updating from NSB5 to NSB6

### DIFF
--- a/src/SqlPersistence.Tests/Subscription/SubscriptionPersisterTests.Subscribe_version_migration.approved.txt
+++ b/src/SqlPersistence.Tests/Subscription/SubscriptionPersisterTests.Subscribe_version_migration.approved.txt
@@ -1,0 +1,6 @@
+﻿[
+  {
+    "TransportAddress": "e@machine1",
+    "Endpoint": "endpoint"
+  }
+]

--- a/src/SqlPersistence.Tests/Subscription/SubscriptionPersisterTests.cs
+++ b/src/SqlPersistence.Tests/Subscription/SubscriptionPersisterTests.cs
@@ -224,6 +224,22 @@ public abstract class SubscriptionPersisterTests
     }
 
     [Test]
+    public void Subscribe_version_migration()
+    {
+        var persister = Setup(schema);
+        var type1 = new MessageType("type1", new Version(0, 0, 0, 0));
+        //NSB 5.x: endpoint is null
+        persister.Subscribe(new Subscriber("e@machine1", null), type1, null).Await();
+        //NSB 6.x: same subscriber now mentions endpoint
+        persister.Subscribe(new Subscriber("e@machine1", "endpoint"), type1, null).Await();
+        var result = persister.GetSubscribers(type1).Result.ToList();
+        Assert.IsNotEmpty(result);
+#if NET452
+        ObjectApprover.VerifyWithJson(result);
+#endif
+    }
+
+    [Test]
     public void Unsubscribe()
     {
         var persister = Setup(schema);


### PR DESCRIPTION
Used persistence: MSSQL
Exception: [exception_stacktrace.txt](https://github.com/Particular/NServiceBus.Persistence.Sql/files/1785594/exception_stacktrace.txt)

## NSB5 flow
1. NSB5 subscribes without a `SubscriberEndpoint` in the subscription message payload
1. The [SubscriptionReceiverBehavior](https://github.com/Particular/NServiceBus/blob/4c22bb6a2126a498c0e8979e43bb27c58d775c47/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/SubscriptionReceiverBehavior.cs#L45) creates a Subscriber with endpoint null
1. The Persister inserts this in DB
1. All is well

## After upgrading subscriber to NSB6
1. Subscription message contains `SubscriberEndpoint` 
1. The [SubscriptionReceiverBehavior](https://github.com/Particular/NServiceBus/blob/4c22bb6a2126a498c0e8979e43bb27c58d775c47/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/SubscriptionReceiverBehavior.cs#L45) creates a Subscriber with the endpoint set
1. The Persister tries to insert this in DB with a T-SQL merge statement containing the following: `and ((target.Endpoint = source.Endpoint) or (target.Endpoint is null and source.endpoint is null))`
1. Target is not null, source is currently null however => [`when not matched`](https://github.com/Particular/NServiceBus.Persistence.Sql/blob/daaf101c828bb9484bb04b903d96dd00ee31ad48/src/SqlPersistence/Subscription/SqlDialect_MsSqlServer.cs#L25) clause is triggered resulting in an insert
1. Clustered index only takes into account [`Subscriber` and `MessageType`](https://github.com/Particular/NServiceBus.Persistence.Sql/blob/daaf101c828bb9484bb04b903d96dd00ee31ad48/src/ScriptBuilder/Subscription/Create_MsSqlServer.sql#L22)
1. Result: Violation of PRIMARY KEY constraint
