### PR TITLE
Update targets file to include scripts in publish output

### DIFF
--- a/src/ScriptBuilder.Tests/CecilExtensions/CustomAttributeMock.cs
+++ b/src/ScriptBuilder.Tests/CecilExtensions/CustomAttributeMock.cs
@@ -38,4 +38,8 @@ public class CustomAttributeMock : ICustomAttribute
     {
         get;
     }
+
+    public bool HasConstructorArguments => throw new NotImplementedException();
+
+    public Collection<CustomAttributeArgument> ConstructorArguments => throw new NotImplementedException();
 }

--- a/src/ScriptBuilder/ScriptBuilder.csproj
+++ b/src/ScriptBuilder/ScriptBuilder.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Cecil" Version="0.10.0-*" />
+    <PackageReference Include="Mono.Cecil" Version="0.10.0" />
     <PackageReference Include="Particular.Packaging" Version="0.1.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/ScriptBuilderTask/NServiceBus.Persistence.Sql.MsBuild.targets
+++ b/src/ScriptBuilderTask/NServiceBus.Persistence.Sql.MsBuild.targets
@@ -34,15 +34,33 @@
       <SqlPersistenceScripts Include="$(SqlPersistenceScriptDirectory)**\*.sql" />
     </ItemGroup>
 
-    <CreateItem Include="@(SqlPersistenceScripts)"
-                AdditionalMetadata="CopyToOutputDirectory=PreserveNewest;TargetPath=NServiceBus.Persistence.Sql\%(RecursiveDir)%(Filename)%(Extension)">
-      <Output TaskParameter="Include" ItemName="_SourceItemsToCopyToOutputDirectoryAlways" />
-    </CreateItem>
+    <ItemGroup>
+      <_SourceItemsToCopyToOutputDirectoryAlways Include="@(SqlPersistenceScripts)">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        <TargetPath>NServiceBus.Persistence.Sql\%(RecursiveDir)%(Filename)%(Extension)</TargetPath>
+      </_SourceItemsToCopyToOutputDirectoryAlways>
+    </ItemGroup>
 
-    <CreateItem Include="@(SqlPersistenceScripts)"
-                AdditionalMetadata="CopyToOutputDirectory=PreserveNewest;TargetPath=NServiceBus.Persistence.Sql\%(RecursiveDir)%(Filename)%(Extension)">
-      <Output TaskParameter="Include" ItemName="AllItemsFullPathWithTargetPath" />
-    </CreateItem>
+  </Target>
+
+  <Target Name="AddSqlPersistenceScriptsToGetCopyToPublishDirectoryItems"
+          BeforeTargets="GetCopyToPublishDirectoryItems"
+          Condition="('$(UsingMicrosoftNETSdk)' == 'true' AND '$(DesignTimeBuild)' != 'true') OR ('$(UsingMicrosoftNETSdk)' != 'true' AND '$(BuildingProject)' == 'true')">
+
+    <PropertyGroup>
+      <SqlPersistenceScriptDirectory>$(ProjectDir)$(IntermediateOutputPath)NServiceBus.Persistence.Sql\</SqlPersistenceScriptDirectory>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <SqlPersistenceScriptsForPublish Include="$(SqlPersistenceScriptDirectory)**\*.sql" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <_SourceItemsToCopyToPublishDirectoryAlways Include="@(SqlPersistenceScriptsForPublish)">
+        <CopyToPublishDirectory>Always</CopyToPublishDirectory>
+        <TargetPath>NServiceBus.Persistence.Sql\%(RecursiveDir)%(Filename)%(Extension)</TargetPath>
+      </_SourceItemsToCopyToPublishDirectoryAlways>
+    </ItemGroup>
 
   </Target>
 


### PR DESCRIPTION
This change updates the ScriptBuilder MSBuild targets to ensure that the scripts are copied to the publish output when publishing an SDK-style project from VS 2017 or from the commandline via `dotnet publish`.