### PR TITLE
Test MySQL with MySQL.Data 8.x on .NET Core

### DIFF
--- a/src/MySqlAcceptanceTests/MySqlAcceptanceTests.csproj
+++ b/src/MySqlAcceptanceTests/MySqlAcceptanceTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)Test.snk</AssemblyOriginatorKeyFile>
     <DefineConstants>$(DefineConstants);MySQL</DefineConstants>

--- a/src/SqlPersistence.Tests/SqlPersistence.Tests.csproj
+++ b/src/SqlPersistence.Tests/SqlPersistence.Tests.csproj
@@ -27,13 +27,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
-    <Compile Remove="Saga\MySqlSagaPersisterTests.cs" />
-    <Compile Remove="Outbox\MySqlOutboxPersisterTests.cs" />
-    <Compile Remove="Timeout\MySqlServerTimeoutPersisterTests.cs" />
-    <Compile Remove="Subscription\MySqlServerSubscriptionPersisterTests.cs" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
     <Compile Remove="Saga\OracleSagaPersisterTests.cs" />
     <Compile Remove="Outbox\OracleOutboxPersisterTests.cs" />
     <Compile Remove="Timeout\OracleTimeoutPersisterTests.cs" />

--- a/src/SqlPersistence.Tests/SynchronizedStorage/MySqlAdaptTransportConnectionTests.cs
+++ b/src/SqlPersistence.Tests/SynchronizedStorage/MySqlAdaptTransportConnectionTests.cs
@@ -1,4 +1,3 @@
-#if NET452
 using System;
 using System.Data.Common;
 using NServiceBus.Persistence.Sql.ScriptBuilder;
@@ -21,4 +20,3 @@ class MySqlAdaptTransportConnectionTests : AdaptTransportConnectionTests
         };
     }
 }
-#endif

--- a/src/TestHelper/MySqlConnectionBuilder.cs
+++ b/src/TestHelper/MySqlConnectionBuilder.cs
@@ -1,4 +1,3 @@
-#if NET452
 using System;
 using MySql.Data.MySqlClient;
 
@@ -14,4 +13,3 @@ public static class MySqlConnectionBuilder
         return new MySqlConnection(connection);
     }
 }
-#endif

--- a/src/TestHelper/TestHelper.csproj
+++ b/src/TestHelper/TestHelper.csproj
@@ -8,12 +8,12 @@
 
   <ItemGroup>
     <PackageReference Include="Npgsql " Version="3.*" />
+    <PackageReference Include="MySql.Data" Version="8.*" ExcludeAssets="contentFiles" />
     <PackageReference Include="System.Data.SqlClient" Version="4.*" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
     <PackageReference Include="Oracle.ManagedDataAccess" Version="12.*" />
-    <PackageReference Include="MySql.Data" Version="6.*" ExcludeAssets="contentFiles" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Although there's a reporting problem on TeamCity, it looks like MySQL.Data 8.x on .NET Core works just fine. This PR adds it to master. While we could release a 4.0.1 instead of a 4.0.0, I'm not sure we even have to.

After this is merged, the same branch (or master?) can be merged into develop and then into any feature branches so that both 4.0.x and 4.1.x and the current maintenance release will have the new tests and cooperate with the changes that had to be made on TeamCity.