### PR TITLE
Diagnostic info

### DIFF
--- a/src/SqlPersistence/Config/SqlDialect.cs
+++ b/src/SqlPersistence/Config/SqlDialect.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus
 {
+    using System.Collections.Generic;
     using System.Data.Common;
     using System.Threading.Tasks;
 
@@ -56,5 +57,7 @@ namespace NServiceBus
         internal virtual void ValidateTablePrefix(string tablePrefix)
         {
         }
+
+        internal abstract void AddExtraDiagnosticsInfo(Dictionary<string, object> diagnostics);
     }
 }

--- a/src/SqlPersistence/Config/SqlDialect.cs
+++ b/src/SqlPersistence/Config/SqlDialect.cs
@@ -57,6 +57,6 @@ namespace NServiceBus
         {
         }
 
-        internal abstract object GetDiagnosticsInfo();
+        internal abstract object GetCustomDialectDiagnosticsInfo();
     }
 }

--- a/src/SqlPersistence/Config/SqlDialect.cs
+++ b/src/SqlPersistence/Config/SqlDialect.cs
@@ -1,6 +1,5 @@
 namespace NServiceBus
 {
-    using System.Collections.Generic;
     using System.Data.Common;
     using System.Threading.Tasks;
 
@@ -58,6 +57,6 @@ namespace NServiceBus
         {
         }
 
-        internal abstract void AddExtraDiagnosticsInfo(Dictionary<string, object> diagnostics);
+        internal abstract object GetDiagnosticsInfo();
     }
 }

--- a/src/SqlPersistence/Config/SqlDialect_MsSqlServer.cs
+++ b/src/SqlPersistence/Config/SqlDialect_MsSqlServer.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus
 {
     using System;
+    using System.Collections.Generic;
     using System.Data.Common;
     using System.Data.SqlClient;
 
@@ -50,6 +51,12 @@ namespace NServiceBus
             {
                 var command = connection.CreateCommand();
                 return new CommandWrapper(command, this);
+            }
+
+            internal override void AddExtraDiagnosticsInfo(Dictionary<string, object> diagnostics)
+            {
+                diagnostics.Add("CustomSchema", string.IsNullOrEmpty(Schema));
+                diagnostics.Add(nameof(DoNotUseTransportConnection), DoNotUseTransportConnection);
             }
 
             internal string Schema { get; set; }

--- a/src/SqlPersistence/Config/SqlDialect_MsSqlServer.cs
+++ b/src/SqlPersistence/Config/SqlDialect_MsSqlServer.cs
@@ -53,10 +53,13 @@ namespace NServiceBus
                 return new CommandWrapper(command, this);
             }
 
-            internal override void AddExtraDiagnosticsInfo(Dictionary<string, object> diagnostics)
+            internal override object GetDiagnosticsInfo()
             {
-                diagnostics.Add("CustomSchema", string.IsNullOrEmpty(Schema));
-                diagnostics.Add(nameof(DoNotUseTransportConnection), DoNotUseTransportConnection);
+                return new
+                {
+                    CustomSchema = string.IsNullOrEmpty(Schema),
+                    DoNotUseTransportConnection
+                };
             }
 
             internal string Schema { get; set; }

--- a/src/SqlPersistence/Config/SqlDialect_MsSqlServer.cs
+++ b/src/SqlPersistence/Config/SqlDialect_MsSqlServer.cs
@@ -1,7 +1,6 @@
 namespace NServiceBus
 {
     using System;
-    using System.Collections.Generic;
     using System.Data.Common;
     using System.Data.SqlClient;
 
@@ -53,7 +52,7 @@ namespace NServiceBus
                 return new CommandWrapper(command, this);
             }
 
-            internal override object GetDiagnosticsInfo()
+            internal override object GetCustomDialectDiagnosticsInfo()
             {
                 return new
                 {

--- a/src/SqlPersistence/Config/SqlDialect_MySql.cs
+++ b/src/SqlPersistence/Config/SqlDialect_MySql.cs
@@ -26,9 +26,9 @@ namespace NServiceBus
                 return new CommandWrapper(command, this);
             }
 
-            internal override void AddExtraDiagnosticsInfo(Dictionary<string, object> diagnostics)
+            internal override object GetDiagnosticsInfo()
             {
-                
+                return null;
             }
         }
     }

--- a/src/SqlPersistence/Config/SqlDialect_MySql.cs
+++ b/src/SqlPersistence/Config/SqlDialect_MySql.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus
 {
+    using System.Collections.Generic;
     using System.Data.Common;
 
     public abstract partial class SqlDialect
@@ -23,6 +24,11 @@ namespace NServiceBus
             {
                 var command = connection.CreateCommand();
                 return new CommandWrapper(command, this);
+            }
+
+            internal override void AddExtraDiagnosticsInfo(Dictionary<string, object> diagnostics)
+            {
+                
             }
         }
     }

--- a/src/SqlPersistence/Config/SqlDialect_MySql.cs
+++ b/src/SqlPersistence/Config/SqlDialect_MySql.cs
@@ -1,6 +1,5 @@
 namespace NServiceBus
 {
-    using System.Collections.Generic;
     using System.Data.Common;
 
     public abstract partial class SqlDialect
@@ -26,7 +25,7 @@ namespace NServiceBus
                 return new CommandWrapper(command, this);
             }
 
-            internal override object GetDiagnosticsInfo()
+            internal override object GetCustomDialectDiagnosticsInfo()
             {
                 return null;
             }

--- a/src/SqlPersistence/Config/SqlDialect_Oracle.cs
+++ b/src/SqlPersistence/Config/SqlDialect_Oracle.cs
@@ -1,7 +1,6 @@
 namespace NServiceBus
 {
     using System;
-    using System.Collections.Generic;
     using System.Data;
     using System.Data.Common;
     using System.Reflection;
@@ -69,7 +68,7 @@ namespace NServiceBus
                 }
             }
 
-            internal override object GetDiagnosticsInfo()
+            internal override object GetCustomDialectDiagnosticsInfo()
             {
                 return new { CustomSchema = string.IsNullOrEmpty(Schema)};
             }

--- a/src/SqlPersistence/Config/SqlDialect_Oracle.cs
+++ b/src/SqlPersistence/Config/SqlDialect_Oracle.cs
@@ -69,9 +69,9 @@ namespace NServiceBus
                 }
             }
 
-            internal override void AddExtraDiagnosticsInfo(Dictionary<string, object> diagnostics)
+            internal override object GetDiagnosticsInfo()
             {
-                diagnostics.Add("CustomSchema", string.IsNullOrEmpty(Schema));
+                return new { CustomSchema = string.IsNullOrEmpty(Schema)};
             }
 
             internal string Schema { get; set; }

--- a/src/SqlPersistence/Config/SqlDialect_Oracle.cs
+++ b/src/SqlPersistence/Config/SqlDialect_Oracle.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus
 {
     using System;
+    using System.Collections.Generic;
     using System.Data;
     using System.Data.Common;
     using System.Reflection;
@@ -66,6 +67,11 @@ namespace NServiceBus
                 {
                     throw new Exception($"Table prefix '{tablePrefix}' contains non-ASCII characters, which is not supported by SQL persistence using Oracle. Change the endpoint name or specify a custom tablePrefix using endpointConfiguration.{nameof(SqlPersistenceConfig.TablePrefix)}(tablePrefix).");
                 }
+            }
+
+            internal override void AddExtraDiagnosticsInfo(Dictionary<string, object> diagnostics)
+            {
+                diagnostics.Add("CustomSchema", string.IsNullOrEmpty(Schema));
             }
 
             internal string Schema { get; set; }

--- a/src/SqlPersistence/Config/SqlDialect_PostgreSql.cs
+++ b/src/SqlPersistence/Config/SqlDialect_PostgreSql.cs
@@ -1,7 +1,6 @@
 namespace NServiceBus
 {
     using System;
-    using System.Collections.Generic;
     using System.Data;
     using System.Data.Common;
 
@@ -84,7 +83,7 @@ dialect.JsonBParameterModifier(
                 throw new Exception($"Table prefix '{tablePrefix}' contains more than 20 characters, which is not supported by SQL persistence using PostgreSQL. Shorten the endpoint name or specify a custom tablePrefix using endpointConfiguration.{nameof(SqlPersistenceConfig.TablePrefix)}(tablePrefix).");
             }
 
-            internal override object GetDiagnosticsInfo()
+            internal override object GetCustomDialectDiagnosticsInfo()
             {
                 return new
                 {

--- a/src/SqlPersistence/Config/SqlDialect_PostgreSql.cs
+++ b/src/SqlPersistence/Config/SqlDialect_PostgreSql.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus
 {
     using System;
+    using System.Collections.Generic;
     using System.Data;
     using System.Data.Common;
 
@@ -82,6 +83,13 @@ dialect.JsonBParameterModifier(
                 }
                 throw new Exception($"Table prefix '{tablePrefix}' contains more than 20 characters, which is not supported by SQL persistence using PostgreSQL. Shorten the endpoint name or specify a custom tablePrefix using endpointConfiguration.{nameof(SqlPersistenceConfig.TablePrefix)}(tablePrefix).");
             }
+
+            internal override void AddExtraDiagnosticsInfo(Dictionary<string, object> diagnostics)
+            {
+                diagnostics.Add("CustomSchema", string.IsNullOrEmpty(Schema));
+                diagnostics.Add("CustomJsonBParameterModifier", JsonBParameterModifier != null);
+            }
+
             internal string Schema { get; set; }
         }
     }

--- a/src/SqlPersistence/Config/SqlDialect_PostgreSql.cs
+++ b/src/SqlPersistence/Config/SqlDialect_PostgreSql.cs
@@ -84,10 +84,13 @@ dialect.JsonBParameterModifier(
                 throw new Exception($"Table prefix '{tablePrefix}' contains more than 20 characters, which is not supported by SQL persistence using PostgreSQL. Shorten the endpoint name or specify a custom tablePrefix using endpointConfiguration.{nameof(SqlPersistenceConfig.TablePrefix)}(tablePrefix).");
             }
 
-            internal override void AddExtraDiagnosticsInfo(Dictionary<string, object> diagnostics)
+            internal override object GetDiagnosticsInfo()
             {
-                diagnostics.Add("CustomSchema", string.IsNullOrEmpty(Schema));
-                diagnostics.Add("CustomJsonBParameterModifier", JsonBParameterModifier != null);
+                return new
+                {
+                    CustomSchema = string.IsNullOrEmpty(Schema),
+                    CustomJsonBParameterModifier = JsonBParameterModifier != null
+                };
             }
 
             internal string Schema { get; set; }

--- a/src/SqlPersistence/Config/SqlPersistenceConfig_SqlDialect.cs
+++ b/src/SqlPersistence/Config/SqlPersistenceConfig_SqlDialect.cs
@@ -33,6 +33,9 @@
             var type = typeof(SqlDialectSettings<>).MakeGenericType(typeof(T));
             dialectSettings = (SqlDialectSettings<T>)Activator.CreateInstance(type);
             settings.Set("SqlPersistence.SqlDialect", dialectSettings);
+
+            settings.AddStartupDiagnosticsSection("NServiceBus.Persistence.Sql.SqlDialect", dialectSettings.Dialect.ToString());
+
             return dialectSettings;
         }
     }

--- a/src/SqlPersistence/Config/SqlPersistenceConfig_SqlDialect.cs
+++ b/src/SqlPersistence/Config/SqlPersistenceConfig_SqlDialect.cs
@@ -34,8 +34,6 @@
             dialectSettings = (SqlDialectSettings<T>)Activator.CreateInstance(type);
             settings.Set("SqlPersistence.SqlDialect", dialectSettings);
 
-            settings.AddStartupDiagnosticsSection("NServiceBus.Persistence.Sql.SqlDialect", dialectSettings.Dialect.ToString());
-
             return dialectSettings;
         }
     }

--- a/src/SqlPersistence/Outbox/SqlOutboxFeature.cs
+++ b/src/SqlPersistence/Outbox/SqlOutboxFeature.cs
@@ -20,6 +20,7 @@ class SqlOutboxFeature : Feature
 
         if (settings.GetOrDefault<bool>(DisableCleanup))
         {
+            settings.AddStartupDiagnosticsSection("NServiceBus.Persistence.Sql.Outbox", new { CleanupDisabled = true });
             return;
         }
 
@@ -27,6 +28,13 @@ class SqlOutboxFeature : Feature
         {
             var frequencyToRunCleanup = settings.GetOrDefault<TimeSpan?>(FrequencyToRunDeduplicationDataCleanup) ?? TimeSpan.FromMinutes(1);
             var timeToKeepDeduplicationData = settings.GetOrDefault<TimeSpan?>(TimeToKeepDeduplicationData) ?? TimeSpan.FromDays(7);
+
+            settings.AddStartupDiagnosticsSection("NServiceBus.Persistence.Sql.Outbox", new
+            {
+                CleanupDisabled = false,
+                timeToKeepDeduplicationData,
+                frequencyToRunCleanup
+            });
 
             return new OutboxCleaner(outboxPersister.RemoveEntriesOlderThan, b.Build<CriticalError>().Raise, timeToKeepDeduplicationData, frequencyToRunCleanup, new AsyncTimer());
         });

--- a/src/SqlPersistence/Outbox/SqlOutboxFeature.cs
+++ b/src/SqlPersistence/Outbox/SqlOutboxFeature.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using NServiceBus;
 using NServiceBus.Features;
 
@@ -21,14 +20,9 @@ class SqlOutboxFeature : Feature
 
         if (settings.GetOrDefault<bool>(DisableCleanup))
         {
-            var diagnostics = new Dictionary<string, object>
-            {
-                { "CleanupDisabled", true }
-            };
-            sqlDialect.AddExtraDiagnosticsInfo(diagnostics);
             settings.AddStartupDiagnosticsSection("NServiceBus.Persistence.Sql.Outbox", new
             {
-                diagnostics
+                CleanupDisabled = true
             });
 
             return;
@@ -39,16 +33,12 @@ class SqlOutboxFeature : Feature
             var frequencyToRunCleanup = settings.GetOrDefault<TimeSpan?>(FrequencyToRunDeduplicationDataCleanup) ?? TimeSpan.FromMinutes(1);
             var timeToKeepDeduplicationData = settings.GetOrDefault<TimeSpan?>(TimeToKeepDeduplicationData) ?? TimeSpan.FromDays(7);
 
-            var diagnostics = new Dictionary<string, object>
-            {
-                { "CleanupDisabled", false },
-                {nameof(timeToKeepDeduplicationData), timeToKeepDeduplicationData },
-                {nameof(frequencyToRunCleanup), frequencyToRunCleanup }
-            };
-            sqlDialect.AddExtraDiagnosticsInfo(diagnostics);
+
             settings.AddStartupDiagnosticsSection("NServiceBus.Persistence.Sql.Outbox", new
             {
-                diagnostics
+                CleanupDisabled = false,
+                TimeToKeepDeduplicationData = timeToKeepDeduplicationData,
+                FrequencyToRunDeduplicationDataCleanup = frequencyToRunCleanup
             });
 
             return new OutboxCleaner(outboxPersister.RemoveEntriesOlderThan, b.Build<CriticalError>().Raise, timeToKeepDeduplicationData, frequencyToRunCleanup, new AsyncTimer());

--- a/src/SqlPersistence/Outbox/SqlOutboxFeature.cs
+++ b/src/SqlPersistence/Outbox/SqlOutboxFeature.cs
@@ -33,7 +33,6 @@ class SqlOutboxFeature : Feature
             var frequencyToRunCleanup = settings.GetOrDefault<TimeSpan?>(FrequencyToRunDeduplicationDataCleanup) ?? TimeSpan.FromMinutes(1);
             var timeToKeepDeduplicationData = settings.GetOrDefault<TimeSpan?>(TimeToKeepDeduplicationData) ?? TimeSpan.FromDays(7);
 
-
             settings.AddStartupDiagnosticsSection("NServiceBus.Persistence.Sql.Outbox", new
             {
                 CleanupDisabled = false,

--- a/src/SqlPersistence/Saga/SqlSagaFeature.cs
+++ b/src/SqlPersistence/Saga/SqlSagaFeature.cs
@@ -1,4 +1,7 @@
-﻿using NServiceBus.Features;
+﻿using System.Collections.Generic;
+using NServiceBus;
+using NServiceBus.Features;
+using NServiceBus.Persistence.Sql;
 
 class SqlSagaFeature : Feature
 {
@@ -9,5 +12,19 @@ class SqlSagaFeature : Feature
 
     protected override void Setup(FeatureConfigurationContext context)
     {
+        var settings = context.Settings;
+
+        var customJsonSettings = SagaSettings.GetJsonSerializerSettings(settings);
+        var versionSpecificJsonSettings = SagaSettings.GetVersionSettings(settings);
+        var customSagaWriter = SagaSettings.GetWriterCreator(settings);
+        var customSagaReader = SagaSettings.GetReaderCreator(settings);
+
+        settings.AddStartupDiagnosticsSection("NServiceBus.Persistence.Sql.Sagas", new Dictionary<string, object>
+        {
+            { nameof(customJsonSettings), customJsonSettings != null},
+            { nameof(versionSpecificJsonSettings), versionSpecificJsonSettings != null},
+            { nameof(customSagaWriter), customSagaWriter != null},
+            { nameof(customSagaReader), customSagaReader != null}
+        });
     }
 }

--- a/src/SqlPersistence/Saga/SqlSagaFeature.cs
+++ b/src/SqlPersistence/Saga/SqlSagaFeature.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using NServiceBus;
+﻿using NServiceBus;
 using NServiceBus.Features;
 using NServiceBus.Persistence.Sql;
 
@@ -19,12 +18,12 @@ class SqlSagaFeature : Feature
         var customSagaWriter = SagaSettings.GetWriterCreator(settings);
         var customSagaReader = SagaSettings.GetReaderCreator(settings);
 
-        settings.AddStartupDiagnosticsSection("NServiceBus.Persistence.Sql.Sagas", new Dictionary<string, object>
+        settings.AddStartupDiagnosticsSection("NServiceBus.Persistence.Sql.Sagas", new 
         {
-            { nameof(customJsonSettings), customJsonSettings != null},
-            { nameof(versionSpecificJsonSettings), versionSpecificJsonSettings != null},
-            { nameof(customSagaWriter), customSagaWriter != null},
-            { nameof(customSagaReader), customSagaReader != null}
+            CustomJsonSettings = customJsonSettings != null,
+            VersionSpecificJsonSettings = versionSpecificJsonSettings != null,
+            CustomSagaWriter = customSagaWriter != null,
+            CustomSagaReader = customSagaReader != null
         });
     }
 }

--- a/src/SqlPersistence/SqlPersistence.cs
+++ b/src/SqlPersistence/SqlPersistence.cs
@@ -34,6 +34,15 @@
             });
             Defaults(s =>
             {
+                var dialect = s.GetSqlDialect();
+                var diagnostics = dialect.GetCustomDialectDiagnosticsInfo();
+
+                s.AddStartupDiagnosticsSection("NServiceBus.Persistence.Sql.SqlDialect", new
+                {
+                    dialect.Name,
+                    diagnostics
+                });
+
                 s.EnableFeatureByDefault<InstallerFeature>();
             });
         }

--- a/src/SqlPersistence/SqlPersistence.cs
+++ b/src/SqlPersistence/SqlPersistence.cs
@@ -39,8 +39,8 @@
 
                 s.AddStartupDiagnosticsSection("NServiceBus.Persistence.Sql.SqlDialect", new
                 {
-                    dialect.Name,
-                    diagnostics
+                    Name = dialect.Name,
+                    CustomDiagnostics = diagnostics
                 });
 
                 s.EnableFeatureByDefault<InstallerFeature>();

--- a/src/SqlPersistence/Subscription/SqlSubscriptionFeature.cs
+++ b/src/SqlPersistence/Subscription/SqlSubscriptionFeature.cs
@@ -22,6 +22,11 @@ class SqlSubscriptionFeature : Feature
 
         sqlDialect.ValidateTablePrefix(tablePrefix);
 
+        settings.AddStartupDiagnosticsSection("NServiceBus.Persistence.Sql.Subscriptions", new
+        {
+            cacheFor
+        });
+
         context.Container.RegisterSingleton(typeof (ISubscriptionStorage), persister);
     }
 }

--- a/src/SqlPersistence/Subscription/SqlSubscriptionFeature.cs
+++ b/src/SqlPersistence/Subscription/SqlSubscriptionFeature.cs
@@ -1,4 +1,5 @@
-﻿using NServiceBus;
+﻿using System.Collections.Generic;
+using NServiceBus;
 using NServiceBus.Features;
 using NServiceBus.Persistence.Sql;
 using NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions;
@@ -21,10 +22,15 @@ class SqlSubscriptionFeature : Feature
         var persister = new SubscriptionPersister(connectionBuilder, tablePrefix, sqlDialect, cacheFor);
 
         sqlDialect.ValidateTablePrefix(tablePrefix);
-
+        
+        var diagnostics = new Dictionary<string, object>
+        {
+            { nameof(cacheFor), cacheFor }
+        };
+        sqlDialect.AddExtraDiagnosticsInfo(diagnostics);
         settings.AddStartupDiagnosticsSection("NServiceBus.Persistence.Sql.Subscriptions", new
         {
-            cacheFor
+            diagnostics
         });
 
         context.Container.RegisterSingleton(typeof (ISubscriptionStorage), persister);

--- a/src/SqlPersistence/Subscription/SqlSubscriptionFeature.cs
+++ b/src/SqlPersistence/Subscription/SqlSubscriptionFeature.cs
@@ -22,7 +22,12 @@ class SqlSubscriptionFeature : Feature
 
         sqlDialect.ValidateTablePrefix(tablePrefix);
 
-        settings.AddStartupDiagnosticsSection("NServiceBus.Persistence.Sql.Subscriptions", new { cacheFor});
+        settings.AddStartupDiagnosticsSection("NServiceBus.Persistence.Sql.Subscriptions", 
+            new
+            {
+                EntriesCashedFor = cacheFor,
+                CustomConnectionBuilder = settings.HasSetting($"SqlPersistence.ConnectionBuilder.{typeof(StorageType.Subscriptions).Name}")
+            });
 
         context.Container.RegisterSingleton(typeof (ISubscriptionStorage), persister);
     }

--- a/src/SqlPersistence/Subscription/SqlSubscriptionFeature.cs
+++ b/src/SqlPersistence/Subscription/SqlSubscriptionFeature.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using NServiceBus;
+﻿using NServiceBus;
 using NServiceBus.Features;
 using NServiceBus.Persistence.Sql;
 using NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions;
@@ -22,16 +21,8 @@ class SqlSubscriptionFeature : Feature
         var persister = new SubscriptionPersister(connectionBuilder, tablePrefix, sqlDialect, cacheFor);
 
         sqlDialect.ValidateTablePrefix(tablePrefix);
-        
-        var diagnostics = new Dictionary<string, object>
-        {
-            { nameof(cacheFor), cacheFor }
-        };
-        sqlDialect.AddExtraDiagnosticsInfo(diagnostics);
-        settings.AddStartupDiagnosticsSection("NServiceBus.Persistence.Sql.Subscriptions", new
-        {
-            diagnostics
-        });
+
+        settings.AddStartupDiagnosticsSection("NServiceBus.Persistence.Sql.Subscriptions", new { cacheFor});
 
         context.Container.RegisterSingleton(typeof (ISubscriptionStorage), persister);
     }

--- a/src/SqlPersistence/Timeout/SqlTimeoutFeature.cs
+++ b/src/SqlPersistence/Timeout/SqlTimeoutFeature.cs
@@ -16,16 +16,16 @@ class SqlTimeoutFeature : Feature
         var sqlDialect = settings.GetSqlDialect();
         var connectionBuilder = settings.GetConnectionBuilder<StorageType.Timeouts>();
         var tablePrefix = settings.GetTablePrefix();
-        var TimeoutsCleanupExecutionInterval = context.Settings.GetOrDefault<TimeSpan?>("SqlPersistence.Timeout.CleanupExecutionInterval") ?? TimeSpan.FromMinutes(2);
+        var timeoutsCleanupExecutionInterval = context.Settings.GetOrDefault<TimeSpan?>("SqlPersistence.Timeout.CleanupExecutionInterval") ?? TimeSpan.FromMinutes(2);
 
         sqlDialect.ValidateTablePrefix(tablePrefix);
 
         settings.AddStartupDiagnosticsSection("NServiceBus.Persistence.Sql.Timeouts", new
         {
-            TimeoutsCleanupExecutionInterval
+            TimeoutsCleanupExecutionInterval = timeoutsCleanupExecutionInterval
         });
 
-        var persister = new TimeoutPersister(connectionBuilder, tablePrefix, sqlDialect, TimeoutsCleanupExecutionInterval, () => DateTime.UtcNow);
+        var persister = new TimeoutPersister(connectionBuilder, tablePrefix, sqlDialect, timeoutsCleanupExecutionInterval, () => DateTime.UtcNow);
         context.Container.RegisterSingleton(typeof(IPersistTimeouts), persister);
         context.Container.RegisterSingleton(typeof(IQueryTimeouts), persister);
     }

--- a/src/SqlPersistence/Timeout/SqlTimeoutFeature.cs
+++ b/src/SqlPersistence/Timeout/SqlTimeoutFeature.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using NServiceBus;
 using NServiceBus.Features;
 using NServiceBus.Timeout.Core;
@@ -17,22 +16,16 @@ class SqlTimeoutFeature : Feature
         var sqlDialect = settings.GetSqlDialect();
         var connectionBuilder = settings.GetConnectionBuilder<StorageType.Timeouts>();
         var tablePrefix = settings.GetTablePrefix();
-        var timeoutsCleanupExecutionInterval = context.Settings.GetOrDefault<TimeSpan?>("SqlPersistence.Timeout.CleanupExecutionInterval") ?? TimeSpan.FromMinutes(2);
+        var TimeoutsCleanupExecutionInterval = context.Settings.GetOrDefault<TimeSpan?>("SqlPersistence.Timeout.CleanupExecutionInterval") ?? TimeSpan.FromMinutes(2);
 
         sqlDialect.ValidateTablePrefix(tablePrefix);
 
-        var diagnostics = new Dictionary<string, object>
-        {
-            { nameof(timeoutsCleanupExecutionInterval), timeoutsCleanupExecutionInterval }
-        };
-        sqlDialect.AddExtraDiagnosticsInfo(diagnostics);
-
         settings.AddStartupDiagnosticsSection("NServiceBus.Persistence.Sql.Timeouts", new
         {
-            diagnostics
+            TimeoutsCleanupExecutionInterval
         });
 
-        var persister = new TimeoutPersister(connectionBuilder, tablePrefix, sqlDialect, timeoutsCleanupExecutionInterval, () => DateTime.UtcNow);
+        var persister = new TimeoutPersister(connectionBuilder, tablePrefix, sqlDialect, TimeoutsCleanupExecutionInterval, () => DateTime.UtcNow);
         context.Container.RegisterSingleton(typeof(IPersistTimeouts), persister);
         context.Container.RegisterSingleton(typeof(IQueryTimeouts), persister);
     }

--- a/src/SqlPersistence/Timeout/SqlTimeoutFeature.cs
+++ b/src/SqlPersistence/Timeout/SqlTimeoutFeature.cs
@@ -22,7 +22,8 @@ class SqlTimeoutFeature : Feature
 
         settings.AddStartupDiagnosticsSection("NServiceBus.Persistence.Sql.Timeouts", new
         {
-            TimeoutsCleanupExecutionInterval = timeoutsCleanupExecutionInterval
+            TimeoutsCleanupExecutionInterval = timeoutsCleanupExecutionInterval,
+            CustomConnectionBuilder = settings.HasSetting($"SqlPersistence.ConnectionBuilder.{typeof(StorageType.Timeouts).Name}")
         });
 
         var persister = new TimeoutPersister(connectionBuilder, tablePrefix, sqlDialect, timeoutsCleanupExecutionInterval, () => DateTime.UtcNow);

--- a/src/SqlPersistence/Timeout/SqlTimeoutFeature.cs
+++ b/src/SqlPersistence/Timeout/SqlTimeoutFeature.cs
@@ -20,6 +20,11 @@ class SqlTimeoutFeature : Feature
 
         sqlDialect.ValidateTablePrefix(tablePrefix);
 
+        settings.AddStartupDiagnosticsSection("NServiceBus.Persistence.Sql.Timeouts", new
+        {
+            timeoutsCleanupExecutionInterval
+        });
+
         var persister = new TimeoutPersister(connectionBuilder, tablePrefix, sqlDialect, timeoutsCleanupExecutionInterval, () => DateTime.UtcNow);
         context.Container.RegisterSingleton(typeof(IPersistTimeouts), persister);
         context.Container.RegisterSingleton(typeof(IQueryTimeouts), persister);

--- a/src/SqlPersistence/Timeout/SqlTimeoutFeature.cs
+++ b/src/SqlPersistence/Timeout/SqlTimeoutFeature.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using NServiceBus;
 using NServiceBus.Features;
 using NServiceBus.Timeout.Core;
@@ -20,9 +21,15 @@ class SqlTimeoutFeature : Feature
 
         sqlDialect.ValidateTablePrefix(tablePrefix);
 
+        var diagnostics = new Dictionary<string, object>
+        {
+            { nameof(timeoutsCleanupExecutionInterval), timeoutsCleanupExecutionInterval }
+        };
+        sqlDialect.AddExtraDiagnosticsInfo(diagnostics);
+
         settings.AddStartupDiagnosticsSection("NServiceBus.Persistence.Sql.Timeouts", new
         {
-            timeoutsCleanupExecutionInterval
+            diagnostics
         });
 
         var persister = new TimeoutPersister(connectionBuilder, tablePrefix, sqlDialect, timeoutsCleanupExecutionInterval, () => DateTime.UtcNow);


### PR DESCRIPTION
PoA:
- [x] Selected dialect
- [x] ~~Version~~ Covered here https://github.com/Particular/NServiceBus/blob/ceac08e8c7441dab4add154afd5ec4cd576c7836/src/NServiceBus.Core/Persistence/PersistenceStartup.cs#L35
- [x] Subscriptions caching
- [x] Timeouts cleanup
- [x] Outbox settings (if outbox enabled) such as cleanup enabled/disabled, how long data is stored, how often the dedup process is kicked off
- [x] Info whether multiple connection strings are used (not log connection string itself, but yes/no whether they were used per feature) Waits for https://github.com/Particular/NServiceBus.Persistence.Sql/pull/284
- [x] Info whether custom schema is used (not log the schema value itself, but yes/no whether it's configured)
- [x] Info whether SqlServer Transport connection is re-used (`DoNotUseSqlServerTransportConnection`)
- [x] Info whether JsonBParameterModifier is used
- Sagas:
   - [x] Custom JSonSettings usage (used/not used)? Do we need/want detailed data here?
   - [x] [Version/type specific deserialization settings](https://docs.particular.net/persistence/sql/saga#json-net-settings-custom-settings-version-type-specific-deserialization-settings), custom reader, custom writer (used/not used)? 