### PR TITLE
Add test from SQL Server transport

### DIFF
--- a/src/SqlPersistence.Tests/Integration/When_using_transaction_scope.cs
+++ b/src/SqlPersistence.Tests/Integration/When_using_transaction_scope.cs
@@ -1,0 +1,165 @@
+﻿using System;
+using System.Threading.Tasks;
+using System.Transactions;
+using NServiceBus;
+using NServiceBus.Persistence.Sql;
+using NServiceBus.Pipeline;
+using NServiceBus.Transport.SQLServer;
+using NUnit.Framework;
+
+public class When_using_transaction_scope
+{
+    [SetUp]
+    public void SetUp()
+    {
+        var configuration = new EndpointConfiguration("SQL_Integration_Endpoint");
+        configuration.SendFailedMessagesTo("error");
+        configuration.PurgeOnStartup(true);
+        configuration.LimitMessageProcessingConcurrencyTo(1);
+        configuration.EnableInstallers();
+        configuration.MakeInstanceUniquelyAddressable("1");
+
+        configuration.UseTransport<SqlServerTransport>()
+            .Transactions(TransportTransactionMode.TransactionScope)
+            .UseCustomSqlConnectionFactory(async () =>
+            {
+                var connection = MsSqlConnectionBuilder.Build();
+                await connection.OpenAsync().ConfigureAwait(false);
+                return connection;
+            });
+
+        var persistence = configuration.UsePersistence<SqlPersistence>();
+        persistence.ConnectionBuilder(MsSqlConnectionBuilder.Build);
+        persistence.SubscriptionSettings().DisableCache();
+        persistence.SqlDialect<SqlDialect.MsSqlServer>();
+
+        context = new Context();
+
+        configuration.RegisterComponents(c => c.ConfigureComponent(() => context, DependencyLifecycle.SingleInstance));
+
+        configuration.Pipeline.Register<BehaviorThatThrowsAfterFirstMessage.Registration>();
+        //Hack to include these messages in the scanning despite the fact that the assembly is signed with Particular key.
+        configuration.Conventions().Conventions.AddSystemMessagesConventions(t => t == typeof(SagaMessage) || t == typeof(ReplyMessage));
+
+        endpoint = Endpoint.Start(configuration).GetAwaiter().GetResult();
+    }
+
+    [Test]
+    public async Task Transaction_shared_with_sql_persistence_should_not_escalate_to_dtc()
+    {
+        var options = new SendOptions();
+        options.SetMessageId(context.Id.ToString());
+        options.RouteToThisInstance();
+
+        await endpoint.Send(new SagaMessage
+        {
+            Id = context.Id
+        }, options);
+
+        await Task.WhenAny(Task.Delay(TimeSpan.FromSeconds(20)), context.CompletionSource.Task);
+
+        Assert.IsFalse(context.TransactionEscalatedToDTC, "Transaction should not be escalated to DTC");
+
+        Assert.AreEqual(2, context.SagaHandlerInvocationNumber, "Saga handler should be called twice");
+        Assert.AreEqual(1, context.SagaCounterValue, "Saga value should be incremented only once");
+    }
+
+    IEndpointInstance endpoint;
+    Context context;
+
+    public class Context
+    {
+        public int SagaCounterValue { get; set; }
+
+        public int SagaHandlerInvocationNumber { get; set; }
+
+        public bool TransactionEscalatedToDTC { get; set; }
+        public readonly Guid Id = Guid.NewGuid();
+
+        public TaskCompletionSource<int> CompletionSource = new TaskCompletionSource<int>();
+    }
+
+    public class TestSaga : SqlSaga<TestSaga.SagaData>, IAmStartedByMessages<SagaMessage>
+    {
+        public Context TestContext { get; set; }
+
+        public async Task Handle(SagaMessage message, IMessageHandlerContext context)
+        {
+            Data.SomeId = message.Id;
+
+            if (message.Id == TestContext.Id)
+            {
+                Data.Counter += 1;
+
+                TestContext.SagaCounterValue = Data.Counter;
+                TestContext.SagaHandlerInvocationNumber++;
+
+                await context.SendLocal(new ReplyMessage
+                {
+                    Id = message.Id
+                });
+            }
+        }
+
+        protected override void ConfigureMapping(IMessagePropertyMapper mapper)
+        {
+            mapper.ConfigureMapping<SagaMessage>(m => m.Id);
+        }
+
+        protected override string CorrelationPropertyName => "SomeId";
+        public class SagaData : ContainSagaData
+        {
+            public virtual Guid SomeId { get; set; }
+            public virtual int Counter { get; set; }
+        }
+    }
+
+    class BehaviorThatThrowsAfterFirstMessage : Behavior<ITransportReceiveContext>
+    {
+        public Context TestContext { get; set; }
+
+        public override async Task Invoke(ITransportReceiveContext context, Func<Task> next)
+        {
+            await next();
+
+            if (context.Message.MessageId == TestContext.Id.ToString() && TestContext.SagaHandlerInvocationNumber == 1)
+            {
+                TestContext.TransactionEscalatedToDTC = Transaction.Current.TransactionInformation.DistributedIdentifier != Guid.Empty;
+
+                throw new Exception("Simulated exception after saga processing is done");
+            }
+        }
+
+        public class Registration : RegisterStep
+        {
+            public Registration() : base("BehaviorThatThrowsAfterFirstMessage", typeof(BehaviorThatThrowsAfterFirstMessage), "BehaviorThatThrowsAfterFirstMessage")
+            {
+            }
+        }
+    }
+
+    public class Handler : IHandleMessages<ReplyMessage>
+    {
+        public Context TestContext { get; set; }
+
+        public Task Handle(ReplyMessage message, IMessageHandlerContext context)
+        {
+            if (TestContext.Id == message.Id)
+            {
+                TestContext.CompletionSource.SetResult(0);
+            }
+
+            return Task.FromResult(0);
+        }
+    }
+
+    public class SagaMessage : IMessage
+    {
+        public Guid Id { get; set; }
+    }
+
+    public class ReplyMessage : IMessage
+    {
+        public Guid Id { get; set; }
+    }
+}


### PR DESCRIPTION
This adds the test removed in https://github.com/Particular/NServiceBus.SqlServer/pull/440.

Looking at what this test is doing, is this scenario already covered by the other tests in the integration folder? If so, then I guess we don't need to add this one.