### PR TITLE
Use pessimistic locking when loading sagas to prevent lock contention on congested sagas

### DIFF
--- a/src/SqlPersistence.Tests/APIApprovals.Approve.approved.txt
+++ b/src/SqlPersistence.Tests/APIApprovals.Approve.approved.txt
@@ -133,7 +133,7 @@ namespace NServiceBus
         [System.ObsoleteAttribute("Not for public use")]
         public abstract string BuildSaveCommand(string correlationProperty, string transitionalCorrelationProperty, string tableName);
         [System.ObsoleteAttribute("Not for public use")]
-        public abstract string BuildSelectFromCommand(string tableName);
+        public abstract System.Func<string, string> BuildSelectFromCommand(string tableName);
         [System.ObsoleteAttribute("Not for public use")]
         public abstract string BuildUpdateCommand(string transitionalCorrelationProperty, string tableName);
         [System.ObsoleteAttribute("Not for public use")]
@@ -146,7 +146,7 @@ namespace NServiceBus
             public override string BuildGetByPropertyCommand(string propertyName, string tableName) { }
             public override string BuildGetBySagaIdCommand(string tableName) { }
             public override string BuildSaveCommand(string correlationProperty, string transitionalCorrelationProperty, string tableName) { }
-            public override string BuildSelectFromCommand(string tableName) { }
+            public override System.Func<string, string> BuildSelectFromCommand(string tableName) { }
             public override string BuildUpdateCommand(string transitionalCorrelationProperty, string tableName) { }
             public override string GetSagaTableName(string tablePrefix, string tableSuffix) { }
         }
@@ -157,7 +157,7 @@ namespace NServiceBus
             public override string BuildGetByPropertyCommand(string propertyName, string tableName) { }
             public override string BuildGetBySagaIdCommand(string tableName) { }
             public override string BuildSaveCommand(string correlationProperty, string transitionalCorrelationProperty, string tableName) { }
-            public override string BuildSelectFromCommand(string tableName) { }
+            public override System.Func<string, string> BuildSelectFromCommand(string tableName) { }
             public override string BuildUpdateCommand(string transitionalCorrelationProperty, string tableName) { }
             public override string GetSagaTableName(string tablePrefix, string tableSuffix) { }
         }
@@ -168,7 +168,7 @@ namespace NServiceBus
             public override string BuildGetByPropertyCommand(string propertyName, string tableName) { }
             public override string BuildGetBySagaIdCommand(string tableName) { }
             public override string BuildSaveCommand(string correlationProperty, string transitionalCorrelationProperty, string tableName) { }
-            public override string BuildSelectFromCommand(string tableName) { }
+            public override System.Func<string, string> BuildSelectFromCommand(string tableName) { }
             public override string BuildUpdateCommand(string transitionalCorrelationProperty, string tableName) { }
             public override string GetSagaTableName(string tablePrefix, string tableSuffix) { }
         }
@@ -179,7 +179,7 @@ namespace NServiceBus
             public override string BuildGetByPropertyCommand(string propertyName, string tableName) { }
             public override string BuildGetBySagaIdCommand(string tableName) { }
             public override string BuildSaveCommand(string correlationProperty, string transitionalCorrelationProperty, string tableName) { }
-            public override string BuildSelectFromCommand(string tableName) { }
+            public override System.Func<string, string> BuildSelectFromCommand(string tableName) { }
             public override string BuildUpdateCommand(string transitionalCorrelationProperty, string tableName) { }
             public override string GetSagaTableName(string tablePrefix, string tableSuffix) { }
         }

--- a/src/SqlPersistence.Tests/Saga/CommandTests/SagaCommandTests.GetByProperty.MsSql.approved.txt
+++ b/src/SqlPersistence.Tests/Saga/CommandTests/SagaCommandTests.GetByProperty.MsSql.approved.txt
@@ -6,4 +6,5 @@ select
     Metadata,
     Data
 from TheTableName
+with (updlock)
 where Correlation_ThePropertyName = @propertyValue

--- a/src/SqlPersistence.Tests/Saga/CommandTests/SagaCommandTests.GetByProperty.MySql.approved.txt
+++ b/src/SqlPersistence.Tests/Saga/CommandTests/SagaCommandTests.GetByProperty.MySql.approved.txt
@@ -7,3 +7,4 @@ select
     Data
 from TheTableName
 where Correlation_ThePropertyName = @propertyValue
+for update

--- a/src/SqlPersistence.Tests/Saga/CommandTests/SagaCommandTests.GetByProperty.Oracle.approved.txt
+++ b/src/SqlPersistence.Tests/Saga/CommandTests/SagaCommandTests.GetByProperty.Oracle.approved.txt
@@ -7,3 +7,4 @@ select
     Data
 from TheTableName
 where CORR_THEPROPERTYNAME = :propertyValue
+for update

--- a/src/SqlPersistence.Tests/Saga/CommandTests/SagaCommandTests.GetByProperty.PostgreSql.approved.txt
+++ b/src/SqlPersistence.Tests/Saga/CommandTests/SagaCommandTests.GetByProperty.PostgreSql.approved.txt
@@ -7,3 +7,4 @@ select
     "Data"
 from TheTableName
 where "Correlation_ThePropertyName" = @propertyValue
+for update

--- a/src/SqlPersistence.Tests/Saga/CommandTests/SagaCommandTests.GetBySagaId.MsSql.approved.txt
+++ b/src/SqlPersistence.Tests/Saga/CommandTests/SagaCommandTests.GetBySagaId.MsSql.approved.txt
@@ -6,4 +6,5 @@ select
     Metadata,
     Data
 from TheTableName
+with (updlock)
 where Id = @Id

--- a/src/SqlPersistence.Tests/Saga/CommandTests/SagaCommandTests.GetBySagaId.MySql.approved.txt
+++ b/src/SqlPersistence.Tests/Saga/CommandTests/SagaCommandTests.GetBySagaId.MySql.approved.txt
@@ -7,3 +7,4 @@ select
     Data
 from TheTableName
 where Id = @Id
+for update

--- a/src/SqlPersistence.Tests/Saga/CommandTests/SagaCommandTests.GetBySagaId.Oracle.approved.txt
+++ b/src/SqlPersistence.Tests/Saga/CommandTests/SagaCommandTests.GetBySagaId.Oracle.approved.txt
@@ -7,3 +7,4 @@ select
     Data
 from TheTableName
 where Id = :Id
+for update

--- a/src/SqlPersistence.Tests/Saga/CommandTests/SagaCommandTests.GetBySagaId.PostgreSql.approved.txt
+++ b/src/SqlPersistence.Tests/Saga/CommandTests/SagaCommandTests.GetBySagaId.PostgreSql.approved.txt
@@ -7,3 +7,4 @@ select
     "Data"
 from TheTableName
 where "Id" = @Id
+for update

--- a/src/SqlPersistence.Tests/Saga/CommandTests/SagaCommandTests.SelectFrom.MsSql.approved.txt
+++ b/src/SqlPersistence.Tests/Saga/CommandTests/SagaCommandTests.SelectFrom.MsSql.approved.txt
@@ -6,3 +6,5 @@ select
     Metadata,
     Data
 from TheTableName
+with (updlock)
+where 1 = 1

--- a/src/SqlPersistence.Tests/Saga/CommandTests/SagaCommandTests.SelectFrom.MySql.approved.txt
+++ b/src/SqlPersistence.Tests/Saga/CommandTests/SagaCommandTests.SelectFrom.MySql.approved.txt
@@ -6,3 +6,5 @@ select
     Metadata,
     Data
 from TheTableName
+where 1 = 1
+for update

--- a/src/SqlPersistence.Tests/Saga/CommandTests/SagaCommandTests.SelectFrom.Oracle.approved.txt
+++ b/src/SqlPersistence.Tests/Saga/CommandTests/SagaCommandTests.SelectFrom.Oracle.approved.txt
@@ -6,3 +6,5 @@ select
     Metadata,
     Data
 from TheTableName
+where 1 = 1
+for update

--- a/src/SqlPersistence.Tests/Saga/CommandTests/SagaCommandTests.SelectFrom.PostgreSql.approved.txt
+++ b/src/SqlPersistence.Tests/Saga/CommandTests/SagaCommandTests.SelectFrom.PostgreSql.approved.txt
@@ -6,3 +6,5 @@ select
     "Metadata",
     "Data"
 from TheTableName
+where 1 = 1
+for update

--- a/src/SqlPersistence.Tests/Saga/CommandTests/SagaCommandTests.cs
+++ b/src/SqlPersistence.Tests/Saga/CommandTests/SagaCommandTests.cs
@@ -55,7 +55,7 @@ public abstract class SagaCommandTests
     {
         using (NamerFactory.AsEnvironmentSpecificTest(() => GetType().Name))
         {
-            Approvals.Verify(sqlDialect.BuildSelectFromCommand("TheTableName"));
+            Approvals.Verify(sqlDialect.BuildSelectFromCommand("TheTableName")("1 = 1"));
         }
     }
 

--- a/src/SqlPersistence/Saga/RuntimeSagaInfo.cs
+++ b/src/SqlPersistence/Saga/RuntimeSagaInfo.cs
@@ -21,7 +21,7 @@ class RuntimeSagaInfo
     ConcurrentDictionary<Version, JsonSerializer> deserializers;
     public readonly Version CurrentVersion;
     public readonly string CompleteCommand;
-    public readonly string SelectFromCommand;
+    public readonly Func<string, string> SelectFromCommandBuilder;
     public readonly string GetBySagaIdCommand;
     public readonly string SaveCommand;
     public readonly string UpdateCommand;
@@ -63,7 +63,7 @@ class RuntimeSagaInfo
         TableName = sqlDialect.GetSagaTableName(tablePrefix, tableSuffix);
 
         CompleteCommand = sqlDialect.BuildCompleteCommand(TableName);
-        SelectFromCommand = sqlDialect.BuildSelectFromCommand(TableName);
+        SelectFromCommandBuilder = sqlDialect.BuildSelectFromCommand(TableName);
         GetBySagaIdCommand = sqlDialect.BuildGetBySagaIdCommand(TableName);
         SaveCommand = sqlDialect.BuildSaveCommand(sqlSagaAttributeData.CorrelationProperty, sqlSagaAttributeData.TransitionalCorrelationProperty, TableName);
         UpdateCommand = sqlDialect.BuildUpdateCommand(sqlSagaAttributeData.TransitionalCorrelationProperty, TableName);

--- a/src/SqlPersistence/Saga/SagaPersister_Get.cs
+++ b/src/SqlPersistence/Saga/SagaPersister_Get.cs
@@ -20,9 +20,7 @@ partial class SagaPersister
         where TSagaData : class, IContainSagaData
     {
         var sagaInfo = sagaInfoCache.GetInfo(typeof(TSagaData));
-        var commandText = $@"
-{sagaInfo.SelectFromCommand}
-where {whereClause}";
+        var commandText = sagaInfo.SelectFromCommandBuilder(whereClause);
         return GetSagaData<TSagaData>(session, commandText, sagaInfo, appendParameters);
     }
 

--- a/src/SqlPersistence/Saga/SqlDialect.cs
+++ b/src/SqlPersistence/Saga/SqlDialect.cs
@@ -8,7 +8,7 @@ namespace NServiceBus
         [Obsolete("Not for public use")]
         public abstract string GetSagaTableName(string tablePrefix, string tableSuffix);
         [Obsolete("Not for public use")]
-        public abstract string BuildSelectFromCommand(string tableName);
+        public abstract Func<string, string> BuildSelectFromCommand(string tableName);
         [Obsolete("Not for public use")]
         public abstract string BuildCompleteCommand(string tableName);
         [Obsolete("Not for public use")]

--- a/src/SqlPersistence/Saga/SqlDialect_MsSqlServer.cs
+++ b/src/SqlPersistence/Saga/SqlDialect_MsSqlServer.cs
@@ -88,6 +88,7 @@ select
     Metadata,
     Data
 from {tableName}
+with (updlock)
 where Id = @Id
 ";
             }
@@ -102,6 +103,7 @@ select
     Metadata,
     Data
 from {tableName}
+with (updlock)
 where Correlation_{propertyName} = @propertyValue
 ";
             }
@@ -124,6 +126,7 @@ select
     Metadata,
     Data
 from {tableName}
+with (updlock)
 ";
             }
         }

--- a/src/SqlPersistence/Saga/SqlDialect_MsSqlServer.cs
+++ b/src/SqlPersistence/Saga/SqlDialect_MsSqlServer.cs
@@ -2,6 +2,7 @@
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 namespace NServiceBus
 {
+    using System;
     using System.Text;
 
     public partial class SqlDialect
@@ -116,9 +117,9 @@ where Id = @Id and Concurrency = @Concurrency
 ";
             }
 
-            public override string BuildSelectFromCommand(string tableName)
+            public override Func<string, string> BuildSelectFromCommand(string tableName)
             {
-                return $@"
+                return whereClause => $@"
 select
     Id,
     SagaTypeVersion,
@@ -127,6 +128,7 @@ select
     Data
 from {tableName}
 with (updlock)
+where {whereClause}
 ";
             }
         }

--- a/src/SqlPersistence/Saga/SqlDialect_MySql.cs
+++ b/src/SqlPersistence/Saga/SqlDialect_MySql.cs
@@ -2,6 +2,7 @@
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 namespace NServiceBus
 {
+    using System;
     using System.Text;
 
     public partial class SqlDialect
@@ -82,6 +83,7 @@ select
     Data
 from {tableName}
 where Id = @Id
+for update
 ";
             }
 
@@ -96,6 +98,7 @@ select
     Data
 from {tableName}
 where Correlation_{propertyName} = @propertyValue
+for update
 ";
             }
 
@@ -107,9 +110,9 @@ where Id = @Id and Concurrency = @Concurrency
 ";
             }
 
-            public override string BuildSelectFromCommand(string tableName)
+            public override Func<string, string> BuildSelectFromCommand(string tableName)
             {
-                return $@"
+                return whereClause => $@"
 select
     Id,
     SagaTypeVersion,
@@ -117,6 +120,8 @@ select
     Metadata,
     Data
 from {tableName}
+where {whereClause}
+for update
 ";
             }
         }

--- a/src/SqlPersistence/Saga/SqlDialect_Oracle.cs
+++ b/src/SqlPersistence/Saga/SqlDialect_Oracle.cs
@@ -91,6 +91,7 @@ select
     Data
 from {tableName}
 where Id = :Id
+for update
 ";
             }
 
@@ -105,6 +106,7 @@ select
     Data
 from {tableName}
 where {CorrelationPropertyName(propertyName)} = :propertyValue
+for update
 ";
             }
 
@@ -116,9 +118,9 @@ where Id = :Id and Concurrency = :Concurrency
 ";
             }
 
-            public override string BuildSelectFromCommand(string tableName)
+            public override Func<string, string> BuildSelectFromCommand(string tableName)
             {
-                return $@"
+                return whereClause => $@"
 select
     Id,
     SagaTypeVersion,
@@ -126,6 +128,8 @@ select
     Metadata,
     Data
 from {tableName}
+where {whereClause}
+for update
 ";
             }
 

--- a/src/SqlPersistence/Saga/SqlDialect_PostgreSql.cs
+++ b/src/SqlPersistence/Saga/SqlDialect_PostgreSql.cs
@@ -2,6 +2,7 @@
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 namespace NServiceBus
 {
+    using System;
     using System.Text;
     using Logging;
     using Newtonsoft.Json;
@@ -109,6 +110,7 @@ select
     ""Data""
 from {tableName}
 where ""Id"" = @Id
+for update
 ";
             }
 
@@ -123,6 +125,7 @@ select
     ""Data""
 from {tableName}
 where ""Correlation_{propertyName}"" = @propertyValue
+for update
 ";
             }
 
@@ -134,9 +137,9 @@ where ""Id"" = @Id and ""Concurrency"" = @Concurrency
 ";
             }
 
-            public override string BuildSelectFromCommand(string tableName)
+            public override Func<string, string> BuildSelectFromCommand(string tableName)
             {
-                return $@"
+                return whereClause => $@"
 select
     ""Id"",
     ""SagaTypeVersion"",
@@ -144,6 +147,8 @@ select
     ""Metadata"",
     ""Data""
 from {tableName}
+where {whereClause}
+for update
 ";
             }
         }


### PR DESCRIPTION
 * Adds `for update` or equivalent clause to all three saga loading SQLs: by ID, by property and by finder
 * Slightly changes the API of a dialect to allow adding the `for update` at the end of the statement