### PR TITLE
Allow use of regular Saga<T> base class

### DIFF
--- a/src/AcceptanceTestsHolder/AcceptanceTestsHolder.csproj
+++ b/src/AcceptanceTestsHolder/AcceptanceTestsHolder.csproj
@@ -31,10 +31,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="NServiceBus.AcceptanceTesting, Version=7.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NServiceBus.AcceptanceTesting.7.0.0\lib\net452\NServiceBus.AcceptanceTesting.dll</HintPath>
+      <HintPath>..\packages\NServiceBus.AcceptanceTesting.7.0.1\lib\net452\NServiceBus.AcceptanceTesting.dll</HintPath>
     </Reference>
     <Reference Include="NServiceBus.Core, Version=7.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NServiceBus.7.0.0\lib\net452\NServiceBus.Core.dll</HintPath>
+      <HintPath>..\packages\NServiceBus.7.0.1\lib\net452\NServiceBus.Core.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=3.7.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.7.1\lib\net45\nunit.framework.dll</HintPath>

--- a/src/AcceptanceTestsHolder/AcceptanceTestsHolder.csproj
+++ b/src/AcceptanceTestsHolder/AcceptanceTestsHolder.csproj
@@ -212,6 +212,7 @@
     <Compile Include="App_Packages\NSB.AcceptanceTests\Tx\When_receiving_with_the_default_settings.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests\Tx\When_sending_within_an_ambient_transaction.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests\Versioning\When_multiple_versions_of_a_message_is_published.cs" />
+    <Compile Include="App_Packages\When_using_intermediate_saga_base_class.cs" />
     <Compile Include="App_Packages\When_using_outbox_but_no_sagas.cs" />
     <Compile Include="App_Packages\When_using_different_persistence.cs" />
     <Compile Include="Partials\When_Deferring_a_message.cs" />

--- a/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Outbox/When_clearing_saga_timeouts.cs
+++ b/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Outbox/When_clearing_saga_timeouts.cs
@@ -7,7 +7,6 @@
     using Extensibility;
     using Features;
     using NServiceBus;
-    using NServiceBus.Persistence.Sql;
     using NServiceBus.Outbox;
     using NServiceBus.Persistence;
     using NUnit.Framework;
@@ -61,18 +60,17 @@
                 }
             }
 
-            public class PlaceOrderSaga : SqlSaga<PlaceOrderSaga.PlaceOrderSagaData>, IAmStartedByMessages<PlaceOrder>
+            public class PlaceOrderSaga : Saga<PlaceOrderSaga.PlaceOrderSagaData>, IAmStartedByMessages<PlaceOrder>
             {
                 public Task Handle(PlaceOrder message, IMessageHandlerContext context)
                 {
                     MarkAsComplete();
                     return context.SendLocal(new SignalDone());
                 }
-                protected override string CorrelationPropertyName => nameof(PlaceOrderSagaData.DataId);
 
-                protected override void ConfigureMapping(IMessagePropertyMapper mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<PlaceOrderSagaData> mapper)
                 {
-                    mapper.ConfigureMapping<PlaceOrder>(m => m.DataId);
+                    mapper.ConfigureMapping<PlaceOrder>(m => m.DataId).ToSaga(s => s.DataId);
                 }
 
                 public class PlaceOrderSagaData : ContainSagaData

--- a/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_an_endpoint_replies_to_a_saga.cs
+++ b/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_an_endpoint_replies_to_a_saga.cs
@@ -7,7 +7,6 @@
     using EndpointTemplates;
     using Features;
     using NUnit.Framework;
-    using NServiceBus.Persistence.Sql;
 
     // Repro for issue  https://github.com/NServiceBus/NServiceBus/issues/1277 to test the fix
     // making sure that the saga correlation still works.
@@ -65,7 +64,7 @@
                 });
             }
 
-            public class CorrelationTestSaga : SqlSaga<CorrelationTestSaga.CorrelationTestSagaData>,
+            public class CorrelationTestSaga : Saga<CorrelationTestSaga.CorrelationTestSagaData>,
                 IAmStartedByMessages<StartSaga>,
                 IHandleMessages<DoSomethingResponse>
             {
@@ -87,12 +86,10 @@
                     return Task.FromResult(0);
                 }
 
-                protected override string CorrelationPropertyName => nameof(CorrelationTestSagaData.RunId);
-
-                protected override void ConfigureMapping(IMessagePropertyMapper mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<CorrelationTestSagaData> mapper)
                 {
-                    mapper.ConfigureMapping<StartSaga>(m => m.RunId);
-                    mapper.ConfigureMapping<DoSomethingResponse>(m => m.RunId);
+                    mapper.ConfigureMapping<StartSaga>(m => m.RunId).ToSaga(s => s.RunId);
+                    mapper.ConfigureMapping<DoSomethingResponse>(m => m.RunId).ToSaga(s => s.RunId);
                 }
 
                 public class CorrelationTestSagaData : ContainSagaData

--- a/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_correlated_property_value_is_changed.cs
+++ b/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_correlated_property_value_is_changed.cs
@@ -6,7 +6,6 @@
     using AcceptanceTesting.Support;
     using EndpointTemplates;
     using NUnit.Framework;
-    using Persistence.Sql;
 
     [TestFixture]
     public class When_correlated_property_value_is_changed : NServiceBusAcceptanceTest
@@ -42,7 +41,7 @@
                 EndpointSetup<DefaultServer>();
             }
 
-            public class CorrIdChangedSaga : SqlSaga<CorrIdChangedSaga.CorrIdChangedSagaData>,
+            public class CorrIdChangedSaga : Saga<CorrIdChangedSaga.CorrIdChangedSagaData>,
                 IAmStartedByMessages<StartSaga>
             {
                 public Context TestContext { get; set; }
@@ -54,10 +53,9 @@
                     return Task.FromResult(0);
                 }
 
-                protected override string CorrelationPropertyName => nameof(CorrIdChangedSagaData.DataId);
-                protected override void ConfigureMapping(IMessagePropertyMapper mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<CorrIdChangedSagaData> mapper)
                 {
-                    mapper.ConfigureMapping<StartSaga>(m => m.DataId);
+                    mapper.ConfigureMapping<StartSaga>(m => m.DataId).ToSaga(s => s.DataId);
                 }
 
                 public class CorrIdChangedSagaData : ContainSagaData

--- a/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_correlating_on_special_characters.cs
+++ b/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_correlating_on_special_characters.cs
@@ -4,7 +4,6 @@
     using AcceptanceTesting;
     using EndpointTemplates;
     using NUnit.Framework;
-    using NServiceBus.Persistence.Sql;
 
     partial class When_correlating_special_chars : NServiceBusAcceptanceTest
     {
@@ -37,13 +36,13 @@
                 EndpointSetup<DefaultServer>();
             }
 
-            public class SagaDataWithSpecialPropertyValues : ContainSagaData
+            public class SagaDataSpecialValues : ContainSagaData
             {
                 public virtual string SpecialCharacterValues { get; set; }
             }
 
             public class SagaSpecialValues :
-                SqlSaga<SagaDataWithSpecialPropertyValues>,
+                Saga<SagaDataSpecialValues>,
                 IAmStartedByMessages<MessageWithSpecialPropertyValues>,
                 IHandleMessages<FollowupMessageWithSpecialPropertyValues>
             {
@@ -54,12 +53,10 @@
                     this.testContext = testContext;
                 }
 
-                protected override string CorrelationPropertyName => nameof(SagaDataWithSpecialPropertyValues.SpecialCharacterValues);
-
-                protected override void ConfigureMapping(IMessagePropertyMapper mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaDataSpecialValues> mapper)
                 {
-                    mapper.ConfigureMapping<MessageWithSpecialPropertyValues>(m => m.SpecialCharacterValues);
-                    mapper.ConfigureMapping<FollowupMessageWithSpecialPropertyValues>(m => m.SpecialCharacterValues);
+                    mapper.ConfigureMapping<MessageWithSpecialPropertyValues>(m => m.SpecialCharacterValues).ToSaga(s => s.SpecialCharacterValues);
+                    mapper.ConfigureMapping<FollowupMessageWithSpecialPropertyValues>(m => m.SpecialCharacterValues).ToSaga(s => s.SpecialCharacterValues);
                 }
 
                 public Task Handle(MessageWithSpecialPropertyValues message, IMessageHandlerContext context)

--- a/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_doing_request_response_between_sagas.cs
+++ b/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_doing_request_response_between_sagas.cs
@@ -6,7 +6,6 @@ namespace NServiceBus.AcceptanceTests.Sagas
     using EndpointTemplates;
     using Features;
     using NUnit.Framework;
-    using Persistence.Sql;
 
     public partial class When_doing_request_response_between_sagas : NServiceBusAcceptanceTest
     {
@@ -33,7 +32,7 @@ namespace NServiceBus.AcceptanceTests.Sagas
                 EndpointSetup<DefaultServer>(config => config.EnableFeature<TimeoutManager>());
             }
 
-            public class RequestResponseRequestingSaga1 : SqlSaga<RequestResponseRequestingSaga1.RequestResponseRequestingSagaData1>,
+            public class RequestResponseRequestingSaga1 : Saga<RequestResponseRequestingSaga1.RequestResponseRequestingSagaData1>,
                 IAmStartedByMessages<InitiateRequestingSaga>,
                 IHandleMessages<ResponseFromOtherSaga>
             {
@@ -43,11 +42,9 @@ namespace NServiceBus.AcceptanceTests.Sagas
                 {
                     return context.SendLocal(new RequestToRespondingSaga
                     {
-                        SomeId = Guid.NewGuid()
+                        SomeId = Guid.NewGuid() 
                     });
                 }
-
-                protected override string CorrelationPropertyName => nameof(RequestResponseRequestingSagaData1.CorrIdForResponse);
 
                 public Task Handle(ResponseFromOtherSaga message, IMessageHandlerContext context)
                 {
@@ -57,19 +54,20 @@ namespace NServiceBus.AcceptanceTests.Sagas
 
                     return Task.FromResult(0);
                 }
-                protected override void ConfigureMapping(IMessagePropertyMapper mapper)
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<RequestResponseRequestingSagaData1> mapper)
                 {
-                    mapper.ConfigureMapping<InitiateRequestingSaga>(m => m.Id);
-                    mapper.ConfigureMapping<ResponseFromOtherSaga>(m => m.SomeCorrelationId);
+                    mapper.ConfigureMapping<InitiateRequestingSaga>(m => m.Id).ToSaga(s => s.CorrIdForResponse);
+                    mapper.ConfigureMapping<ResponseFromOtherSaga>(m => m.SomeCorrelationId).ToSaga(s => s.CorrIdForResponse);
                 }
 
                 public class RequestResponseRequestingSagaData1 : ContainSagaData
                 {
-                    public virtual Guid CorrIdForResponse { get; set; }
+                    public virtual Guid CorrIdForResponse { get; set; } 
                 }
             }
 
-            public class RequestResponseRespondingSaga1 : SqlSaga<RequestResponseRespondingSaga1.RequestResponseRespondingSagaData1>,
+            public class RequestResponseRespondingSaga1 : Saga<RequestResponseRespondingSaga1.RequestResponseRespondingSagaData1>,
                 IAmStartedByMessages<RequestToRespondingSaga>
             {
                 public Context TestContext { get; set; }
@@ -82,10 +80,9 @@ namespace NServiceBus.AcceptanceTests.Sagas
                     return context.Reply(new ResponseFromOtherSaga{SomeCorrelationId = Guid.NewGuid()});
                 }
 
-                protected override string CorrelationPropertyName => nameof(RequestResponseRespondingSagaData1.CorrIdForRequest);
-                protected override void ConfigureMapping(IMessagePropertyMapper mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<RequestResponseRespondingSagaData1> mapper)
                 {
-                    mapper.ConfigureMapping<RequestToRespondingSaga>(m => m.SomeId);
+                    mapper.ConfigureMapping<RequestToRespondingSaga>(m => m.SomeId).ToSaga(s => s.CorrIdForRequest);
                 }
 
                 public class RequestResponseRespondingSagaData1 : ContainSagaData

--- a/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_message_has_a_saga_id.cs
+++ b/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_message_has_a_saga_id.cs
@@ -7,7 +7,6 @@
     using Features;
     using NServiceBus.Sagas;
     using NUnit.Framework;
-    using Persistence.Sql;
 
     public class When_message_has_a_saga_id : NServiceBusAcceptanceTest
     {
@@ -52,13 +51,11 @@
                 EndpointSetup<DefaultServer>(c => c.EnableFeature<TimeoutManager>());
             }
 
-            public class MessageWithSagaIdSaga : SqlSaga<MessageWithSagaIdSaga.MessageWithSagaIdSagaData>,
+            public class MessageWithSagaIdSaga : Saga<MessageWithSagaIdSaga.MessageWithSagaIdSagaData>,
                 IAmStartedByMessages<MessageWithSagaId>,
                 IHandleTimeouts<MessageWithSagaId>,
                 IHandleSagaNotFound
             {
-                protected override string CorrelationPropertyName => nameof(MessageWithSagaIdSagaData.DataId);
-
                 public Context TestContext { get; set; }
 
                 public Task Handle(MessageWithSagaId message, IMessageHandlerContext context)
@@ -79,9 +76,10 @@
                     return Task.FromResult(0);
                 }
 
-                protected override void ConfigureMapping(IMessagePropertyMapper mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<MessageWithSagaIdSagaData> mapper)
                 {
-                    mapper.ConfigureMapping<MessageWithSagaId>(m => m.DataId);
+                    mapper.ConfigureMapping<MessageWithSagaId>(m => m.DataId)
+                        .ToSaga(s => s.DataId);
                 }
 
                 public class MessageWithSagaIdSagaData : ContainSagaData

--- a/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_receiving_multiple_timeouts.cs
+++ b/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_receiving_multiple_timeouts.cs
@@ -7,7 +7,6 @@
     using Features;
     using NServiceBus.Sagas;
     using NUnit.Framework;
-    using Persistence.Sql;
 
     public class When_receiving_multiple_timeouts : NServiceBusAcceptanceTest
     {
@@ -48,13 +47,11 @@
                 });
             }
 
-            public class MultiTimeoutsSaga1 : SqlSaga<MultiTimeoutsSaga1.MultiTimeoutsSaga1Data>,
+            public class MultiTimeoutsSaga1 : Saga<MultiTimeoutsSaga1.MultiTimeoutsSaga1Data>,
                 IAmStartedByMessages<StartSaga1>,
                 IHandleTimeouts<Saga1Timeout>,
                 IHandleTimeouts<Saga2Timeout>
             {
-                protected override string CorrelationPropertyName => nameof(MultiTimeoutsSaga1Data.ContextId);
-
                 public Context TestContext { get; set; }
 
                 public async Task Handle(StartSaga1 message, IMessageHandlerContext context)
@@ -104,9 +101,10 @@
                     return Task.FromResult(0);
                 }
 
-                protected override void ConfigureMapping(IMessagePropertyMapper mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<MultiTimeoutsSaga1Data> mapper)
                 {
-                    mapper.ConfigureMapping<StartSaga1>(m => m.ContextId);
+                    mapper.ConfigureMapping<StartSaga1>(m => m.ContextId)
+                        .ToSaga(s => s.ContextId);
                 }
 
                 public class MultiTimeoutsSaga1Data : ContainSagaData

--- a/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_reply_from_saga_not_found_handler.cs
+++ b/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_reply_from_saga_not_found_handler.cs
@@ -8,7 +8,6 @@
     using Features;
     using NServiceBus.Sagas;
     using NUnit.Framework;
-    using Persistence.Sql;
 
     public class When_reply_from_saga_not_found_handler : NServiceBusAcceptanceTest
     {
@@ -60,10 +59,8 @@
                 EndpointSetup<DefaultServer>(c => c.EnableFeature<TimeoutManager>());
             }
 
-            public class NotFoundHandlerSaga1 : SqlSaga<NotFoundHandlerSaga1.NotFoundHandlerSaga1Data>, IAmStartedByMessages<StartSaga1>, IHandleMessages<MessageToSaga>
+            public class NotFoundHandlerSaga1 : Saga<NotFoundHandlerSaga1.NotFoundHandlerSaga1Data>, IAmStartedByMessages<StartSaga1>, IHandleMessages<MessageToSaga>
             {
-                protected override string CorrelationPropertyName => nameof(NotFoundHandlerSaga1Data.ContextId);
-
                 public Task Handle(StartSaga1 message, IMessageHandlerContext context)
                 {
                     Data.ContextId = message.ContextId;
@@ -75,10 +72,12 @@
                     return Task.FromResult(0);
                 }
 
-                protected override void ConfigureMapping(IMessagePropertyMapper mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<NotFoundHandlerSaga1Data> mapper)
                 {
-                    mapper.ConfigureMapping<StartSaga1>(m => m.ContextId);
-                    mapper.ConfigureMapping<MessageToSaga>(m => m.ContextId);
+                    mapper.ConfigureMapping<StartSaga1>(m => m.ContextId)
+                        .ToSaga(s => s.ContextId);
+                    mapper.ConfigureMapping<MessageToSaga>(m => m.ContextId)
+                        .ToSaga(s => s.ContextId);
                 }
 
                 public class NotFoundHandlerSaga1Data : ContainSagaData

--- a/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_replying_to_originator.cs
+++ b/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_replying_to_originator.cs
@@ -6,7 +6,6 @@ namespace NServiceBus.AcceptanceTests.Sagas
     using EndpointTemplates;
     using Features;
     using NUnit.Framework;
-    using Persistence.Sql;
 
     public class When_replying_to_originator : NServiceBusAcceptanceTest
     {
@@ -33,7 +32,7 @@ namespace NServiceBus.AcceptanceTests.Sagas
                 EndpointSetup<DefaultServer>(config => config.EnableFeature<TimeoutManager>());
             }
 
-            public class RequestResponseRequestingSaga2 : SqlSaga<RequestResponseRequestingSaga2.RequestResponseRequestingSagaData2>,
+            public class RequestResponseRequestingSaga2 : Saga<RequestResponseRequestingSaga2.RequestResponseRequestingSagaData2>,
                 IAmStartedByMessages<InitiateRequestingSaga>,
                 IHandleMessages<ResponseFromOtherSaga>
             {
@@ -56,11 +55,10 @@ namespace NServiceBus.AcceptanceTests.Sagas
                     return Task.FromResult(0);
                 }
 
-                protected override string CorrelationPropertyName => nameof(RequestResponseRequestingSagaData2.CorrIdForResponse);
-                protected override void ConfigureMapping(IMessagePropertyMapper mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<RequestResponseRequestingSagaData2> mapper)
                 {
-                    mapper.ConfigureMapping<InitiateRequestingSaga>(m => m.Id);
-                    mapper.ConfigureMapping<ResponseFromOtherSaga>(m => m.SomeCorrelationId);
+                    mapper.ConfigureMapping<InitiateRequestingSaga>(m => m.Id).ToSaga(s => s.CorrIdForResponse);
+                    mapper.ConfigureMapping<ResponseFromOtherSaga>(m => m.SomeCorrelationId).ToSaga(s => s.CorrIdForResponse);
                 }
 
                 public class RequestResponseRequestingSagaData2 : ContainSagaData
@@ -69,8 +67,7 @@ namespace NServiceBus.AcceptanceTests.Sagas
                 }
             }
 
-            public class RequestResponseRespondingSaga2 :
-                SqlSaga<RequestResponseRespondingSaga2.RequestResponseRespondingSagaData2>,
+            public class RequestResponseRespondingSaga2 : Saga<RequestResponseRespondingSaga2.RequestResponseRespondingSagaData2>,
                 IAmStartedByMessages<RequestToRespondingSaga>,
                 IHandleMessages<SendReplyFromNonInitiatingHandler>
             {
@@ -87,17 +84,17 @@ namespace NServiceBus.AcceptanceTests.Sagas
                 public Task Handle(SendReplyFromNonInitiatingHandler message, IMessageHandlerContext context)
                 {
                     //reply to originator must be used here since the sender of the incoming message is this saga and not the requesting saga
-                    return ReplyToOriginator(context, new ResponseFromOtherSaga
+                    return ReplyToOriginator(context, new ResponseFromOtherSaga 
                     {
                         SomeCorrelationId = Data.CorrIdForRequest
                     });
                 }
-                protected override string CorrelationPropertyName => nameof(RequestResponseRespondingSagaData2.CorrIdForRequest);
-                protected override void ConfigureMapping(IMessagePropertyMapper mapper)
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<RequestResponseRespondingSagaData2> mapper)
                 {
-                    mapper.ConfigureMapping<RequestToRespondingSaga>(m => m.SomeIdThatTheResponseSagaCanCorrelateBackToUs);
+                    mapper.ConfigureMapping<RequestToRespondingSaga>(m => m.SomeIdThatTheResponseSagaCanCorrelateBackToUs).ToSaga(s => s.CorrIdForRequest);
                     //this line is just needed so we can test the non-initiating handler case
-                    mapper.ConfigureMapping<SendReplyFromNonInitiatingHandler>(m => m.SagaIdSoWeCanCorrelate);
+                    mapper.ConfigureMapping<SendReplyFromNonInitiatingHandler>(m => m.SagaIdSoWeCanCorrelate).ToSaga(s => s.CorrIdForRequest);
                 }
 
                 public class RequestResponseRespondingSagaData2 : ContainSagaData

--- a/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_replying_to_saga_event.cs
+++ b/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_replying_to_saga_event.cs
@@ -6,7 +6,6 @@
     using EndpointTemplates;
     using Features;
     using NUnit.Framework;
-    using Persistence.Sql;
 
     public class When_replying_to_saga_event : NServiceBusAcceptanceTest
     {
@@ -71,11 +70,9 @@
                 });
             }
 
-            public class ReplyToPubMsgSaga : SqlSaga<ReplyToPubMsgSaga.ReplyToPubMsgSagaData>, IAmStartedByMessages<StartSaga>, IHandleMessages<DidSomethingResponse>
+            public class ReplyToPubMsgSaga : Saga<ReplyToPubMsgSaga.ReplyToPubMsgSagaData>, IAmStartedByMessages<StartSaga>, IHandleMessages<DidSomethingResponse>
             {
                 public Context Context { get; set; }
-
-                protected override string CorrelationPropertyName => nameof(ReplyToPubMsgSagaData.DataId);
 
                 public Task Handle(StartSaga message, IMessageHandlerContext context)
                 {
@@ -91,9 +88,9 @@
                     return Task.FromResult(0);
                 }
 
-                protected override void ConfigureMapping(IMessagePropertyMapper mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<ReplyToPubMsgSagaData> mapper)
                 {
-                    mapper.ConfigureMapping<StartSaga>(m => m.DataId);
+                    mapper.ConfigureMapping<StartSaga>(m => m.DataId).ToSaga(s => s.DataId);
                 }
 
                 public class ReplyToPubMsgSagaData : ContainSagaData

--- a/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_saga_exists_for_start_message.cs
+++ b/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_saga_exists_for_start_message.cs
@@ -6,7 +6,6 @@
     using AcceptanceTesting;
     using EndpointTemplates;
     using NUnit.Framework;
-    using Persistence.Sql;
 
     public class When_saga_exists_for_start_message : NServiceBusAcceptanceTest
     {
@@ -48,10 +47,9 @@
                 EndpointSetup<DefaultServer>(c => c.LimitMessageProcessingConcurrencyTo(1));
             }
 
-            public class TestSaga05 : SqlSaga<TestSagaData05>, IAmStartedByMessages<StartSagaMessage>
+            public class TestSaga05 : Saga<TestSagaData05>, IAmStartedByMessages<StartSagaMessage>
             {
                 public Context TestContext { get; set; }
-                protected override string CorrelationPropertyName => nameof(TestSagaData05.SomeId);
 
                 public Task Handle(StartSagaMessage message, IMessageHandlerContext context)
                 {
@@ -60,9 +58,10 @@
                     return Task.FromResult(0);
                 }
 
-                protected override void ConfigureMapping(IMessagePropertyMapper mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TestSagaData05> mapper)
                 {
-                    mapper.ConfigureMapping<StartSagaMessage>(m => m.SomeId);
+                    mapper.ConfigureMapping<StartSagaMessage>(m => m.SomeId)
+                        .ToSaga(s => s.SomeId);
                 }
             }
 

--- a/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_saga_handles_unmapped_message.cs
+++ b/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_saga_handles_unmapped_message.cs
@@ -6,7 +6,6 @@
     using AcceptanceTesting;
     using EndpointTemplates;
     using NUnit.Framework;
-    using Persistence.Sql;
 
     public class When_saga_handles_unmapped_message : NServiceBusAcceptanceTest
     {
@@ -50,19 +49,17 @@
                 EndpointSetup<DefaultServer>();
             }
 
-            public class UnmappedMsgSaga : SqlSaga<UnmappedMsgSagaData>,
+            public class UnmappedMsgSaga : Saga<UnmappedMsgSagaData>,
                 IAmStartedByMessages<StartSagaMessage>,
                 IHandleMessages<MappedEchoMessage>,
                 IHandleMessages<EchoMessage>
             {
-                protected override string CorrelationPropertyName => nameof(UnmappedMsgSagaData.SomeId);
-
                 public Context Context { get; set; }
 
-                protected override void ConfigureMapping(IMessagePropertyMapper mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<UnmappedMsgSagaData> mapper)
                 {
-                    mapper.ConfigureMapping<StartSagaMessage>(msg => msg.SomeId);
-                    mapper.ConfigureMapping<MappedEchoMessage>(msg => msg.SomeId);
+                    mapper.ConfigureMapping<StartSagaMessage>(msg => msg.SomeId).ToSaga(saga => saga.SomeId);
+                    mapper.ConfigureMapping<MappedEchoMessage>(msg => msg.SomeId).ToSaga(saga => saga.SomeId);
                     // No mapping for EchoMessage, so saga can't possibly be found
                 }
 

--- a/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_saga_has_a_non_empty_constructor.cs
+++ b/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_saga_has_a_non_empty_constructor.cs
@@ -5,7 +5,6 @@
     using AcceptanceTesting;
     using EndpointTemplates;
     using NUnit.Framework;
-    using Persistence.Sql;
 
     public class When_saga_has_a_non_empty_constructor : NServiceBusAcceptanceTest
     {
@@ -35,12 +34,10 @@
                 EndpointSetup<DefaultServer>();
             }
 
-            public class TestSaga11 : SqlSaga<TestSagaData11>,
+            public class TestSaga11 : Saga<TestSagaData11>,
                 IAmStartedByMessages<StartSagaMessage>,
                 IHandleMessages<OtherMessage>
             {
-                protected override string CorrelationPropertyName => nameof(TestSagaData11.SomeId);
-
                 public TestSaga11(Context testContext)
                 {
                     this.testContext = testContext;
@@ -61,10 +58,12 @@
                     return Task.FromResult(0);
                 }
 
-                protected override void ConfigureMapping(IMessagePropertyMapper mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TestSagaData11> mapper)
                 {
-                    mapper.ConfigureMapping<StartSagaMessage>(m => m.SomeId);
-                    mapper.ConfigureMapping<OtherMessage>(m => m.SomeId);
+                    mapper.ConfigureMapping<StartSagaMessage>(m => m.SomeId)
+                        .ToSaga(s => s.SomeId);
+                    mapper.ConfigureMapping<OtherMessage>(m => m.SomeId)
+                        .ToSaga(s => s.SomeId);
                 }
 
                 Context testContext;

--- a/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_saga_id_changed.cs
+++ b/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_saga_id_changed.cs
@@ -7,7 +7,6 @@
     using AcceptanceTesting.Support;
     using EndpointTemplates;
     using NUnit.Framework;
-    using Persistence.Sql;
 
     [TestFixture]
     public class When_saga_id_changed : NServiceBusAcceptanceTest
@@ -42,7 +41,7 @@
                 EndpointSetup<DefaultServer>();
             }
 
-            public class SagaIdChangedSaga : SqlSaga<SagaIdChangedSaga.SagaIdChangedSagaData>,
+            public class SagaIdChangedSaga : Saga<SagaIdChangedSaga.SagaIdChangedSagaData>,
                 IAmStartedByMessages<StartSaga>
             {
                 public Context TestContext { get; set; }
@@ -54,10 +53,9 @@
                     return Task.FromResult(0);
                 }
 
-                protected override string CorrelationPropertyName => nameof(SagaIdChangedSagaData.DataId);
-                protected override void ConfigureMapping(IMessagePropertyMapper mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaIdChangedSagaData> mapper)
                 {
-                    mapper.ConfigureMapping<StartSaga>(m => m.DataId);
+                    mapper.ConfigureMapping<StartSaga>(m => m.DataId).ToSaga(s => s.DataId);
                 }
 
                 public class SagaIdChangedSagaData : ContainSagaData

--- a/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_saga_is_mapped_to_complex_expression.cs
+++ b/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_saga_is_mapped_to_complex_expression.cs
@@ -5,7 +5,6 @@
     using AcceptanceTesting;
     using EndpointTemplates;
     using NUnit.Framework;
-    using NServiceBus.Persistence.Sql;
 
     public class When_saga_is_mapped_to_complex_expression : NServiceBusAcceptanceTest
     {
@@ -46,7 +45,7 @@
                 EndpointSetup<DefaultServer>(c => c.LimitMessageProcessingConcurrencyTo(1));
             }
 
-            public class TestSaga02 : SqlSaga<TestSagaData02>,
+            public class TestSaga02 : Saga<TestSagaData02>,
                 IAmStartedByMessages<StartSagaMessage>, IAmStartedByMessages<OtherMessage>
             {
                 public Context Context { get; set; }
@@ -65,12 +64,13 @@
                     return Task.FromResult(0);
                 }
 
-                protected override string CorrelationPropertyName => nameof(TestSagaData02.KeyValue);
-
-                protected override void ConfigureMapping(IMessagePropertyMapper mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TestSagaData02> mapper)
                 {
-                    mapper.ConfigureMapping<StartSagaMessage>(m => m.Key);
-                    mapper.ConfigureMapping<OtherMessage>(m => m.Part1 + "_" + m.Part2);
+                    mapper.ConfigureMapping<StartSagaMessage>(m => m.Key)
+                        .ToSaga(s => s.KeyValue);
+
+                    mapper.ConfigureMapping<OtherMessage>(m => m.Part1 + "_" + m.Part2)
+                        .ToSaga(s => s.KeyValue);
                 }
             }
 

--- a/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_saga_message_goes_through_delayed_retries.cs
+++ b/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_saga_message_goes_through_delayed_retries.cs
@@ -6,7 +6,6 @@
     using EndpointTemplates;
     using Features;
     using NUnit.Framework;
-    using Persistence.Sql;
 
     //repro for issue: https://github.com/NServiceBus/NServiceBus/issues/1020
     public class When_saga_message_goes_through_delayed_retries : NServiceBusAcceptanceTest
@@ -46,12 +45,10 @@
                 });
             }
 
-            public class DelayedRetryTestingSaga : SqlSaga<DelayedRetryTestingSagaData>,
+            public class DelayedRetryTestingSaga : Saga<DelayedRetryTestingSagaData>,
                 IAmStartedByMessages<StartSagaMessage>,
                 IHandleMessages<SecondSagaMessage>
             {
-                protected override string CorrelationPropertyName => nameof(DelayedRetryTestingSagaData.SomeId);
-
                 public Context TestContext { get; set; }
 
                 public Task Handle(StartSagaMessage message, IMessageHandlerContext context)
@@ -78,10 +75,12 @@
                     return Task.FromResult(0);
                 }
 
-                protected override void ConfigureMapping(IMessagePropertyMapper mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<DelayedRetryTestingSagaData> mapper)
                 {
-                    mapper.ConfigureMapping<StartSagaMessage>(m => m.SomeId);
-                    mapper.ConfigureMapping<SecondSagaMessage>(m => m.SomeId);
+                    mapper.ConfigureMapping<StartSagaMessage>(m => m.SomeId)
+                        .ToSaga(s => s.SomeId);
+                    mapper.ConfigureMapping<SecondSagaMessage>(m => m.SomeId)
+                        .ToSaga(s => s.SomeId);
                 }
             }
 

--- a/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_sagas_cant_be_found.cs
+++ b/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_sagas_cant_be_found.cs
@@ -7,7 +7,6 @@
     using Features;
     using NServiceBus.Sagas;
     using NUnit.Framework;
-    using Persistence.Sql;
 
     public partial class When_sagas_cant_be_found : NServiceBusAcceptanceTest
     {
@@ -52,7 +51,7 @@
                 EndpointSetup<DefaultServer>(config => config.EnableFeature<TimeoutManager>());
             }
 
-            public class CantBeFoundSaga1 : SqlSaga<CantBeFoundSaga1.CantBeFoundSaga1Data>, IAmStartedByMessages<StartSaga>, IHandleMessages<MessageToSaga>
+            public class CantBeFoundSaga1 : Saga<CantBeFoundSaga1.CantBeFoundSaga1Data>, IAmStartedByMessages<StartSaga>, IHandleMessages<MessageToSaga>
             {
                 public Task Handle(StartSaga message, IMessageHandlerContext context)
                 {
@@ -65,12 +64,10 @@
                     return Task.FromResult(0);
                 }
 
-
-                protected override string CorrelationPropertyName => nameof(CantBeFoundSaga1Data.MessageId);
-                protected override void ConfigureMapping(IMessagePropertyMapper mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<CantBeFoundSaga1Data> mapper)
                 {
-                    mapper.ConfigureMapping<StartSaga>(m => m.Id);
-                    mapper.ConfigureMapping<MessageToSaga>(m => m.Id);
+                    mapper.ConfigureMapping<StartSaga>(m => m.Id).ToSaga(s => s.MessageId);
+                    mapper.ConfigureMapping<MessageToSaga>(m => m.Id).ToSaga(s => s.MessageId);
                 }
 
                 public class CantBeFoundSaga1Data : ContainSagaData
@@ -79,7 +76,7 @@
                 }
             }
 
-            public class CantBeFoundSaga2 : SqlSaga<CantBeFoundSaga2.CantBeFoundSaga2Data>, IAmStartedByMessages<StartSaga>, IHandleMessages<MessageToSaga>
+            public class CantBeFoundSaga2 : Saga<CantBeFoundSaga2.CantBeFoundSaga2Data>, IAmStartedByMessages<StartSaga>, IHandleMessages<MessageToSaga>
             {
                 public Task Handle(StartSaga message, IMessageHandlerContext context)
                 {
@@ -92,18 +89,16 @@
                     return Task.FromResult(0);
                 }
 
-                protected override void ConfigureMapping(IMessagePropertyMapper mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<CantBeFoundSaga2Data> mapper)
                 {
-                    mapper.ConfigureMapping<StartSaga>(m => m.Id);
-                    mapper.ConfigureMapping<MessageToSaga>(m => m.Id);
+                    mapper.ConfigureMapping<StartSaga>(m => m.Id).ToSaga(s => s.MessageId);
+                    mapper.ConfigureMapping<MessageToSaga>(m => m.Id).ToSaga(s => s.MessageId);
                 }
 
                 public class CantBeFoundSaga2Data : ContainSagaData
                 {
                     public virtual Guid MessageId { get; set; }
                 }
-
-                protected override string CorrelationPropertyName => nameof(CantBeFoundSaga2Data.MessageId);
             }
 
             public class SagaNotFound : IHandleSagaNotFound
@@ -130,7 +125,7 @@
                 });
             }
 
-            public class ReceiverWithOrderedSagasSaga1 : SqlSaga<ReceiverWithOrderedSagasSaga1.ReceiverWithOrderedSagasSaga1Data>, IAmStartedByMessages<StartSaga>, IHandleMessages<MessageToSaga>
+            public class ReceiverWithOrderedSagasSaga1 : Saga<ReceiverWithOrderedSagasSaga1.ReceiverWithOrderedSagasSaga1Data>, IAmStartedByMessages<StartSaga>, IHandleMessages<MessageToSaga>
             {
                 public Task Handle(StartSaga message, IMessageHandlerContext context)
                 {
@@ -143,12 +138,10 @@
                     return Task.FromResult(0);
                 }
 
-                protected override string CorrelationPropertyName => nameof(ReceiverWithOrderedSagasSaga1Data.MessageId);
-
-                protected override void ConfigureMapping(IMessagePropertyMapper mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<ReceiverWithOrderedSagasSaga1Data> mapper)
                 {
-                    mapper.ConfigureMapping<StartSaga>(m => m.Id);
-                    mapper.ConfigureMapping<MessageToSaga>(m => m.Id);
+                    mapper.ConfigureMapping<StartSaga>(m => m.Id).ToSaga(s => s.MessageId);
+                    mapper.ConfigureMapping<MessageToSaga>(m => m.Id).ToSaga(s => s.MessageId);
                 }
 
                 public class ReceiverWithOrderedSagasSaga1Data : ContainSagaData
@@ -157,7 +150,7 @@
                 }
             }
 
-            public class ReceiverWithOrderedSagasSaga2 : SqlSaga<ReceiverWithOrderedSagasSaga2.ReceiverWithOrderedSagasSaga2Data>, IHandleMessages<StartSaga>, IAmStartedByMessages<MessageToSaga>
+            public class ReceiverWithOrderedSagasSaga2 : Saga<ReceiverWithOrderedSagasSaga2.ReceiverWithOrderedSagasSaga2Data>, IHandleMessages<StartSaga>, IAmStartedByMessages<MessageToSaga>
             {
                 public Context Context { get; set; }
 
@@ -174,11 +167,10 @@
                     return Task.FromResult(0);
                 }
 
-                protected override string CorrelationPropertyName => nameof(ReceiverWithOrderedSagasSaga2Data.MessageId);
-                protected override void ConfigureMapping(IMessagePropertyMapper mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<ReceiverWithOrderedSagasSaga2Data> mapper)
                 {
-                    mapper.ConfigureMapping<StartSaga>(m => m.Id);
-                    mapper.ConfigureMapping<MessageToSaga>(m => m.Id);
+                    mapper.ConfigureMapping<StartSaga>(m => m.Id).ToSaga(s => s.MessageId);
+                    mapper.ConfigureMapping<MessageToSaga>(m => m.Id).ToSaga(s => s.MessageId);
                 }
 
                 public class ReceiverWithOrderedSagasSaga2Data : ContainSagaData

--- a/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_sagas_share_timeout_messages.cs
+++ b/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_sagas_share_timeout_messages.cs
@@ -6,7 +6,6 @@
     using EndpointTemplates;
     using Features;
     using NUnit.Framework;
-    using Persistence.Sql;
 
     public class When_sagas_share_timeout_messages : NServiceBusAcceptanceTest
     {
@@ -41,17 +40,15 @@
                 });
             }
 
-            public class TimeoutSharingSaga1 : SqlSaga<TimeoutSharingSaga1.TimeoutSharingSagaData1>,
+            public class TimeoutSharingSaga1 : Saga<TimeoutSharingSaga1.TimeoutSharingSagaData1>,
                 IAmStartedByMessages<StartSagaMessage>,
                 IHandleTimeouts<MySagaTimeout>
             {
-                protected override string CorrelationPropertyName => nameof(TimeoutSharingSagaData1.CorrelationProperty);
-
                 public Context Context { get; set; }
 
-                protected override void ConfigureMapping(IMessagePropertyMapper mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TimeoutSharingSagaData1> mapper)
                 {
-                    mapper.ConfigureMapping<StartSagaMessage>(m => m.Id);
+                    mapper.ConfigureMapping<StartSagaMessage>(m => m.Id).ToSaga(s => s.CorrelationProperty);
                 }
 
                 public Task Handle(StartSagaMessage message, IMessageHandlerContext context)
@@ -72,15 +69,13 @@
 
             }
 
-            public class TimeoutSharingSaga2 : SqlSaga<TimeoutSharingSaga2.TimeoutSharingSagaData2>, IAmStartedByMessages<StartSagaMessage>, IHandleTimeouts<MySagaTimeout>
+            public class TimeoutSharingSaga2 : Saga<TimeoutSharingSaga2.TimeoutSharingSagaData2>, IAmStartedByMessages<StartSagaMessage>, IHandleTimeouts<MySagaTimeout>
             {
-                protected override string CorrelationPropertyName => nameof(TimeoutSharingSagaData2.CorrelationProperty);
-
                 public Context Context { get; set; }
 
-                protected override void ConfigureMapping(IMessagePropertyMapper mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TimeoutSharingSagaData2> mapper)
                 {
-                    mapper.ConfigureMapping<StartSagaMessage>(m => m.Id);
+                    mapper.ConfigureMapping<StartSagaMessage>(m => m.Id).ToSaga(s => s.CorrelationProperty);
                 }
 
                 public Task Handle(StartSagaMessage message, IMessageHandlerContext context)

--- a/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_sending_from_a_saga_handle.cs
+++ b/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_sending_from_a_saga_handle.cs
@@ -6,7 +6,6 @@
     using EndpointTemplates;
     using Features;
     using NUnit.Framework;
-    using Persistence.Sql;
 
     public class When_sending_from_a_saga_handle : NServiceBusAcceptanceTest
     {
@@ -36,10 +35,8 @@
                 EndpointSetup<DefaultServer>(config => config.EnableFeature<TimeoutManager>());
             }
 
-            public class TwoSaga1Saga1 : SqlSaga<TwoSaga1Saga1Data>, IAmStartedByMessages<StartSaga1>, IHandleMessages<MessageSaga1WillHandle>
+            public class TwoSaga1Saga1 : Saga<TwoSaga1Saga1Data>, IAmStartedByMessages<StartSaga1>, IHandleMessages<MessageSaga1WillHandle>
             {
-                protected override string CorrelationPropertyName => nameof(TwoSaga1Saga1Data.DataId);
-
                 public Task Handle(StartSaga1 message, IMessageHandlerContext context)
                 {
                     Data.DataId = message.DataId;
@@ -58,10 +55,10 @@
                     MarkAsComplete();
                 }
 
-                protected override void ConfigureMapping(IMessagePropertyMapper mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TwoSaga1Saga1Data> mapper)
                 {
-                    mapper.ConfigureMapping<MessageSaga1WillHandle>(m => m.DataId);
-                    mapper.ConfigureMapping<StartSaga1>(m => m.DataId);
+                    mapper.ConfigureMapping<MessageSaga1WillHandle>(m => m.DataId).ToSaga(s => s.DataId);
+                    mapper.ConfigureMapping<StartSaga1>(m => m.DataId).ToSaga(s => s.DataId);
                 }
             }
 
@@ -70,10 +67,8 @@
                 public virtual Guid DataId { get; set; }
             }
 
-            public class TwoSaga1Saga2 : SqlSaga<TwoSaga1Saga2.TwoSaga1Saga2Data>, IAmStartedByMessages<StartSaga2>
+            public class TwoSaga1Saga2 : Saga<TwoSaga1Saga2.TwoSaga1Saga2Data>, IAmStartedByMessages<StartSaga2>
             {
-                protected override string CorrelationPropertyName => nameof(TwoSaga1Saga2Data.DataId);
-
                 public Context Context { get; set; }
 
                 public Task Handle(StartSaga2 message, IMessageHandlerContext context)
@@ -84,9 +79,9 @@
                     return Task.FromResult(0);
                 }
 
-                protected override void ConfigureMapping(IMessagePropertyMapper mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TwoSaga1Saga2Data> mapper)
                 {
-                    mapper.ConfigureMapping<StartSaga2>(m => m.DataId);
+                    mapper.ConfigureMapping<StartSaga2>(m => m.DataId).ToSaga(s => s.DataId);
                 }
 
                 public class TwoSaga1Saga2Data : ContainSagaData

--- a/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_sending_from_a_saga_timeout.cs
+++ b/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_sending_from_a_saga_timeout.cs
@@ -6,7 +6,6 @@
     using EndpointTemplates;
     using Features;
     using NUnit.Framework;
-    using Persistence.Sql;
 
     public class When_sending_from_a_saga_timeout : NServiceBusAcceptanceTest
     {
@@ -36,12 +35,10 @@
                 EndpointSetup<DefaultServer>(config => config.EnableFeature<TimeoutManager>());
             }
 
-            public class SendFromTimeoutSaga1 : SqlSaga<SendFromTimeoutSaga1.SendFromTimeoutSaga1Data>,
+            public class SendFromTimeoutSaga1 : Saga<SendFromTimeoutSaga1.SendFromTimeoutSaga1Data>,
                 IAmStartedByMessages<StartSaga1>,
                 IHandleTimeouts<Saga1Timeout>
             {
-                protected override string CorrelationPropertyName => nameof(SendFromTimeoutSaga1Data.DataId);
-
                 public Context TestContext { get; set; }
 
                 public Task Handle(StartSaga1 message, IMessageHandlerContext context)
@@ -59,9 +56,9 @@
                     MarkAsComplete();
                 }
 
-                protected override void ConfigureMapping(IMessagePropertyMapper mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SendFromTimeoutSaga1Data> mapper)
                 {
-                    mapper.ConfigureMapping<StartSaga1>(m => m.DataId);
+                    mapper.ConfigureMapping<StartSaga1>(m => m.DataId).ToSaga(s => s.DataId);
                 }
 
                 public class SendFromTimeoutSaga1Data : ContainSagaData
@@ -70,10 +67,8 @@
                 }
             }
 
-            public class SendFromTimeoutSaga2 : SqlSaga<SendFromTimeoutSaga2.SendFromTimeoutSaga2Data>, IAmStartedByMessages<StartSaga2>
+            public class SendFromTimeoutSaga2 : Saga<SendFromTimeoutSaga2.SendFromTimeoutSaga2Data>, IAmStartedByMessages<StartSaga2>
             {
-                protected override string CorrelationPropertyName => nameof(SendFromTimeoutSaga2Data.DataId);
-
                 public Context Context { get; set; }
 
                 public Task Handle(StartSaga2 message, IMessageHandlerContext context)
@@ -83,9 +78,9 @@
                     return Task.FromResult(0);
                 }
 
-                protected override void ConfigureMapping(IMessagePropertyMapper mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SendFromTimeoutSaga2Data> mapper)
                 {
-                    mapper.ConfigureMapping<StartSaga2>(m => m.DataId);
+                    mapper.ConfigureMapping<StartSaga2>(m => m.DataId).ToSaga(s => s.DataId);
                 }
 
                 public class SendFromTimeoutSaga2Data : ContainSagaData

--- a/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_started_by_base_event_from_other_saga.cs
+++ b/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_started_by_base_event_from_other_saga.cs
@@ -6,7 +6,6 @@
     using EndpointTemplates;
     using Features;
     using NUnit.Framework;
-    using Persistence.Sql;
 
     //Repro for #1323
     public class When_started_by_base_event_from_other_saga : NServiceBusAcceptanceTest
@@ -65,10 +64,9 @@
                 metadata => metadata.RegisterPublisherFor<BaseEvent>(typeof(Publisher)));
             }
 
-            public class SagaStartedByBaseEvent : SqlSaga<SagaStartedByBaseEvent.SagaStartedByBaseEventSagaData>, IAmStartedByMessages<BaseEvent>
+            public class SagaStartedByBaseEvent : Saga<SagaStartedByBaseEvent.SagaStartedByBaseEventSagaData>, IAmStartedByMessages<BaseEvent>
             {
                 public SagaContext Context { get; set; }
-                protected override string CorrelationPropertyName => nameof(SagaStartedByBaseEventSagaData.DataId);
 
                 public Task Handle(BaseEvent message, IMessageHandlerContext context)
                 {
@@ -78,9 +76,9 @@
                     return Task.FromResult(0);
                 }
 
-                protected override void ConfigureMapping(IMessagePropertyMapper mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaStartedByBaseEventSagaData> mapper)
                 {
-                    mapper.ConfigureMapping<BaseEvent>(m => m.DataId);
+                    mapper.ConfigureMapping<BaseEvent>(m => m.DataId).ToSaga(s => s.DataId);
                 }
 
                 public class SagaStartedByBaseEventSagaData : ContainSagaData

--- a/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_started_by_event_from_another_saga.cs
+++ b/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_started_by_event_from_another_saga.cs
@@ -6,8 +6,6 @@
     using EndpointTemplates;
     using Features;
     using NUnit.Framework;
-    using Persistence.Sql;
-    using Routing;
 
     //Repro for #1323
     public class When_started_by_event_from_another_saga : NServiceBusAcceptanceTest
@@ -57,12 +55,10 @@
                 });
             }
 
-            public class EventFromOtherSaga1 : SqlSaga<EventFromOtherSaga1.EventFromOtherSaga1Data>,
+            public class EventFromOtherSaga1 : Saga<EventFromOtherSaga1.EventFromOtherSaga1Data>,
                 IAmStartedByMessages<StartSaga>,
                 IHandleTimeouts<EventFromOtherSaga1.Timeout1>
             {
-                protected override string CorrelationPropertyName => nameof(EventFromOtherSaga1Data.DataId);
-
                 public Context TestContext { get; set; }
 
                 public async Task Handle(StartSaga message, IMessageHandlerContext context)
@@ -83,9 +79,9 @@
                     return Task.FromResult(0);
                 }
 
-                protected override void ConfigureMapping(IMessagePropertyMapper mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<EventFromOtherSaga1Data> mapper)
                 {
-                    mapper.ConfigureMapping<StartSaga>(m => m.DataId);
+                    mapper.ConfigureMapping<StartSaga>(m => m.DataId).ToSaga(s => s.DataId);
                 }
 
                 public class EventFromOtherSaga1Data : ContainSagaData
@@ -111,12 +107,10 @@
                 metadata => metadata.RegisterPublisherFor<SomethingHappenedEvent>(typeof(SagaThatPublishesAnEvent)));
             }
 
-            public class EventFromOtherSaga2 : SqlSaga<EventFromOtherSaga2.EventFromOtherSaga2Data>,
+            public class EventFromOtherSaga2 : Saga<EventFromOtherSaga2.EventFromOtherSaga2Data>,
                 IAmStartedByMessages<SomethingHappenedEvent>,
                 IHandleTimeouts<EventFromOtherSaga2.Saga2Timeout>
             {
-                protected override string CorrelationPropertyName => nameof(EventFromOtherSaga2Data.DataId);
-
                 public Context Context { get; set; }
 
                 public Task Handle(SomethingHappenedEvent message, IMessageHandlerContext context)
@@ -133,9 +127,9 @@
                     return Task.FromResult(0);
                 }
 
-                protected override void ConfigureMapping(IMessagePropertyMapper mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<EventFromOtherSaga2Data> mapper)
                 {
-                    mapper.ConfigureMapping<SomethingHappenedEvent>(m => m.DataId);
+                    mapper.ConfigureMapping<SomethingHappenedEvent>(m => m.DataId).ToSaga(s => s.DataId);
                 }
 
                 public class EventFromOtherSaga2Data : ContainSagaData

--- a/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_timeout_hit_not_found_saga.cs
+++ b/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_timeout_hit_not_found_saga.cs
@@ -7,7 +7,6 @@
     using Features;
     using NServiceBus.Sagas;
     using NUnit.Framework;
-    using Persistence.Sql;
 
     public class When_timeout_hit_not_found_saga : NServiceBusAcceptanceTest
     {
@@ -38,14 +37,12 @@
                 EndpointSetup<DefaultServer>(config => config.EnableFeature<TimeoutManager>());
             }
 
-            public class TimeoutHitsNotFoundSaga : SqlSaga<TimeoutHitsNotFoundSaga.TimeoutHitsNotFoundSagaData>,
+            public class TimeoutHitsNotFoundSaga : Saga<TimeoutHitsNotFoundSaga.TimeoutHitsNotFoundSagaData>,
                 IAmStartedByMessages<StartSaga>,
                 IHandleSagaNotFound,
                 IHandleTimeouts<TimeoutHitsNotFoundSaga.MyTimeout>,
                 IHandleMessages<SomeOtherMessage>
             {
-                protected override string CorrelationPropertyName => nameof(TimeoutHitsNotFoundSagaData.DataId);
-
                 public Context TestContext { get; set; }
 
                 public async Task Handle(StartSaga message, IMessageHandlerContext context)
@@ -86,10 +83,10 @@
                     return Task.FromResult(0);
                 }
 
-                protected override void ConfigureMapping(IMessagePropertyMapper mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TimeoutHitsNotFoundSagaData> mapper)
                 {
-                    mapper.ConfigureMapping<StartSaga>(m => m.DataId);
-                    mapper.ConfigureMapping<SomeOtherMessage>(m => m.DataId);
+                    mapper.ConfigureMapping<StartSaga>(m => m.DataId).ToSaga(s => s.DataId);
+                    mapper.ConfigureMapping<SomeOtherMessage>(m => m.DataId).ToSaga(s => s.DataId);
                 }
 
                 public class TimeoutHitsNotFoundSagaData : ContainSagaData

--- a/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_two_sagas_subscribe_to_the_same_event.cs
+++ b/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_two_sagas_subscribe_to_the_same_event.cs
@@ -7,8 +7,6 @@
     using EndpointTemplates;
     using Features;
     using NUnit.Framework;
-    using Persistence.Sql;
-    using Routing;
 
     // Repro for issue  https://github.com/NServiceBus/NServiceBus/issues/1277
     public class When_two_sagas_subscribe_to_the_same_event : NServiceBusAcceptanceTest
@@ -75,7 +73,7 @@
                     metadata => metadata.RegisterPublisherFor<GroupPendingEvent>(typeof(Publisher)));
             }
 
-            public class Saga1 : SqlSaga<Saga1.MySaga1Data>,
+            public class Saga1 : Saga<Saga1.MySaga1Data>,
                 IAmStartedByMessages<GroupPendingEvent>,
                 IHandleMessages<CompleteSaga1Now>
             {
@@ -98,11 +96,10 @@
                     return Task.FromResult(0);
                 }
 
-                protected override string CorrelationPropertyName => nameof(MySaga1Data.DataId);
-                protected override void ConfigureMapping(IMessagePropertyMapper mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<MySaga1Data> mapper)
                 {
-                    mapper.ConfigureMapping<GroupPendingEvent>(m => m.DataId);
-                    mapper.ConfigureMapping<CompleteSaga1Now>(m => m.DataId);
+                    mapper.ConfigureMapping<GroupPendingEvent>(m => m.DataId).ToSaga(s => s.DataId);
+                    mapper.ConfigureMapping<CompleteSaga1Now>(m => m.DataId).ToSaga(s => s.DataId);
                 }
 
                 public class MySaga1Data : ContainSagaData
@@ -111,7 +108,7 @@
                 }
             }
 
-            public class Saga2 : SqlSaga<Saga2.MySaga2Data>,
+            public class Saga2 : Saga<Saga2.MySaga2Data>,
                 IAmStartedByMessages<StartSaga2>,
                 IHandleMessages<GroupPendingEvent>
             {
@@ -132,11 +129,10 @@
                     return Task.FromResult(0);
                 }
 
-                protected override string CorrelationPropertyName => nameof(MySaga2Data.DataId);
-                protected override void ConfigureMapping(IMessagePropertyMapper mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<MySaga2Data> mapper)
                 {
-                    mapper.ConfigureMapping<StartSaga2>(m => m.DataId);
-                    mapper.ConfigureMapping<GroupPendingEvent>(m => m.DataId);
+                    mapper.ConfigureMapping<StartSaga2>(m => m.DataId).ToSaga(s => s.DataId);
+                    mapper.ConfigureMapping<GroupPendingEvent>(m => m.DataId).ToSaga(s => s.DataId);
                 }
 
                 public class MySaga2Data : ContainSagaData

--- a/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_updating_existing_correlation_property.cs
+++ b/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_updating_existing_correlation_property.cs
@@ -7,7 +7,6 @@
     using AcceptanceTesting.Support;
     using EndpointTemplates;
     using NUnit.Framework;
-    using Persistence.Sql;
 
     public class When_updating_existing_correlation_property : NServiceBusAcceptanceTest
     {
@@ -42,7 +41,7 @@
                 EndpointSetup<DefaultServer>();
             }
 
-            public class ChangeCorrPropertySaga : SqlSaga<ChangeCorrPropertySagaData>, IAmStartedByMessages<StartSagaMessage>
+            public class ChangeCorrPropertySaga : Saga<ChangeCorrPropertySagaData>, IAmStartedByMessages<StartSagaMessage>
             {
                 public Context TestContext { get; set; }
 
@@ -62,10 +61,10 @@
                     });
                 }
 
-                protected override string CorrelationPropertyName => nameof(ChangeCorrPropertySagaData.SomeId);
-                protected override void ConfigureMapping(IMessagePropertyMapper mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<ChangeCorrPropertySagaData> mapper)
                 {
-                    mapper.ConfigureMapping<StartSagaMessage>(m => m.SomeId);
+                    mapper.ConfigureMapping<StartSagaMessage>(m => m.SomeId)
+                        .ToSaga(s => s.SomeId);
                 }
             }
 

--- a/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_using_a_received_message_for_timeout.cs
+++ b/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_using_a_received_message_for_timeout.cs
@@ -6,7 +6,6 @@
     using EndpointTemplates;
     using Features;
     using NUnit.Framework;
-    using Persistence.Sql;
 
     public class When_using_a_received_message_for_timeout : NServiceBusAcceptanceTest
     {
@@ -38,10 +37,8 @@
                 EndpointSetup<DefaultServer>(config => config.EnableFeature<TimeoutManager>());
             }
 
-            public class TestSaga01 : SqlSaga<TestSagaData01>, IAmStartedByMessages<StartSagaMessage>, IHandleTimeouts<StartSagaMessage>
+            public class TestSaga01 : Saga<TestSagaData01>, IAmStartedByMessages<StartSagaMessage>, IHandleTimeouts<StartSagaMessage>
             {
-                protected override string CorrelationPropertyName => nameof(TestSagaData01.SomeId);
-
                 public Context TestContext { get; set; }
 
                 public Task Handle(StartSagaMessage message, IMessageHandlerContext context)
@@ -57,9 +54,10 @@
                     return Task.FromResult(0);
                 }
 
-                protected override void ConfigureMapping(IMessagePropertyMapper mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TestSagaData01> mapper)
                 {
-                    mapper.ConfigureMapping<StartSagaMessage>(m => m.SomeId);
+                    mapper.ConfigureMapping<StartSagaMessage>(m => m.SomeId)
+                        .ToSaga(s => s.SomeId);
                 }
             }
 

--- a/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_using_contain_saga_data.cs
+++ b/src/AcceptanceTestsHolder/App_Packages/NSB.AcceptanceTests/Sagas/When_using_contain_saga_data.cs
@@ -6,7 +6,6 @@
     using EndpointTemplates;
     using Features;
     using NUnit.Framework;
-    using Persistence.Sql;
 
     public class When_using_contain_saga_data : NServiceBusAcceptanceTest
     {
@@ -37,12 +36,10 @@
                 EndpointSetup<DefaultServer>(config => config.EnableFeature<TimeoutManager>());
             }
 
-            public class MySaga : SqlSaga<MySaga.MySagaData>,
+            public class MySaga : Saga<MySaga.MySagaData>,
                 IAmStartedByMessages<StartSaga>,
                 IHandleTimeouts<MySaga.TimeHasPassed>
             {
-                protected override string CorrelationPropertyName => nameof(MySagaData.DataId);
-
                 public Context TestContext { get; set; }
 
                 public Task Handle(StartSaga message, IMessageHandlerContext context)
@@ -59,9 +56,9 @@
                     return Task.FromResult(0);
                 }
 
-                protected override void ConfigureMapping(IMessagePropertyMapper mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<MySagaData> mapper)
                 {
-                    mapper.ConfigureMapping<StartSaga>(m => m.DataId);
+                    mapper.ConfigureMapping<StartSaga>(m => m.DataId).ToSaga(s => s.DataId);
                 }
 
                 public class MySagaData : ContainSagaData

--- a/src/AcceptanceTestsHolder/App_Packages/When_using_intermediate_saga_base_class.cs
+++ b/src/AcceptanceTestsHolder/App_Packages/When_using_intermediate_saga_base_class.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using System.Threading.Tasks;
+using NServiceBus;
+using NServiceBus.AcceptanceTesting;
+using NServiceBus.AcceptanceTests;
+using NServiceBus.AcceptanceTests.EndpointTemplates;
+using NServiceBus.Persistence.Sql;
+using NUnit.Framework;
+
+[TestFixture]
+public class When_using_intermediate_saga_base_class : NServiceBusAcceptanceTest
+{
+    [Test]
+    public void Ensure_Core_Saga_will_throw()
+    {
+        PerformTestOn<CoreSagaBaseClassEndpoint>();
+    }
+
+    [Test]
+    public void Ensure_SqlSaga_will_throw()
+    {
+        PerformTestOn<SqlSagaBaseClassEndpoint>();
+    }
+
+    void PerformTestOn<TEndpointSelection>()
+        where TEndpointSelection : EndpointConfigurationBuilder
+    {
+        var ex = Assert.ThrowsAsync<Exception>(async () =>
+        {
+            await Scenario.Define<Context>()
+                .WithEndpoint<TEndpointSelection>(c => { c.When(session => session.SendLocal(new StartSaga { Correlation = "Corr" })); })
+                .Done(c => c.EndpointsStarted)
+                .Run()
+                .ConfigureAwait(false);
+        });
+
+        Assert.IsTrue(ex.Message == "Saga implementations must inherit from either Saga<T> or SqlSaga<T> directly. Deep class hierarchies are not supported.");
+    }
+
+    public class Context : ScenarioContext
+    {
+    }
+
+    public class CoreSagaBaseClassEndpoint : EndpointConfigurationBuilder
+    {
+        public CoreSagaBaseClassEndpoint()
+        {
+            EndpointSetup<DefaultServer>();
+        }
+
+        public class CoreSagaWithBase : BaseSaga
+        {
+            public class SagaData : ContainSagaData
+            {
+                public string Correlation { get; set; }
+            }
+
+            public override Task Handle(StartSaga message, IMessageHandlerContext context)
+            {
+                return Task.FromResult(0);
+            }
+        }
+
+        public class BaseSaga : Saga<CoreSagaWithBase.SagaData>,
+            IAmStartedByMessages<StartSaga>
+        {
+            protected override void ConfigureHowToFindSaga(SagaPropertyMapper<CoreSagaWithBase.SagaData> mapper)
+            {
+                mapper.ConfigureMapping<StartSaga>(msg => msg.Correlation).ToSaga(saga => saga.Correlation);
+            }
+
+
+            public virtual Task Handle(StartSaga message, IMessageHandlerContext context)
+            {
+                return Task.FromResult(0);
+            }
+        }
+
+    }
+
+    public class SqlSagaBaseClassEndpoint : EndpointConfigurationBuilder
+    {
+        public SqlSagaBaseClassEndpoint()
+        {
+            EndpointSetup<DefaultServer>();
+        }
+
+        public class SqlSagaWithBase : BaseSqlSaga,
+            IAmStartedByMessages<StartSaga>
+        {
+            public class SagaData : ContainSagaData
+            {
+                public string Correlation { get; set; }
+            }
+
+            protected override void ConfigureMapping(IMessagePropertyMapper mapper)
+            {
+                base.ConfigureMapping(mapper);
+                mapper.ConfigureMapping<StartSaga>(msg => msg.Correlation);
+            }
+
+            public Task Handle(StartSaga message, IMessageHandlerContext context)
+            {
+                return Task.FromResult(0);
+            }
+        }
+
+        public class BaseSqlSaga : SqlSaga<SqlSagaWithBase.SagaData>
+        {
+            protected override string CorrelationPropertyName => "Correlation";
+
+            protected override void ConfigureMapping(IMessagePropertyMapper mapper)
+            {
+
+            }
+        }
+    }
+
+    public class StartSaga : ICommand
+    {
+        public string Correlation { get; set; }
+    }
+
+}

--- a/src/AcceptanceTestsHolder/packages.config
+++ b/src/AcceptanceTestsHolder/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NServiceBus" version="7.0.0" targetFramework="net46" />
-  <package id="NServiceBus.AcceptanceTesting" version="7.0.0" targetFramework="net46" />
-  <package id="NServiceBus.AcceptanceTests.Sources" version="7.0.0" targetFramework="net46" />
+  <package id="NServiceBus" version="7.0.1" targetFramework="net46" />
+  <package id="NServiceBus.AcceptanceTesting" version="7.0.1" targetFramework="net46" />
+  <package id="NServiceBus.AcceptanceTests.Sources" version="7.0.1" targetFramework="net46" />
   <package id="NUnit" version="3.7.1" targetFramework="net46" />
 </packages>

--- a/src/NServiceBus.Persistence.Sql.sln
+++ b/src/NServiceBus.Persistence.Sql.sln
@@ -40,6 +40,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MsSqlAcceptanceTests.SqlTransport", "MsSqlAcceptanceTests.SqlTransport\MsSqlAcceptanceTests.SqlTransport.csproj", "{0E98C052-F67F-4826-A344-7685504CA955}"
 EndProject
+Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "VBTestCode", "VBTestCode\VBTestCode.vbproj", "{86E76F2D-6743-442E-BDAD-80D6A872D4FA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -106,6 +108,10 @@ Global
 		{0E98C052-F67F-4826-A344-7685504CA955}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0E98C052-F67F-4826-A344-7685504CA955}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0E98C052-F67F-4826-A344-7685504CA955}.Release|Any CPU.Build.0 = Release|Any CPU
+		{86E76F2D-6743-442E-BDAD-80D6A872D4FA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{86E76F2D-6743-442E-BDAD-80D6A872D4FA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{86E76F2D-6743-442E-BDAD-80D6A872D4FA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{86E76F2D-6743-442E-BDAD-80D6A872D4FA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/ScriptBuilder.Tests/ApprovalFiles/CoreSagaMetadataTests.AllowConcatenatingMsgProperties.approved.txt
+++ b/src/ScriptBuilder.Tests/ApprovalFiles/CoreSagaMetadataTests.AllowConcatenatingMsgProperties.approved.txt
@@ -1,0 +1,15 @@
+﻿{
+  "HasUnmanagedCalls": false,
+  "HasUnexpectedCalls": false,
+  "HasBranchingLogic": false,
+  "SagaDefinition": {
+    "TableSuffix": "ConcatMsgPropertiesSaga",
+    "CorrelationProperty": {
+      "Type": "String",
+      "Name": "Correlation"
+    },
+    "TransitionalCorrelationProperty": null,
+    "Name": "CoreSagaMetadataTests/ConcatMsgPropertiesSaga"
+  },
+  "Exception": null
+}

--- a/src/ScriptBuilder.Tests/ApprovalFiles/CoreSagaMetadataTests.AllowConcatenatingMsgPropertiesWithFormat.approved.txt
+++ b/src/ScriptBuilder.Tests/ApprovalFiles/CoreSagaMetadataTests.AllowConcatenatingMsgPropertiesWithFormat.approved.txt
@@ -1,0 +1,15 @@
+﻿{
+  "HasUnmanagedCalls": false,
+  "HasUnexpectedCalls": false,
+  "HasBranchingLogic": false,
+  "SagaDefinition": {
+    "TableSuffix": "ConcatMsgPropertiesWithFormatSaga",
+    "CorrelationProperty": {
+      "Type": "String",
+      "Name": "Correlation"
+    },
+    "TransitionalCorrelationProperty": null,
+    "Name": "CoreSagaMetadataTests/ConcatMsgPropertiesWithFormatSaga"
+  },
+  "Exception": null
+}

--- a/src/ScriptBuilder.Tests/ApprovalFiles/CoreSagaMetadataTests.AllowConcatenatingMsgPropertiesWithInterpolation.approved.txt
+++ b/src/ScriptBuilder.Tests/ApprovalFiles/CoreSagaMetadataTests.AllowConcatenatingMsgPropertiesWithInterpolation.approved.txt
@@ -1,0 +1,15 @@
+﻿{
+  "HasUnmanagedCalls": false,
+  "HasUnexpectedCalls": false,
+  "HasBranchingLogic": false,
+  "SagaDefinition": {
+    "TableSuffix": "ConcatMsgPropertiesWithInterpolationSaga",
+    "CorrelationProperty": {
+      "Type": "String",
+      "Name": "Correlation"
+    },
+    "TransitionalCorrelationProperty": null,
+    "Name": "CoreSagaMetadataTests/ConcatMsgPropertiesWithInterpolationSaga"
+  },
+  "Exception": null
+}

--- a/src/ScriptBuilder.Tests/ApprovalFiles/CoreSagaMetadataTests.AllowConcatenatingMsgPropertiesWithOtherMethods.approved.txt
+++ b/src/ScriptBuilder.Tests/ApprovalFiles/CoreSagaMetadataTests.AllowConcatenatingMsgPropertiesWithOtherMethods.approved.txt
@@ -1,0 +1,15 @@
+﻿{
+  "HasUnmanagedCalls": false,
+  "HasUnexpectedCalls": false,
+  "HasBranchingLogic": false,
+  "SagaDefinition": {
+    "TableSuffix": "ConcatMsgPropertiesWithOtherMethods",
+    "CorrelationProperty": {
+      "Type": "String",
+      "Name": "Correlation"
+    },
+    "TransitionalCorrelationProperty": null,
+    "Name": "CoreSagaMetadataTests/ConcatMsgPropertiesWithOtherMethods"
+  },
+  "Exception": null
+}

--- a/src/ScriptBuilder.Tests/ApprovalFiles/CoreSagaMetadataTests.DontAllowForLoop.approved.txt
+++ b/src/ScriptBuilder.Tests/ApprovalFiles/CoreSagaMetadataTests.DontAllowForLoop.approved.txt
@@ -1,0 +1,7 @@
+﻿{
+  "HasUnmanagedCalls": false,
+  "HasUnexpectedCalls": false,
+  "HasBranchingLogic": true,
+  "SagaDefinition": null,
+  "Exception": "Looping & branching statements are not allowed in a ConfigureHowToFindSaga method."
+}

--- a/src/ScriptBuilder.Tests/ApprovalFiles/CoreSagaMetadataTests.DontAllowMethodCallInMapping.approved.txt
+++ b/src/ScriptBuilder.Tests/ApprovalFiles/CoreSagaMetadataTests.DontAllowMethodCallInMapping.approved.txt
@@ -1,0 +1,7 @@
+﻿{
+  "HasUnmanagedCalls": false,
+  "HasUnexpectedCalls": true,
+  "HasBranchingLogic": false,
+  "SagaDefinition": null,
+  "Exception": "Unable to determine Saga correlation property because an unexpected method call was detected in the ConfigureHowToFindSaga method."
+}

--- a/src/ScriptBuilder.Tests/ApprovalFiles/CoreSagaMetadataTests.DontAllowPassingMapper.approved.txt
+++ b/src/ScriptBuilder.Tests/ApprovalFiles/CoreSagaMetadataTests.DontAllowPassingMapper.approved.txt
@@ -1,0 +1,7 @@
+﻿{
+  "HasUnmanagedCalls": false,
+  "HasUnexpectedCalls": true,
+  "HasBranchingLogic": false,
+  "SagaDefinition": null,
+  "Exception": "Unable to determine Saga correlation property because an unexpected method call was detected in the ConfigureHowToFindSaga method."
+}

--- a/src/ScriptBuilder.Tests/ApprovalFiles/CoreSagaMetadataTests.DontAllowWhileLoop.approved.txt
+++ b/src/ScriptBuilder.Tests/ApprovalFiles/CoreSagaMetadataTests.DontAllowWhileLoop.approved.txt
@@ -1,0 +1,7 @@
+﻿{
+  "HasUnmanagedCalls": false,
+  "HasUnexpectedCalls": false,
+  "HasBranchingLogic": true,
+  "SagaDefinition": null,
+  "Exception": "Looping & branching statements are not allowed in a ConfigureHowToFindSaga method."
+}

--- a/src/ScriptBuilder.Tests/ApprovalFiles/CoreSagaMetadataTests.DontMapConflictingCorrelationIds.approved.txt
+++ b/src/ScriptBuilder.Tests/ApprovalFiles/CoreSagaMetadataTests.DontMapConflictingCorrelationIds.approved.txt
@@ -1,0 +1,7 @@
+﻿{
+  "HasUnmanagedCalls": false,
+  "HasUnexpectedCalls": false,
+  "HasBranchingLogic": false,
+  "SagaDefinition": null,
+  "Exception": "Saga can only have one correlation property identified by .ToSaga() expressions. Fix mappings in ConfigureHowToFindSaga to map to a single correlation property or decorate the saga with [SqlSaga] attribute."
+}

--- a/src/ScriptBuilder.Tests/ApprovalFiles/CoreSagaMetadataTests.DontMapDelegateCalls.approved.txt
+++ b/src/ScriptBuilder.Tests/ApprovalFiles/CoreSagaMetadataTests.DontMapDelegateCalls.approved.txt
@@ -1,0 +1,7 @@
+﻿{
+  "HasUnmanagedCalls": false,
+  "HasUnexpectedCalls": true,
+  "HasBranchingLogic": false,
+  "SagaDefinition": null,
+  "Exception": "Unable to determine Saga correlation property because an unexpected method call was detected in the ConfigureHowToFindSaga method."
+}

--- a/src/ScriptBuilder.Tests/ApprovalFiles/CoreSagaMetadataTests.DontMapSwitchingLogic.approved.txt
+++ b/src/ScriptBuilder.Tests/ApprovalFiles/CoreSagaMetadataTests.DontMapSwitchingLogic.approved.txt
@@ -1,0 +1,7 @@
+﻿{
+  "HasUnmanagedCalls": false,
+  "HasUnexpectedCalls": false,
+  "HasBranchingLogic": true,
+  "SagaDefinition": null,
+  "Exception": "Looping & branching statements are not allowed in a ConfigureHowToFindSaga method."
+}

--- a/src/ScriptBuilder.Tests/ApprovalFiles/CoreSagaMetadataTests.DontMapWithIntermediateBase.approved.txt
+++ b/src/ScriptBuilder.Tests/ApprovalFiles/CoreSagaMetadataTests.DontMapWithIntermediateBase.approved.txt
@@ -1,0 +1,7 @@
+﻿{
+  "HasUnmanagedCalls": false,
+  "HasUnexpectedCalls": true,
+  "HasBranchingLogic": false,
+  "SagaDefinition": null,
+  "Exception": null
+}

--- a/src/ScriptBuilder.Tests/ApprovalFiles/CoreSagaMetadataTests.DualMapping.approved.txt
+++ b/src/ScriptBuilder.Tests/ApprovalFiles/CoreSagaMetadataTests.DualMapping.approved.txt
@@ -1,0 +1,15 @@
+﻿{
+  "HasUnmanagedCalls": false,
+  "HasUnexpectedCalls": false,
+  "HasBranchingLogic": false,
+  "SagaDefinition": {
+    "TableSuffix": "DualMappingSaga",
+    "CorrelationProperty": {
+      "Type": "String",
+      "Name": "Correlation"
+    },
+    "TransitionalCorrelationProperty": null,
+    "Name": "CoreSagaMetadataTests/DualMappingSaga"
+  },
+  "Exception": null
+}

--- a/src/ScriptBuilder.Tests/ApprovalFiles/CoreSagaMetadataTests.SingleMapping.approved.txt
+++ b/src/ScriptBuilder.Tests/ApprovalFiles/CoreSagaMetadataTests.SingleMapping.approved.txt
@@ -1,0 +1,15 @@
+﻿{
+  "HasUnmanagedCalls": false,
+  "HasUnexpectedCalls": false,
+  "HasBranchingLogic": false,
+  "SagaDefinition": {
+    "TableSuffix": "SingleMappingSaga",
+    "CorrelationProperty": {
+      "Type": "String",
+      "Name": "Correlation"
+    },
+    "TransitionalCorrelationProperty": null,
+    "Name": "CoreSagaMetadataTests/SingleMappingSaga"
+  },
+  "Exception": null
+}

--- a/src/ScriptBuilder.Tests/ApprovalFiles/CoreSagaMetadataTests.SingleMappingValueType.approved.txt
+++ b/src/ScriptBuilder.Tests/ApprovalFiles/CoreSagaMetadataTests.SingleMappingValueType.approved.txt
@@ -1,0 +1,15 @@
+﻿{
+  "HasUnmanagedCalls": false,
+  "HasUnexpectedCalls": false,
+  "HasBranchingLogic": false,
+  "SagaDefinition": {
+    "TableSuffix": "SingleMappingValueTypeSaga",
+    "CorrelationProperty": {
+      "Type": "Int",
+      "Name": "Correlation"
+    },
+    "TransitionalCorrelationProperty": null,
+    "Name": "CoreSagaMetadataTests/SingleMappingValueTypeSaga"
+  },
+  "Exception": null
+}

--- a/src/ScriptBuilder.Tests/ApprovalFiles/CoreSagaMetadataTests.SupplyAdditionalMetadataViaAttribute.approved.txt
+++ b/src/ScriptBuilder.Tests/ApprovalFiles/CoreSagaMetadataTests.SupplyAdditionalMetadataViaAttribute.approved.txt
@@ -1,0 +1,18 @@
+﻿{
+  "HasUnmanagedCalls": false,
+  "HasUnexpectedCalls": false,
+  "HasBranchingLogic": false,
+  "SagaDefinition": {
+    "TableSuffix": "DifferentTableSuffix",
+    "CorrelationProperty": {
+      "Type": "String",
+      "Name": "Correlation"
+    },
+    "TransitionalCorrelationProperty": {
+      "Type": "String",
+      "Name": "TransitionalCorrId"
+    },
+    "Name": "CoreSagaMetadataTests/MetadataInAttributeSaga"
+  },
+  "Exception": null
+}

--- a/src/ScriptBuilder.Tests/ApprovalFiles/CoreSagaMetadataTests.TestSagaInVB.approved.txt
+++ b/src/ScriptBuilder.Tests/ApprovalFiles/CoreSagaMetadataTests.TestSagaInVB.approved.txt
@@ -1,0 +1,15 @@
+﻿{
+  "HasUnmanagedCalls": false,
+  "HasUnexpectedCalls": false,
+  "HasBranchingLogic": false,
+  "SagaDefinition": {
+    "TableSuffix": "VBMultiTestSaga",
+    "CorrelationProperty": {
+      "Type": "String",
+      "Name": "Correlation"
+    },
+    "TransitionalCorrelationProperty": null,
+    "Name": "VBTestCode.VBMultiTestSaga"
+  },
+  "Exception": null
+}

--- a/src/ScriptBuilder.Tests/ApprovalFiles/SagaDefinitionReaderTest.NonSqlSaga.approved.txt
+++ b/src/ScriptBuilder.Tests/ApprovalFiles/SagaDefinitionReaderTest.NonSqlSaga.approved.txt
@@ -1,1 +1,0 @@
-﻿The type 'SagaDefinitionReaderTest/NonSqlSagaSaga' inherits from NServiceBus.Saga which is not supported. Inherit from NServiceBus.Persistence.Sql.SqlSaga.

--- a/src/ScriptBuilder.Tests/Saga/CoreSagaMetadata/CoreSagaMetadataTests.ConcatMsgPropertiesSaga.cs
+++ b/src/ScriptBuilder.Tests/Saga/CoreSagaMetadata/CoreSagaMetadataTests.ConcatMsgPropertiesSaga.cs
@@ -1,0 +1,67 @@
+﻿using NServiceBus;
+
+public partial class CoreSagaMetadataTests
+{
+    public class ConcatMsgPropertiesSaga : Saga<ConcatMsgPropertiesSaga.SagaData>
+    {
+        public class SagaData : ContainSagaData
+        {
+            public string Correlation { get; set; }
+        }
+
+        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+        {
+            mapper.ConfigureMapping<MessageC>(msg => msg.Part1 + msg.Part2).ToSaga(saga => saga.Correlation);
+        }
+    }
+}
+/* IL:
+ConcatMsgPropertiesSaga.ConfigureHowToFindSaga:
+IL_0000:  ldarg.1     
+IL_0001:  ldtoken     UserQuery.MessageC
+IL_0006:  call        System.Type.GetTypeFromHandle
+IL_000B:  ldstr       "msg"
+IL_0010:  call        System.Linq.Expressions.Expression.Parameter
+IL_0015:  stloc.0     
+IL_0016:  ldloc.0     
+IL_0017:  ldtoken     UserQuery+MessageC.get_Part1
+IL_001C:  call        System.Reflection.MethodBase.GetMethodFromHandle
+IL_0021:  castclass   System.Reflection.MethodInfo
+IL_0026:  call        System.Linq.Expressions.Expression.Property
+IL_002B:  ldloc.0     
+IL_002C:  ldtoken     UserQuery+MessageC.get_Part2
+IL_0031:  call        System.Reflection.MethodBase.GetMethodFromHandle
+IL_0036:  castclass   System.Reflection.MethodInfo
+IL_003B:  call        System.Linq.Expressions.Expression.Property
+IL_0040:  ldtoken     System.String.Concat
+IL_0045:  call        System.Reflection.MethodBase.GetMethodFromHandle
+IL_004A:  castclass   System.Reflection.MethodInfo
+IL_004F:  call        System.Linq.Expressions.Expression.Add
+IL_0054:  ldc.i4.1    
+IL_0055:  newarr      System.Linq.Expressions.ParameterExpression
+IL_005A:  dup         
+IL_005B:  ldc.i4.0    
+IL_005C:  ldloc.0     
+IL_005D:  stelem.ref  
+IL_005E:  call        System.Linq.Expressions.Expression.Lambda<Func`2>
+IL_0063:  callvirt    NServiceBus.SagaPropertyMapper<UserQuery+ConcatMsgPropertiesSaga+SagaData>.ConfigureMapping<MessageC>
+IL_0068:  ldtoken     UserQuery+ConcatMsgPropertiesSaga.SagaData
+IL_006D:  call        System.Type.GetTypeFromHandle
+IL_0072:  ldstr       "saga"
+IL_0077:  call        System.Linq.Expressions.Expression.Parameter
+IL_007C:  stloc.0     
+IL_007D:  ldloc.0     
+IL_007E:  ldtoken     UserQuery+ConcatMsgPropertiesSaga+SagaData.get_Correlation
+IL_0083:  call        System.Reflection.MethodBase.GetMethodFromHandle
+IL_0088:  castclass   System.Reflection.MethodInfo
+IL_008D:  call        System.Linq.Expressions.Expression.Property
+IL_0092:  ldc.i4.1    
+IL_0093:  newarr      System.Linq.Expressions.ParameterExpression
+IL_0098:  dup         
+IL_0099:  ldc.i4.0    
+IL_009A:  ldloc.0     
+IL_009B:  stelem.ref  
+IL_009C:  call        System.Linq.Expressions.Expression.Lambda<Func`2>
+IL_00A1:  callvirt    NServiceBus.ToSagaExpression<UserQuery+ConcatMsgPropertiesSaga+SagaData,UserQuery+MessageC>.ToSaga
+IL_00A6:  ret  
+*/

--- a/src/ScriptBuilder.Tests/Saga/CoreSagaMetadata/CoreSagaMetadataTests.ConcatMsgPropertiesWithFormatSaga.cs
+++ b/src/ScriptBuilder.Tests/Saga/CoreSagaMetadata/CoreSagaMetadataTests.ConcatMsgPropertiesWithFormatSaga.cs
@@ -1,0 +1,83 @@
+﻿using NServiceBus;
+
+public partial class CoreSagaMetadataTests
+{
+    public class ConcatMsgPropertiesWithFormatSaga : Saga<ConcatMsgPropertiesWithFormatSaga.SagaData>
+    {
+        public class SagaData : ContainSagaData
+        {
+            public string Correlation { get; set; }
+        }
+
+        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+        {
+            mapper.ConfigureMapping<MessageC>(msg => string.Format("{0}{1}", msg.Part1, msg.Part2)).ToSaga(saga => saga.Correlation);
+        }
+    }
+}
+/* IL:
+ConcatMsgPropertiesWithFormatSaga.ConfigureHowToFindSaga:
+IL_0000:  ldarg.1     
+IL_0001:  ldtoken     UserQuery.MessageC
+IL_0006:  call        System.Type.GetTypeFromHandle
+IL_000B:  ldstr       "msg"
+IL_0010:  call        System.Linq.Expressions.Expression.Parameter
+IL_0015:  stloc.0     
+IL_0016:  ldnull      
+IL_0017:  ldtoken     System.String.Format
+IL_001C:  call        System.Reflection.MethodBase.GetMethodFromHandle
+IL_0021:  castclass   System.Reflection.MethodInfo
+IL_0026:  ldc.i4.3    
+IL_0027:  newarr      System.Linq.Expressions.Expression
+IL_002C:  dup         
+IL_002D:  ldc.i4.0    
+IL_002E:  ldstr       "{0}{1}"
+IL_0033:  ldtoken     System.String
+IL_0038:  call        System.Type.GetTypeFromHandle
+IL_003D:  call        System.Linq.Expressions.Expression.Constant
+IL_0042:  stelem.ref  
+IL_0043:  dup         
+IL_0044:  ldc.i4.1    
+IL_0045:  ldloc.0     
+IL_0046:  ldtoken     UserQuery+MessageC.get_Part1
+IL_004B:  call        System.Reflection.MethodBase.GetMethodFromHandle
+IL_0050:  castclass   System.Reflection.MethodInfo
+IL_0055:  call        System.Linq.Expressions.Expression.Property
+IL_005A:  stelem.ref  
+IL_005B:  dup         
+IL_005C:  ldc.i4.2    
+IL_005D:  ldloc.0     
+IL_005E:  ldtoken     UserQuery+MessageC.get_Part2
+IL_0063:  call        System.Reflection.MethodBase.GetMethodFromHandle
+IL_0068:  castclass   System.Reflection.MethodInfo
+IL_006D:  call        System.Linq.Expressions.Expression.Property
+IL_0072:  stelem.ref  
+IL_0073:  call        System.Linq.Expressions.Expression.Call
+IL_0078:  ldc.i4.1    
+IL_0079:  newarr      System.Linq.Expressions.ParameterExpression
+IL_007E:  dup         
+IL_007F:  ldc.i4.0    
+IL_0080:  ldloc.0     
+IL_0081:  stelem.ref  
+IL_0082:  call        System.Linq.Expressions.Expression.Lambda<Func`2>
+IL_0087:  callvirt    NServiceBus.SagaPropertyMapper<UserQuery+ConcatMsgPropertiesWithFormatSaga+SagaData>.ConfigureMapping<MessageC>
+IL_008C:  ldtoken     UserQuery+ConcatMsgPropertiesWithFormatSaga.SagaData
+IL_0091:  call        System.Type.GetTypeFromHandle
+IL_0096:  ldstr       "saga"
+IL_009B:  call        System.Linq.Expressions.Expression.Parameter
+IL_00A0:  stloc.0     
+IL_00A1:  ldloc.0     
+IL_00A2:  ldtoken     UserQuery+ConcatMsgPropertiesWithFormatSaga+SagaData.get_Correlation
+IL_00A7:  call        System.Reflection.MethodBase.GetMethodFromHandle
+IL_00AC:  castclass   System.Reflection.MethodInfo
+IL_00B1:  call        System.Linq.Expressions.Expression.Property
+IL_00B6:  ldc.i4.1    
+IL_00B7:  newarr      System.Linq.Expressions.ParameterExpression
+IL_00BC:  dup         
+IL_00BD:  ldc.i4.0    
+IL_00BE:  ldloc.0     
+IL_00BF:  stelem.ref  
+IL_00C0:  call        System.Linq.Expressions.Expression.Lambda<Func`2>
+IL_00C5:  callvirt    NServiceBus.ToSagaExpression<UserQuery+ConcatMsgPropertiesWithFormatSaga+SagaData,UserQuery+MessageC>.ToSaga
+IL_00CA:  ret    
+*/

--- a/src/ScriptBuilder.Tests/Saga/CoreSagaMetadata/CoreSagaMetadataTests.ConcatMsgPropertiesWithInterpolationSaga.cs
+++ b/src/ScriptBuilder.Tests/Saga/CoreSagaMetadata/CoreSagaMetadataTests.ConcatMsgPropertiesWithInterpolationSaga.cs
@@ -1,0 +1,83 @@
+﻿using NServiceBus;
+
+public partial class CoreSagaMetadataTests
+{
+    public class ConcatMsgPropertiesWithInterpolationSaga : Saga<ConcatMsgPropertiesWithInterpolationSaga.SagaData>
+    {
+        public class SagaData : ContainSagaData
+        {
+            public string Correlation { get; set; }
+        }
+
+        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+        {
+            mapper.ConfigureMapping<MessageC>(msg => $"{msg.Part1}{msg.Part2}").ToSaga(saga => saga.Correlation);
+        }
+    }
+}
+/* IL:
+ConcatMsgPropertiesWithInterpolationSaga.ConfigureHowToFindSaga:
+IL_0000:  ldarg.1     
+IL_0001:  ldtoken     UserQuery.MessageC
+IL_0006:  call        System.Type.GetTypeFromHandle
+IL_000B:  ldstr       "msg"
+IL_0010:  call        System.Linq.Expressions.Expression.Parameter
+IL_0015:  stloc.0     
+IL_0016:  ldnull      
+IL_0017:  ldtoken     System.String.Format
+IL_001C:  call        System.Reflection.MethodBase.GetMethodFromHandle
+IL_0021:  castclass   System.Reflection.MethodInfo
+IL_0026:  ldc.i4.3    
+IL_0027:  newarr      System.Linq.Expressions.Expression
+IL_002C:  dup         
+IL_002D:  ldc.i4.0    
+IL_002E:  ldstr       "{0}{1}"
+IL_0033:  ldtoken     System.String
+IL_0038:  call        System.Type.GetTypeFromHandle
+IL_003D:  call        System.Linq.Expressions.Expression.Constant
+IL_0042:  stelem.ref  
+IL_0043:  dup         
+IL_0044:  ldc.i4.1    
+IL_0045:  ldloc.0     
+IL_0046:  ldtoken     UserQuery+MessageC.get_Part1
+IL_004B:  call        System.Reflection.MethodBase.GetMethodFromHandle
+IL_0050:  castclass   System.Reflection.MethodInfo
+IL_0055:  call        System.Linq.Expressions.Expression.Property
+IL_005A:  stelem.ref  
+IL_005B:  dup         
+IL_005C:  ldc.i4.2    
+IL_005D:  ldloc.0     
+IL_005E:  ldtoken     UserQuery+MessageC.get_Part2
+IL_0063:  call        System.Reflection.MethodBase.GetMethodFromHandle
+IL_0068:  castclass   System.Reflection.MethodInfo
+IL_006D:  call        System.Linq.Expressions.Expression.Property
+IL_0072:  stelem.ref  
+IL_0073:  call        System.Linq.Expressions.Expression.Call
+IL_0078:  ldc.i4.1    
+IL_0079:  newarr      System.Linq.Expressions.ParameterExpression
+IL_007E:  dup         
+IL_007F:  ldc.i4.0    
+IL_0080:  ldloc.0     
+IL_0081:  stelem.ref  
+IL_0082:  call        System.Linq.Expressions.Expression.Lambda<Func`2>
+IL_0087:  callvirt    NServiceBus.SagaPropertyMapper<UserQuery+ConcatMsgPropertiesWithInterpolationSaga+SagaData>.ConfigureMapping<MessageC>
+IL_008C:  ldtoken     UserQuery+ConcatMsgPropertiesWithInterpolationSaga.SagaData
+IL_0091:  call        System.Type.GetTypeFromHandle
+IL_0096:  ldstr       "saga"
+IL_009B:  call        System.Linq.Expressions.Expression.Parameter
+IL_00A0:  stloc.0     
+IL_00A1:  ldloc.0     
+IL_00A2:  ldtoken     UserQuery+ConcatMsgPropertiesWithInterpolationSaga+SagaData.get_Correlation
+IL_00A7:  call        System.Reflection.MethodBase.GetMethodFromHandle
+IL_00AC:  castclass   System.Reflection.MethodInfo
+IL_00B1:  call        System.Linq.Expressions.Expression.Property
+IL_00B6:  ldc.i4.1    
+IL_00B7:  newarr      System.Linq.Expressions.ParameterExpression
+IL_00BC:  dup         
+IL_00BD:  ldc.i4.0    
+IL_00BE:  ldloc.0     
+IL_00BF:  stelem.ref  
+IL_00C0:  call        System.Linq.Expressions.Expression.Lambda<Func`2>
+IL_00C5:  callvirt    NServiceBus.ToSagaExpression<UserQuery+ConcatMsgPropertiesWithInterpolationSaga+SagaData,UserQuery+MessageC>.ToSaga
+IL_00CA:  ret 
+*/

--- a/src/ScriptBuilder.Tests/Saga/CoreSagaMetadata/CoreSagaMetadataTests.ConcatMsgPropertiesWithOtherMethods.cs
+++ b/src/ScriptBuilder.Tests/Saga/CoreSagaMetadata/CoreSagaMetadataTests.ConcatMsgPropertiesWithOtherMethods.cs
@@ -1,0 +1,78 @@
+﻿using NServiceBus;
+
+public partial class CoreSagaMetadataTests
+{
+    public class ConcatMsgPropertiesWithOtherMethods : Saga<ConcatMsgPropertiesWithOtherMethods.SagaData>
+    {
+        public class SagaData : ContainSagaData
+        {
+            public string Correlation { get; set; }
+        }
+
+        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+        {
+            mapper.ConfigureMapping<MessageC>(msg => msg.Part1.ToUpper() + msg.Part2.ToLowerInvariant())
+                .ToSaga(saga => saga.Correlation);
+        }
+    }
+}
+/* IL:
+ConcatMsgPropertiesWithOtherMethods.ConfigureHowToFindSaga:
+IL_0000:  ldarg.1     
+IL_0001:  ldtoken     UserQuery.MessageC
+IL_0006:  call        System.Type.GetTypeFromHandle
+IL_000B:  ldstr       "msg"
+IL_0010:  call        System.Linq.Expressions.Expression.Parameter
+IL_0015:  stloc.0     
+IL_0016:  ldloc.0     
+IL_0017:  ldtoken     UserQuery+MessageC.get_Part1
+IL_001C:  call        System.Reflection.MethodBase.GetMethodFromHandle
+IL_0021:  castclass   System.Reflection.MethodInfo
+IL_0026:  call        System.Linq.Expressions.Expression.Property
+IL_002B:  ldtoken     System.String.ToUpper
+IL_0030:  call        System.Reflection.MethodBase.GetMethodFromHandle
+IL_0035:  castclass   System.Reflection.MethodInfo
+IL_003A:  call        System.Array.Empty<Expression>
+IL_003F:  call        System.Linq.Expressions.Expression.Call
+IL_0044:  ldloc.0     
+IL_0045:  ldtoken     UserQuery+MessageC.get_Part2
+IL_004A:  call        System.Reflection.MethodBase.GetMethodFromHandle
+IL_004F:  castclass   System.Reflection.MethodInfo
+IL_0054:  call        System.Linq.Expressions.Expression.Property
+IL_0059:  ldtoken     System.String.ToLowerInvariant
+IL_005E:  call        System.Reflection.MethodBase.GetMethodFromHandle
+IL_0063:  castclass   System.Reflection.MethodInfo
+IL_0068:  call        System.Array.Empty<Expression>
+IL_006D:  call        System.Linq.Expressions.Expression.Call
+IL_0072:  ldtoken     System.String.Concat
+IL_0077:  call        System.Reflection.MethodBase.GetMethodFromHandle
+IL_007C:  castclass   System.Reflection.MethodInfo
+IL_0081:  call        System.Linq.Expressions.Expression.Add
+IL_0086:  ldc.i4.1    
+IL_0087:  newarr      System.Linq.Expressions.ParameterExpression
+IL_008C:  dup         
+IL_008D:  ldc.i4.0    
+IL_008E:  ldloc.0     
+IL_008F:  stelem.ref  
+IL_0090:  call        System.Linq.Expressions.Expression.Lambda<Func`2>
+IL_0095:  callvirt    NServiceBus.SagaPropertyMapper<UserQuery+ConcatMsgPropertiesWithOtherMethods+SagaData>.ConfigureMapping<MessageC>
+IL_009A:  ldtoken     UserQuery+ConcatMsgPropertiesWithOtherMethods.SagaData
+IL_009F:  call        System.Type.GetTypeFromHandle
+IL_00A4:  ldstr       "saga"
+IL_00A9:  call        System.Linq.Expressions.Expression.Parameter
+IL_00AE:  stloc.0     
+IL_00AF:  ldloc.0     
+IL_00B0:  ldtoken     UserQuery+ConcatMsgPropertiesWithOtherMethods+SagaData.get_Correlation
+IL_00B5:  call        System.Reflection.MethodBase.GetMethodFromHandle
+IL_00BA:  castclass   System.Reflection.MethodInfo
+IL_00BF:  call        System.Linq.Expressions.Expression.Property
+IL_00C4:  ldc.i4.1    
+IL_00C5:  newarr      System.Linq.Expressions.ParameterExpression
+IL_00CA:  dup         
+IL_00CB:  ldc.i4.0    
+IL_00CC:  ldloc.0     
+IL_00CD:  stelem.ref  
+IL_00CE:  call        System.Linq.Expressions.Expression.Lambda<Func`2>
+IL_00D3:  callvirt    NServiceBus.ToSagaExpression<UserQuery+ConcatMsgPropertiesWithOtherMethods+SagaData,UserQuery+MessageC>.ToSaga
+IL_00D8:  ret  
+*/

--- a/src/ScriptBuilder.Tests/Saga/CoreSagaMetadata/CoreSagaMetadataTests.ConflictingCorrelationSaga.cs
+++ b/src/ScriptBuilder.Tests/Saga/CoreSagaMetadata/CoreSagaMetadataTests.ConflictingCorrelationSaga.cs
@@ -1,0 +1,97 @@
+﻿using NServiceBus;
+
+public partial class CoreSagaMetadataTests
+{
+    public class ConflictingCorrelationSaga : Saga<ConflictingCorrelationSaga.SagaData>
+    {
+        public class SagaData : ContainSagaData
+        {
+            public string Correlation { get; set; }
+            public string OtherProperty { get; set; }
+        }
+
+        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+        {
+            mapper.ConfigureMapping<MessageA>(msg => msg.Correlation).ToSaga(saga => saga.Correlation);
+            mapper.ConfigureMapping<MessageB>(msg => msg.Correlation).ToSaga(saga => saga.OtherProperty);
+        }
+    }
+}
+/* IL:
+ConflictingCorrelationSaga.ConfigureHowToFindSaga:
+IL_0000:  ldarg.1     
+IL_0001:  ldtoken     UserQuery.MessageA
+IL_0006:  call        System.Type.GetTypeFromHandle
+IL_000B:  ldstr       "msg"
+IL_0010:  call        System.Linq.Expressions.Expression.Parameter
+IL_0015:  stloc.0     
+IL_0016:  ldloc.0     
+IL_0017:  ldtoken     UserQuery+MessageA.get_Correlation
+IL_001C:  call        System.Reflection.MethodBase.GetMethodFromHandle
+IL_0021:  castclass   System.Reflection.MethodInfo
+IL_0026:  call        System.Linq.Expressions.Expression.Property
+IL_002B:  ldc.i4.1    
+IL_002C:  newarr      System.Linq.Expressions.ParameterExpression
+IL_0031:  dup         
+IL_0032:  ldc.i4.0    
+IL_0033:  ldloc.0     
+IL_0034:  stelem.ref  
+IL_0035:  call        System.Linq.Expressions.Expression.Lambda<Func`2>
+IL_003A:  callvirt    NServiceBus.SagaPropertyMapper<UserQuery+ConflictingCorrelationSaga+SagaData>.ConfigureMapping<MessageA>
+IL_003F:  ldtoken     UserQuery+ConflictingCorrelationSaga.SagaData
+IL_0044:  call        System.Type.GetTypeFromHandle
+IL_0049:  ldstr       "saga"
+IL_004E:  call        System.Linq.Expressions.Expression.Parameter
+IL_0053:  stloc.0     
+IL_0054:  ldloc.0     
+IL_0055:  ldtoken     UserQuery+ConflictingCorrelationSaga+SagaData.get_Correlation
+IL_005A:  call        System.Reflection.MethodBase.GetMethodFromHandle
+IL_005F:  castclass   System.Reflection.MethodInfo
+IL_0064:  call        System.Linq.Expressions.Expression.Property
+IL_0069:  ldc.i4.1    
+IL_006A:  newarr      System.Linq.Expressions.ParameterExpression
+IL_006F:  dup         
+IL_0070:  ldc.i4.0    
+IL_0071:  ldloc.0     
+IL_0072:  stelem.ref  
+IL_0073:  call        System.Linq.Expressions.Expression.Lambda<Func`2>
+IL_0078:  callvirt    NServiceBus.ToSagaExpression<UserQuery+ConflictingCorrelationSaga+SagaData,UserQuery+MessageA>.ToSaga
+IL_007D:  ldarg.1     
+IL_007E:  ldtoken     UserQuery.MessageB
+IL_0083:  call        System.Type.GetTypeFromHandle
+IL_0088:  ldstr       "msg"
+IL_008D:  call        System.Linq.Expressions.Expression.Parameter
+IL_0092:  stloc.0     
+IL_0093:  ldloc.0     
+IL_0094:  ldtoken     UserQuery+MessageB.get_Correlation
+IL_0099:  call        System.Reflection.MethodBase.GetMethodFromHandle
+IL_009E:  castclass   System.Reflection.MethodInfo
+IL_00A3:  call        System.Linq.Expressions.Expression.Property
+IL_00A8:  ldc.i4.1    
+IL_00A9:  newarr      System.Linq.Expressions.ParameterExpression
+IL_00AE:  dup         
+IL_00AF:  ldc.i4.0    
+IL_00B0:  ldloc.0     
+IL_00B1:  stelem.ref  
+IL_00B2:  call        System.Linq.Expressions.Expression.Lambda<Func`2>
+IL_00B7:  callvirt    NServiceBus.SagaPropertyMapper<UserQuery+ConflictingCorrelationSaga+SagaData>.ConfigureMapping<MessageB>
+IL_00BC:  ldtoken     UserQuery+ConflictingCorrelationSaga.SagaData
+IL_00C1:  call        System.Type.GetTypeFromHandle
+IL_00C6:  ldstr       "saga"
+IL_00CB:  call        System.Linq.Expressions.Expression.Parameter
+IL_00D0:  stloc.0     
+IL_00D1:  ldloc.0     
+IL_00D2:  ldtoken     UserQuery+ConflictingCorrelationSaga+SagaData.get_OtherProperty
+IL_00D7:  call        System.Reflection.MethodBase.GetMethodFromHandle
+IL_00DC:  castclass   System.Reflection.MethodInfo
+IL_00E1:  call        System.Linq.Expressions.Expression.Property
+IL_00E6:  ldc.i4.1    
+IL_00E7:  newarr      System.Linq.Expressions.ParameterExpression
+IL_00EC:  dup         
+IL_00ED:  ldc.i4.0    
+IL_00EE:  ldloc.0     
+IL_00EF:  stelem.ref  
+IL_00F0:  call        System.Linq.Expressions.Expression.Lambda<Func`2>
+IL_00F5:  callvirt    NServiceBus.ToSagaExpression<UserQuery+ConflictingCorrelationSaga+SagaData,UserQuery+MessageB>.ToSaga
+IL_00FA:  ret  
+*/

--- a/src/ScriptBuilder.Tests/Saga/CoreSagaMetadata/CoreSagaMetadataTests.DelegateCallingSaga.cs
+++ b/src/ScriptBuilder.Tests/Saga/CoreSagaMetadata/CoreSagaMetadataTests.DelegateCallingSaga.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using NServiceBus;
+
+public partial class CoreSagaMetadataTests
+{
+    public class DelegateCallingSaga : Saga<DelegateCallingSaga.SagaData>
+    {
+        public class SagaData : ContainSagaData
+        {
+            public string Correlation { get; set; }
+        }
+
+        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+        {
+            Action action = () => mapper.ConfigureMapping<MessageA>(msg => msg.Correlation).ToSaga(saga => saga.Correlation);
+            action();
+        }
+    }
+}
+/* IL:
+DelegateCallingSaga.ConfigureHowToFindSaga:
+IL_0000:  newobj      UserQuery+DelegateCallingSaga+<>c__DisplayClass1_0..ctor
+IL_0005:  dup         
+IL_0006:  ldarg.1     
+IL_0007:  stfld       UserQuery+DelegateCallingSaga+<>c__DisplayClass1_0.mapper
+IL_000C:  ldftn       UserQuery+DelegateCallingSaga+<>c__DisplayClass1_0.<ConfigureHowToFindSaga>b__0
+IL_0012:  newobj      System.Action..ctor
+IL_0017:  callvirt    System.Action.Invoke
+IL_001C:  ret    
+*/

--- a/src/ScriptBuilder.Tests/Saga/CoreSagaMetadata/CoreSagaMetadataTests.DualMappingSaga.cs
+++ b/src/ScriptBuilder.Tests/Saga/CoreSagaMetadata/CoreSagaMetadataTests.DualMappingSaga.cs
@@ -1,0 +1,96 @@
+﻿using NServiceBus;
+
+public partial class CoreSagaMetadataTests
+{
+    public class DualMappingSaga : Saga<DualMappingSaga.SagaData>
+    {
+        public class SagaData : ContainSagaData
+        {
+            public string Correlation { get; set; }
+        }
+
+        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+        {
+            mapper.ConfigureMapping<MessageA>(msg => msg.Correlation).ToSaga(saga => saga.Correlation);
+            mapper.ConfigureMapping<MessageD>(msg => msg.DifferentName).ToSaga(saga => saga.Correlation);
+        }
+    }
+}
+/* IL:
+DualMappingSaga.ConfigureHowToFindSaga:
+IL_0000:  ldarg.1     
+IL_0001:  ldtoken     UserQuery.MessageA
+IL_0006:  call        System.Type.GetTypeFromHandle
+IL_000B:  ldstr       "msg"
+IL_0010:  call        System.Linq.Expressions.Expression.Parameter
+IL_0015:  stloc.0     
+IL_0016:  ldloc.0     
+IL_0017:  ldtoken     UserQuery+MessageA.get_Correlation
+IL_001C:  call        System.Reflection.MethodBase.GetMethodFromHandle
+IL_0021:  castclass   System.Reflection.MethodInfo
+IL_0026:  call        System.Linq.Expressions.Expression.Property
+IL_002B:  ldc.i4.1    
+IL_002C:  newarr      System.Linq.Expressions.ParameterExpression
+IL_0031:  dup         
+IL_0032:  ldc.i4.0    
+IL_0033:  ldloc.0     
+IL_0034:  stelem.ref  
+IL_0035:  call        System.Linq.Expressions.Expression.Lambda<Func`2>
+IL_003A:  callvirt    NServiceBus.SagaPropertyMapper<UserQuery+DualMappingSaga+SagaData>.ConfigureMapping<MessageA>
+IL_003F:  ldtoken     UserQuery+DualMappingSaga.SagaData
+IL_0044:  call        System.Type.GetTypeFromHandle
+IL_0049:  ldstr       "saga"
+IL_004E:  call        System.Linq.Expressions.Expression.Parameter
+IL_0053:  stloc.0     
+IL_0054:  ldloc.0     
+IL_0055:  ldtoken     UserQuery+DualMappingSaga+SagaData.get_Correlation
+IL_005A:  call        System.Reflection.MethodBase.GetMethodFromHandle
+IL_005F:  castclass   System.Reflection.MethodInfo
+IL_0064:  call        System.Linq.Expressions.Expression.Property
+IL_0069:  ldc.i4.1    
+IL_006A:  newarr      System.Linq.Expressions.ParameterExpression
+IL_006F:  dup         
+IL_0070:  ldc.i4.0    
+IL_0071:  ldloc.0     
+IL_0072:  stelem.ref  
+IL_0073:  call        System.Linq.Expressions.Expression.Lambda<Func`2>
+IL_0078:  callvirt    NServiceBus.ToSagaExpression<UserQuery+DualMappingSaga+SagaData,UserQuery+MessageA>.ToSaga
+IL_007D:  ldarg.1     
+IL_007E:  ldtoken     UserQuery.MessageD
+IL_0083:  call        System.Type.GetTypeFromHandle
+IL_0088:  ldstr       "msg"
+IL_008D:  call        System.Linq.Expressions.Expression.Parameter
+IL_0092:  stloc.0     
+IL_0093:  ldloc.0     
+IL_0094:  ldtoken     UserQuery+MessageD.get_DifferentName
+IL_0099:  call        System.Reflection.MethodBase.GetMethodFromHandle
+IL_009E:  castclass   System.Reflection.MethodInfo
+IL_00A3:  call        System.Linq.Expressions.Expression.Property
+IL_00A8:  ldc.i4.1    
+IL_00A9:  newarr      System.Linq.Expressions.ParameterExpression
+IL_00AE:  dup         
+IL_00AF:  ldc.i4.0    
+IL_00B0:  ldloc.0     
+IL_00B1:  stelem.ref  
+IL_00B2:  call        System.Linq.Expressions.Expression.Lambda<Func`2>
+IL_00B7:  callvirt    NServiceBus.SagaPropertyMapper<UserQuery+DualMappingSaga+SagaData>.ConfigureMapping<MessageD>
+IL_00BC:  ldtoken     UserQuery+DualMappingSaga.SagaData
+IL_00C1:  call        System.Type.GetTypeFromHandle
+IL_00C6:  ldstr       "saga"
+IL_00CB:  call        System.Linq.Expressions.Expression.Parameter
+IL_00D0:  stloc.0     
+IL_00D1:  ldloc.0     
+IL_00D2:  ldtoken     UserQuery+DualMappingSaga+SagaData.get_Correlation
+IL_00D7:  call        System.Reflection.MethodBase.GetMethodFromHandle
+IL_00DC:  castclass   System.Reflection.MethodInfo
+IL_00E1:  call        System.Linq.Expressions.Expression.Property
+IL_00E6:  ldc.i4.1    
+IL_00E7:  newarr      System.Linq.Expressions.ParameterExpression
+IL_00EC:  dup         
+IL_00ED:  ldc.i4.0    
+IL_00EE:  ldloc.0     
+IL_00EF:  stelem.ref  
+IL_00F0:  call        System.Linq.Expressions.Expression.Lambda<Func`2>
+IL_00F5:  callvirt    NServiceBus.ToSagaExpression<UserQuery+DualMappingSaga+SagaData,UserQuery+MessageD>.ToSaga
+IL_00FA:  ret  
+*/

--- a/src/ScriptBuilder.Tests/Saga/CoreSagaMetadata/CoreSagaMetadataTests.ForLoopSaga.cs
+++ b/src/ScriptBuilder.Tests/Saga/CoreSagaMetadata/CoreSagaMetadataTests.ForLoopSaga.cs
@@ -1,0 +1,71 @@
+﻿using NServiceBus;
+
+public partial class CoreSagaMetadataTests
+{
+    public class ForLoopSaga : Saga<ForLoopSaga.SagaData>
+    {
+        public class SagaData : ContainSagaData
+        {
+            public string Correlation { get; set; }
+        }
+
+        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+        {
+            for (var i = 0; i < 3; i++)
+            {
+                mapper.ConfigureMapping<MessageA>(msg => msg.Correlation).ToSaga(saga => saga.Correlation);
+            }
+        }
+    }
+}
+/* IL:  
+ForLoopSaga.ConfigureHowToFindSaga:
+IL_0000:  ldc.i4.0    
+IL_0001:  stloc.0     // i
+IL_0002:  br          IL_0088
+IL_0007:  ldarg.1     
+IL_0008:  ldtoken     UserQuery.MessageA
+IL_000D:  call        System.Type.GetTypeFromHandle
+IL_0012:  ldstr       "msg"
+IL_0017:  call        System.Linq.Expressions.Expression.Parameter
+IL_001C:  stloc.1     
+IL_001D:  ldloc.1     
+IL_001E:  ldtoken     UserQuery+MessageA.get_Correlation
+IL_0023:  call        System.Reflection.MethodBase.GetMethodFromHandle
+IL_0028:  castclass   System.Reflection.MethodInfo
+IL_002D:  call        System.Linq.Expressions.Expression.Property
+IL_0032:  ldc.i4.1    
+IL_0033:  newarr      System.Linq.Expressions.ParameterExpression
+IL_0038:  dup         
+IL_0039:  ldc.i4.0    
+IL_003A:  ldloc.1     
+IL_003B:  stelem.ref  
+IL_003C:  call        System.Linq.Expressions.Expression.Lambda<Func`2>
+IL_0041:  callvirt    NServiceBus.SagaPropertyMapper<UserQuery+ForLoopSaga+SagaData>.ConfigureMapping<MessageA>
+IL_0046:  ldtoken     UserQuery+ForLoopSaga.SagaData
+IL_004B:  call        System.Type.GetTypeFromHandle
+IL_0050:  ldstr       "saga"
+IL_0055:  call        System.Linq.Expressions.Expression.Parameter
+IL_005A:  stloc.1     
+IL_005B:  ldloc.1     
+IL_005C:  ldtoken     UserQuery+ForLoopSaga+SagaData.get_Correlation
+IL_0061:  call        System.Reflection.MethodBase.GetMethodFromHandle
+IL_0066:  castclass   System.Reflection.MethodInfo
+IL_006B:  call        System.Linq.Expressions.Expression.Property
+IL_0070:  ldc.i4.1    
+IL_0071:  newarr      System.Linq.Expressions.ParameterExpression
+IL_0076:  dup         
+IL_0077:  ldc.i4.0    
+IL_0078:  ldloc.1     
+IL_0079:  stelem.ref  
+IL_007A:  call        System.Linq.Expressions.Expression.Lambda<Func`2>
+IL_007F:  callvirt    NServiceBus.ToSagaExpression<UserQuery+ForLoopSaga+SagaData,UserQuery+MessageA>.ToSaga
+IL_0084:  ldloc.0     // i
+IL_0085:  ldc.i4.1    
+IL_0086:  add         
+IL_0087:  stloc.0     // i
+IL_0088:  ldloc.0     // i
+IL_0089:  ldc.i4.3    
+IL_008A:  blt         IL_0007
+IL_008F:  ret  
+*/

--- a/src/ScriptBuilder.Tests/Saga/CoreSagaMetadata/CoreSagaMetadataTests.HasBaseSagaClass.cs
+++ b/src/ScriptBuilder.Tests/Saga/CoreSagaMetadata/CoreSagaMetadataTests.HasBaseSagaClass.cs
@@ -1,0 +1,71 @@
+﻿using NServiceBus;
+
+public partial class CoreSagaMetadataTests
+{
+    public class HasBaseSagaClass : BaseSaga<HasBaseSagaClass.SagaData>
+    {
+        public class SagaData : ContainSagaData
+        {
+            public string Correlation { get; set; }
+        }
+
+        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+        {
+            base.ConfigureHowToFindSaga(mapper);
+            mapper.ConfigureMapping<MessageA>(msg => msg.Correlation).ToSaga(saga => saga.Correlation);
+        }
+    }
+
+    public class BaseSaga<TSaga> : Saga<TSaga>
+        where TSaga : class, IContainSagaData, new()
+    {
+        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TSaga> mapper)
+        {
+
+        }
+    }
+}
+/* IL:
+HasBaseSagaClass.ConfigureHowToFindSaga:
+IL_0000:  ldarg.0     
+IL_0001:  ldarg.1     
+IL_0002:  call        UserQuery+BaseSaga<UserQuery+HasBaseSagaClass+SagaData>.ConfigureHowToFindSaga
+IL_0007:  ldarg.1     
+IL_0008:  ldtoken     UserQuery.MessageA
+IL_000D:  call        System.Type.GetTypeFromHandle
+IL_0012:  ldstr       "msg"
+IL_0017:  call        System.Linq.Expressions.Expression.Parameter
+IL_001C:  stloc.0     
+IL_001D:  ldloc.0     
+IL_001E:  ldtoken     UserQuery+MessageA.get_Correlation
+IL_0023:  call        System.Reflection.MethodBase.GetMethodFromHandle
+IL_0028:  castclass   System.Reflection.MethodInfo
+IL_002D:  call        System.Linq.Expressions.Expression.Property
+IL_0032:  ldc.i4.1    
+IL_0033:  newarr      System.Linq.Expressions.ParameterExpression
+IL_0038:  dup         
+IL_0039:  ldc.i4.0    
+IL_003A:  ldloc.0     
+IL_003B:  stelem.ref  
+IL_003C:  call        System.Linq.Expressions.Expression.Lambda<Func`2>
+IL_0041:  callvirt    NServiceBus.SagaPropertyMapper<UserQuery+HasBaseSagaClass+SagaData>.ConfigureMapping<MessageA>
+IL_0046:  ldtoken     UserQuery+HasBaseSagaClass.SagaData
+IL_004B:  call        System.Type.GetTypeFromHandle
+IL_0050:  ldstr       "saga"
+IL_0055:  call        System.Linq.Expressions.Expression.Parameter
+IL_005A:  stloc.0     
+IL_005B:  ldloc.0     
+IL_005C:  ldtoken     UserQuery+HasBaseSagaClass+SagaData.get_Correlation
+IL_0061:  call        System.Reflection.MethodBase.GetMethodFromHandle
+IL_0066:  castclass   System.Reflection.MethodInfo
+IL_006B:  call        System.Linq.Expressions.Expression.Property
+IL_0070:  ldc.i4.1    
+IL_0071:  newarr      System.Linq.Expressions.ParameterExpression
+IL_0076:  dup         
+IL_0077:  ldc.i4.0    
+IL_0078:  ldloc.0     
+IL_0079:  stelem.ref  
+IL_007A:  call        System.Linq.Expressions.Expression.Lambda<Func`2>
+IL_007F:  callvirt    NServiceBus.ToSagaExpression<UserQuery+HasBaseSagaClass+SagaData,UserQuery+MessageA>.ToSaga
+IL_0084:  ret  
+*/

--- a/src/ScriptBuilder.Tests/Saga/CoreSagaMetadata/CoreSagaMetadataTests.MetadataInAttributeSaga.cs
+++ b/src/ScriptBuilder.Tests/Saga/CoreSagaMetadata/CoreSagaMetadataTests.MetadataInAttributeSaga.cs
@@ -1,0 +1,61 @@
+﻿using NServiceBus;
+using NServiceBus.Persistence.Sql;
+
+public partial class CoreSagaMetadataTests
+{
+    [SqlSaga(transitionalCorrelationProperty: "TransitionalCorrId", tableSuffix: "DifferentTableSuffix")]
+    public class MetadataInAttributeSaga : Saga<MetadataInAttributeSaga.SagaData>
+    {
+        public class SagaData : ContainSagaData
+        {
+            public string Correlation { get; set; }
+            public string TransitionalCorrId { get; set; }
+        }
+
+        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+        {
+            mapper.ConfigureMapping<MessageA>(msg => msg.Correlation).ToSaga(saga => saga.Correlation);
+        }
+    }
+}
+/* IL:
+MetadataInAttributeSaga.ConfigureHowToFindSaga:
+IL_0000:  ldarg.1     
+IL_0001:  ldtoken     UserQuery.MessageA
+IL_0006:  call        System.Type.GetTypeFromHandle
+IL_000B:  ldstr       "msg"
+IL_0010:  call        System.Linq.Expressions.Expression.Parameter
+IL_0015:  stloc.0     
+IL_0016:  ldloc.0     
+IL_0017:  ldtoken     UserQuery+MessageA.get_Correlation
+IL_001C:  call        System.Reflection.MethodBase.GetMethodFromHandle
+IL_0021:  castclass   System.Reflection.MethodInfo
+IL_0026:  call        System.Linq.Expressions.Expression.Property
+IL_002B:  ldc.i4.1    
+IL_002C:  newarr      System.Linq.Expressions.ParameterExpression
+IL_0031:  dup         
+IL_0032:  ldc.i4.0    
+IL_0033:  ldloc.0     
+IL_0034:  stelem.ref  
+IL_0035:  call        System.Linq.Expressions.Expression.Lambda<Func`2>
+IL_003A:  callvirt    NServiceBus.SagaPropertyMapper<UserQuery+MetadataInAttributeSaga+SagaData>.ConfigureMapping<MessageA>
+IL_003F:  ldtoken     UserQuery+MetadataInAttributeSaga.SagaData
+IL_0044:  call        System.Type.GetTypeFromHandle
+IL_0049:  ldstr       "saga"
+IL_004E:  call        System.Linq.Expressions.Expression.Parameter
+IL_0053:  stloc.0     
+IL_0054:  ldloc.0     
+IL_0055:  ldtoken     UserQuery+MetadataInAttributeSaga+SagaData.get_Correlation
+IL_005A:  call        System.Reflection.MethodBase.GetMethodFromHandle
+IL_005F:  castclass   System.Reflection.MethodInfo
+IL_0064:  call        System.Linq.Expressions.Expression.Property
+IL_0069:  ldc.i4.1    
+IL_006A:  newarr      System.Linq.Expressions.ParameterExpression
+IL_006F:  dup         
+IL_0070:  ldc.i4.0    
+IL_0071:  ldloc.0     
+IL_0072:  stelem.ref  
+IL_0073:  call        System.Linq.Expressions.Expression.Lambda<Func`2>
+IL_0078:  callvirt    NServiceBus.ToSagaExpression<UserQuery+MetadataInAttributeSaga+SagaData,UserQuery+MessageA>.ToSaga
+IL_007D:  ret
+*/

--- a/src/ScriptBuilder.Tests/Saga/CoreSagaMetadata/CoreSagaMetadataTests.MethodCallInMappingSaga.cs
+++ b/src/ScriptBuilder.Tests/Saga/CoreSagaMetadata/CoreSagaMetadataTests.MethodCallInMappingSaga.cs
@@ -1,0 +1,69 @@
+﻿using NServiceBus;
+
+public partial class CoreSagaMetadataTests
+{
+    public class MethodCallInMappingSaga : Saga<MethodCallInMappingSaga.SagaData>
+    {
+        public class SagaData : ContainSagaData
+        {
+            public string Correlation { get; set; }
+        }
+
+        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+        {
+            mapper.ConfigureMapping<MessageA>(msg => msg.Correlation).ToSaga(saga => MapInMethod(saga));
+        }
+
+        static object MapInMethod(SagaData data)
+        {
+            return data.Correlation;
+        }
+    }
+}
+/* IL:
+MethodCallInMappingSaga.ConfigureHowToFindSaga:
+IL_0000:  ldarg.1     
+IL_0001:  ldtoken     UserQuery.MessageA
+IL_0006:  call        System.Type.GetTypeFromHandle
+IL_000B:  ldstr       "msg"
+IL_0010:  call        System.Linq.Expressions.Expression.Parameter
+IL_0015:  stloc.0     
+IL_0016:  ldloc.0     
+IL_0017:  ldtoken     UserQuery+MessageA.get_Correlation
+IL_001C:  call        System.Reflection.MethodBase.GetMethodFromHandle
+IL_0021:  castclass   System.Reflection.MethodInfo
+IL_0026:  call        System.Linq.Expressions.Expression.Property
+IL_002B:  ldc.i4.1    
+IL_002C:  newarr      System.Linq.Expressions.ParameterExpression
+IL_0031:  dup         
+IL_0032:  ldc.i4.0    
+IL_0033:  ldloc.0     
+IL_0034:  stelem.ref  
+IL_0035:  call        System.Linq.Expressions.Expression.Lambda<Func`2>
+IL_003A:  callvirt    NServiceBus.SagaPropertyMapper<UserQuery+MethodCallInMappingSaga+SagaData>.ConfigureMapping<MessageA>
+IL_003F:  ldtoken     UserQuery+MethodCallInMappingSaga.SagaData
+IL_0044:  call        System.Type.GetTypeFromHandle
+IL_0049:  ldstr       "saga"
+IL_004E:  call        System.Linq.Expressions.Expression.Parameter
+IL_0053:  stloc.0     
+IL_0054:  ldnull      
+IL_0055:  ldtoken     UserQuery+MethodCallInMappingSaga.MapInMethod
+IL_005A:  call        System.Reflection.MethodBase.GetMethodFromHandle
+IL_005F:  castclass   System.Reflection.MethodInfo
+IL_0064:  ldc.i4.1    
+IL_0065:  newarr      System.Linq.Expressions.Expression
+IL_006A:  dup         
+IL_006B:  ldc.i4.0    
+IL_006C:  ldloc.0     
+IL_006D:  stelem.ref  
+IL_006E:  call        System.Linq.Expressions.Expression.Call
+IL_0073:  ldc.i4.1    
+IL_0074:  newarr      System.Linq.Expressions.ParameterExpression
+IL_0079:  dup         
+IL_007A:  ldc.i4.0    
+IL_007B:  ldloc.0     
+IL_007C:  stelem.ref  
+IL_007D:  call        System.Linq.Expressions.Expression.Lambda<Func`2>
+IL_0082:  callvirt    NServiceBus.ToSagaExpression<UserQuery+MethodCallInMappingSaga+SagaData,UserQuery+MessageA>.ToSaga
+IL_0087:  ret         
+*/

--- a/src/ScriptBuilder.Tests/Saga/CoreSagaMetadata/CoreSagaMetadataTests.PassingMapperSaga.cs
+++ b/src/ScriptBuilder.Tests/Saga/CoreSagaMetadata/CoreSagaMetadataTests.PassingMapperSaga.cs
@@ -1,0 +1,28 @@
+﻿using NServiceBus;
+
+public partial class CoreSagaMetadataTests
+{
+    public class PassingMapperSaga : Saga<PassingMapperSaga.SagaData>
+    {
+        public class SagaData : ContainSagaData
+        {
+            public string Correlation { get; set; }
+        }
+
+        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+        {
+            PassTheMapper(mapper);
+        }
+
+        static void PassTheMapper(SagaPropertyMapper<SagaData> mapper)
+        {
+            mapper.ConfigureMapping<MessageA>(msg => msg.Correlation).ToSaga(saga => saga.Correlation);
+        }
+    }
+}
+/* IL:
+PassingMapperSaga.ConfigureHowToFindSaga:
+IL_0000:  ldarg.1     
+IL_0001:  call        UserQuery+PassingMapperSaga.PassTheMapper
+IL_0006:  ret  
+*/

--- a/src/ScriptBuilder.Tests/Saga/CoreSagaMetadata/CoreSagaMetadataTests.SharedMessages.cs
+++ b/src/ScriptBuilder.Tests/Saga/CoreSagaMetadata/CoreSagaMetadataTests.SharedMessages.cs
@@ -1,0 +1,25 @@
+﻿using NServiceBus;
+
+public partial class CoreSagaMetadataTests
+{
+    public class MessageA : ICommand
+    {
+        public string Correlation { get; set; }
+    }
+
+    public class MessageB : ICommand
+    {
+        public string Correlation { get; set; }
+    }
+
+    public class MessageC : ICommand
+    {
+        public string Part1 { get; set; }
+        public string Part2 { get; set; }
+    }
+
+    public class MessageD : ICommand
+    {
+        public string DifferentName { get; set; }
+    }
+}

--- a/src/ScriptBuilder.Tests/Saga/CoreSagaMetadata/CoreSagaMetadataTests.SingleMappingSaga.cs
+++ b/src/ScriptBuilder.Tests/Saga/CoreSagaMetadata/CoreSagaMetadataTests.SingleMappingSaga.cs
@@ -1,0 +1,58 @@
+﻿using NServiceBus;
+
+public partial class CoreSagaMetadataTests
+{
+    public class SingleMappingSaga : Saga<SingleMappingSaga.SagaData>
+    {
+        public class SagaData : ContainSagaData
+        {
+            public string Correlation { get; set; }
+        }
+
+        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+        {
+            mapper.ConfigureMapping<MessageA>(msg => msg.Correlation).ToSaga(saga => saga.Correlation);
+        }
+    }
+}
+/* IL:
+SingleMappingSaga.ConfigureHowToFindSaga:
+IL_0000:  ldarg.1     
+IL_0001:  ldtoken     UserQuery.MessageA
+IL_0006:  call        System.Type.GetTypeFromHandle
+IL_000B:  ldstr       "msg"
+IL_0010:  call        System.Linq.Expressions.Expression.Parameter
+IL_0015:  stloc.0     
+IL_0016:  ldloc.0     
+IL_0017:  ldtoken     UserQuery+MessageA.get_Correlation
+IL_001C:  call        System.Reflection.MethodBase.GetMethodFromHandle
+IL_0021:  castclass   System.Reflection.MethodInfo
+IL_0026:  call        System.Linq.Expressions.Expression.Property
+IL_002B:  ldc.i4.1    
+IL_002C:  newarr      System.Linq.Expressions.ParameterExpression
+IL_0031:  dup         
+IL_0032:  ldc.i4.0    
+IL_0033:  ldloc.0     
+IL_0034:  stelem.ref  
+IL_0035:  call        System.Linq.Expressions.Expression.Lambda<Func`2>
+IL_003A:  callvirt    NServiceBus.SagaPropertyMapper<UserQuery+SingleMappingSaga+SagaData>.ConfigureMapping<MessageA>
+IL_003F:  ldtoken     UserQuery+SingleMappingSaga.SagaData
+IL_0044:  call        System.Type.GetTypeFromHandle
+IL_0049:  ldstr       "saga"
+IL_004E:  call        System.Linq.Expressions.Expression.Parameter
+IL_0053:  stloc.0     
+IL_0054:  ldloc.0     
+IL_0055:  ldtoken     UserQuery+SingleMappingSaga+SagaData.get_Correlation
+IL_005A:  call        System.Reflection.MethodBase.GetMethodFromHandle
+IL_005F:  castclass   System.Reflection.MethodInfo
+IL_0064:  call        System.Linq.Expressions.Expression.Property
+IL_0069:  ldc.i4.1    
+IL_006A:  newarr      System.Linq.Expressions.ParameterExpression
+IL_006F:  dup         
+IL_0070:  ldc.i4.0    
+IL_0071:  ldloc.0     
+IL_0072:  stelem.ref  
+IL_0073:  call        System.Linq.Expressions.Expression.Lambda<Func`2>
+IL_0078:  callvirt    NServiceBus.ToSagaExpression<UserQuery+SingleMappingSaga+SagaData,UserQuery+MessageA>.ToSaga
+IL_007D:  ret    
+*/

--- a/src/ScriptBuilder.Tests/Saga/CoreSagaMetadata/CoreSagaMetadataTests.SingleMappingValueTypeSaga.cs
+++ b/src/ScriptBuilder.Tests/Saga/CoreSagaMetadata/CoreSagaMetadataTests.SingleMappingValueTypeSaga.cs
@@ -1,0 +1,61 @@
+﻿using NServiceBus;
+
+public partial class CoreSagaMetadataTests
+{
+    public class SingleMappingValueTypeSaga : Saga<SingleMappingValueTypeSaga.SagaData>
+    {
+        public class SagaData : ContainSagaData
+        {
+            public int Correlation { get; set; }
+        }
+
+        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+        {
+            mapper.ConfigureMapping<MessageA>(msg => msg.Correlation).ToSaga(saga => saga.Correlation);
+        }
+    }
+}
+/* IL:
+SingleMappingValueTypeSaga.ConfigureHowToFindSaga:
+IL_0000:  ldarg.1     
+IL_0001:  ldtoken     UserQuery.MessageA
+IL_0006:  call        System.Type.GetTypeFromHandle
+IL_000B:  ldstr       "msg"
+IL_0010:  call        System.Linq.Expressions.Expression.Parameter
+IL_0015:  stloc.0     
+IL_0016:  ldloc.0     
+IL_0017:  ldtoken     UserQuery+MessageA.get_Correlation
+IL_001C:  call        System.Reflection.MethodBase.GetMethodFromHandle
+IL_0021:  castclass   System.Reflection.MethodInfo
+IL_0026:  call        System.Linq.Expressions.Expression.Property
+IL_002B:  ldc.i4.1    
+IL_002C:  newarr      System.Linq.Expressions.ParameterExpression
+IL_0031:  dup         
+IL_0032:  ldc.i4.0    
+IL_0033:  ldloc.0     
+IL_0034:  stelem.ref  
+IL_0035:  call        System.Linq.Expressions.Expression.Lambda<Func`2>
+IL_003A:  callvirt    NServiceBus.SagaPropertyMapper<UserQuery+SingleMappingValueTypeSaga+SagaData>.ConfigureMapping<MessageA>
+IL_003F:  ldtoken     UserQuery+SingleMappingValueTypeSaga.SagaData
+IL_0044:  call        System.Type.GetTypeFromHandle
+IL_0049:  ldstr       "saga"
+IL_004E:  call        System.Linq.Expressions.Expression.Parameter
+IL_0053:  stloc.0     
+IL_0054:  ldloc.0     
+IL_0055:  ldtoken     UserQuery+SingleMappingValueTypeSaga+SagaData.get_Correlation
+IL_005A:  call        System.Reflection.MethodBase.GetMethodFromHandle
+IL_005F:  castclass   System.Reflection.MethodInfo
+IL_0064:  call        System.Linq.Expressions.Expression.Property
+IL_0069:  ldtoken     System.Object
+IL_006E:  call        System.Type.GetTypeFromHandle
+IL_0073:  call        System.Linq.Expressions.Expression.Convert
+IL_0078:  ldc.i4.1    
+IL_0079:  newarr      System.Linq.Expressions.ParameterExpression
+IL_007E:  dup         
+IL_007F:  ldc.i4.0    
+IL_0080:  ldloc.0     
+IL_0081:  stelem.ref  
+IL_0082:  call        System.Linq.Expressions.Expression.Lambda<Func`2>
+IL_0087:  callvirt    NServiceBus.ToSagaExpression<UserQuery+SingleMappingValueTypeSaga+SagaData,UserQuery+MessageA>.ToSaga
+IL_008C:  ret   
+*/

--- a/src/ScriptBuilder.Tests/Saga/CoreSagaMetadata/CoreSagaMetadataTests.SwitchingLogicSaga.cs
+++ b/src/ScriptBuilder.Tests/Saga/CoreSagaMetadata/CoreSagaMetadataTests.SwitchingLogicSaga.cs
@@ -1,0 +1,110 @@
+﻿using NServiceBus;
+
+public partial class CoreSagaMetadataTests
+{
+    public class SwitchingLogicSaga : Saga<SwitchingLogicSaga.SagaData>
+    {
+        int number = 0;
+
+        public class SagaData : ContainSagaData
+        {
+            public string Correlation { get; set; }
+            public string OtherProperty { get; set; }
+        }
+
+        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+        {
+            if (number > 0)
+            {
+                mapper.ConfigureMapping<MessageA>(msg => msg.Correlation).ToSaga(saga => saga.Correlation);
+            }
+            else
+            {
+                mapper.ConfigureMapping<MessageB>(msg => msg.Correlation).ToSaga(saga => saga.Correlation);
+            }
+        }
+    }
+}
+/* IL:
+SwitchingLogicSaga.ConfigureHowToFindSaga:
+IL_0000:  ldarg.0     
+IL_0001:  ldfld       UserQuery+SwitchingLogicSaga.number
+IL_0006:  ldc.i4.0    
+IL_0007:  ble.s       IL_0087
+IL_0009:  ldarg.1     
+IL_000A:  ldtoken     UserQuery.MessageA
+IL_000F:  call        System.Type.GetTypeFromHandle
+IL_0014:  ldstr       "msg"
+IL_0019:  call        System.Linq.Expressions.Expression.Parameter
+IL_001E:  stloc.0     
+IL_001F:  ldloc.0     
+IL_0020:  ldtoken     UserQuery+MessageA.get_Correlation
+IL_0025:  call        System.Reflection.MethodBase.GetMethodFromHandle
+IL_002A:  castclass   System.Reflection.MethodInfo
+IL_002F:  call        System.Linq.Expressions.Expression.Property
+IL_0034:  ldc.i4.1    
+IL_0035:  newarr      System.Linq.Expressions.ParameterExpression
+IL_003A:  dup         
+IL_003B:  ldc.i4.0    
+IL_003C:  ldloc.0     
+IL_003D:  stelem.ref  
+IL_003E:  call        System.Linq.Expressions.Expression.Lambda<Func`2>
+IL_0043:  callvirt    NServiceBus.SagaPropertyMapper<UserQuery+SwitchingLogicSaga+SagaData>.ConfigureMapping<MessageA>
+IL_0048:  ldtoken     UserQuery+SwitchingLogicSaga.SagaData
+IL_004D:  call        System.Type.GetTypeFromHandle
+IL_0052:  ldstr       "saga"
+IL_0057:  call        System.Linq.Expressions.Expression.Parameter
+IL_005C:  stloc.0     
+IL_005D:  ldloc.0     
+IL_005E:  ldtoken     UserQuery+SwitchingLogicSaga+SagaData.get_Correlation
+IL_0063:  call        System.Reflection.MethodBase.GetMethodFromHandle
+IL_0068:  castclass   System.Reflection.MethodInfo
+IL_006D:  call        System.Linq.Expressions.Expression.Property
+IL_0072:  ldc.i4.1    
+IL_0073:  newarr      System.Linq.Expressions.ParameterExpression
+IL_0078:  dup         
+IL_0079:  ldc.i4.0    
+IL_007A:  ldloc.0     
+IL_007B:  stelem.ref  
+IL_007C:  call        System.Linq.Expressions.Expression.Lambda<Func`2>
+IL_0081:  callvirt    NServiceBus.ToSagaExpression<UserQuery+SwitchingLogicSaga+SagaData,UserQuery+MessageA>.ToSaga
+IL_0086:  ret         
+IL_0087:  ldarg.1     
+IL_0088:  ldtoken     UserQuery.MessageB
+IL_008D:  call        System.Type.GetTypeFromHandle
+IL_0092:  ldstr       "msg"
+IL_0097:  call        System.Linq.Expressions.Expression.Parameter
+IL_009C:  stloc.0     
+IL_009D:  ldloc.0     
+IL_009E:  ldtoken     UserQuery+MessageB.get_Correlation
+IL_00A3:  call        System.Reflection.MethodBase.GetMethodFromHandle
+IL_00A8:  castclass   System.Reflection.MethodInfo
+IL_00AD:  call        System.Linq.Expressions.Expression.Property
+IL_00B2:  ldc.i4.1    
+IL_00B3:  newarr      System.Linq.Expressions.ParameterExpression
+IL_00B8:  dup         
+IL_00B9:  ldc.i4.0    
+IL_00BA:  ldloc.0     
+IL_00BB:  stelem.ref  
+IL_00BC:  call        System.Linq.Expressions.Expression.Lambda<Func`2>
+IL_00C1:  callvirt    NServiceBus.SagaPropertyMapper<UserQuery+SwitchingLogicSaga+SagaData>.ConfigureMapping<MessageB>
+IL_00C6:  ldtoken     UserQuery+SwitchingLogicSaga.SagaData
+IL_00CB:  call        System.Type.GetTypeFromHandle
+IL_00D0:  ldstr       "saga"
+IL_00D5:  call        System.Linq.Expressions.Expression.Parameter
+IL_00DA:  stloc.0     
+IL_00DB:  ldloc.0     
+IL_00DC:  ldtoken     UserQuery+SwitchingLogicSaga+SagaData.get_Correlation
+IL_00E1:  call        System.Reflection.MethodBase.GetMethodFromHandle
+IL_00E6:  castclass   System.Reflection.MethodInfo
+IL_00EB:  call        System.Linq.Expressions.Expression.Property
+IL_00F0:  ldc.i4.1    
+IL_00F1:  newarr      System.Linq.Expressions.ParameterExpression
+IL_00F6:  dup         
+IL_00F7:  ldc.i4.0    
+IL_00F8:  ldloc.0     
+IL_00F9:  stelem.ref  
+IL_00FA:  call        System.Linq.Expressions.Expression.Lambda<Func`2>
+IL_00FF:  callvirt    NServiceBus.ToSagaExpression<UserQuery+SwitchingLogicSaga+SagaData,UserQuery+MessageB>.ToSaga
+IL_0104:  ret 
+*/

--- a/src/ScriptBuilder.Tests/Saga/CoreSagaMetadata/CoreSagaMetadataTests.WhileLoopSaga.cs
+++ b/src/ScriptBuilder.Tests/Saga/CoreSagaMetadata/CoreSagaMetadataTests.WhileLoopSaga.cs
@@ -1,0 +1,73 @@
+﻿using NServiceBus;
+
+public partial class CoreSagaMetadataTests
+{
+    public class WhileLoopSaga : Saga<WhileLoopSaga.SagaData>
+    {
+        public class SagaData : ContainSagaData
+        {
+            public string Correlation { get; set; }
+        }
+
+        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+        {
+            var i = 0;
+            while(i < 3)
+            {
+                mapper.ConfigureMapping<MessageA>(msg => msg.Correlation).ToSaga(saga => saga.Correlation);
+                i++;
+            }
+        }
+    }
+}
+/* IL:  
+WhileLoopSaga.ConfigureHowToFindSaga:
+IL_0000:  ldc.i4.0    
+IL_0001:  stloc.0     // i
+IL_0002:  br          IL_0088
+IL_0007:  ldarg.1     
+IL_0008:  ldtoken     UserQuery.MessageA
+IL_000D:  call        System.Type.GetTypeFromHandle
+IL_0012:  ldstr       "msg"
+IL_0017:  call        System.Linq.Expressions.Expression.Parameter
+IL_001C:  stloc.1     
+IL_001D:  ldloc.1     
+IL_001E:  ldtoken     UserQuery+MessageA.get_Correlation
+IL_0023:  call        System.Reflection.MethodBase.GetMethodFromHandle
+IL_0028:  castclass   System.Reflection.MethodInfo
+IL_002D:  call        System.Linq.Expressions.Expression.Property
+IL_0032:  ldc.i4.1    
+IL_0033:  newarr      System.Linq.Expressions.ParameterExpression
+IL_0038:  dup         
+IL_0039:  ldc.i4.0    
+IL_003A:  ldloc.1     
+IL_003B:  stelem.ref  
+IL_003C:  call        System.Linq.Expressions.Expression.Lambda<Func`2>
+IL_0041:  callvirt    NServiceBus.SagaPropertyMapper<UserQuery+WhileLoopSaga+SagaData>.ConfigureMapping<MessageA>
+IL_0046:  ldtoken     UserQuery+WhileLoopSaga.SagaData
+IL_004B:  call        System.Type.GetTypeFromHandle
+IL_0050:  ldstr       "saga"
+IL_0055:  call        System.Linq.Expressions.Expression.Parameter
+IL_005A:  stloc.1     
+IL_005B:  ldloc.1     
+IL_005C:  ldtoken     UserQuery+WhileLoopSaga+SagaData.get_Correlation
+IL_0061:  call        System.Reflection.MethodBase.GetMethodFromHandle
+IL_0066:  castclass   System.Reflection.MethodInfo
+IL_006B:  call        System.Linq.Expressions.Expression.Property
+IL_0070:  ldc.i4.1    
+IL_0071:  newarr      System.Linq.Expressions.ParameterExpression
+IL_0076:  dup         
+IL_0077:  ldc.i4.0    
+IL_0078:  ldloc.1     
+IL_0079:  stelem.ref  
+IL_007A:  call        System.Linq.Expressions.Expression.Lambda<Func`2>
+IL_007F:  callvirt    NServiceBus.ToSagaExpression<UserQuery+WhileLoopSaga+SagaData,UserQuery+MessageA>.ToSaga
+IL_0084:  ldloc.0     // i
+IL_0085:  ldc.i4.1    
+IL_0086:  add         
+IL_0087:  stloc.0     // i
+IL_0088:  ldloc.0     // i
+IL_0089:  ldc.i4.3    
+IL_008A:  blt         IL_0007
+IL_008F:  ret
+*/

--- a/src/ScriptBuilder.Tests/Saga/CoreSagaMetadata/CoreSagaMetadataTests.cs
+++ b/src/ScriptBuilder.Tests/Saga/CoreSagaMetadata/CoreSagaMetadataTests.cs
@@ -1,0 +1,168 @@
+﻿using System;
+using System.IO;
+using Mono.Cecil;
+using NServiceBus.Persistence.Sql.ScriptBuilder;
+using NUnit.Framework;
+
+[TestFixture]
+public partial class CoreSagaMetadataTests
+{
+    ModuleDefinition module;
+
+    public CoreSagaMetadataTests()
+    {
+        var path = Path.Combine(TestContext.CurrentContext.TestDirectory, "ScriptBuilder.Tests.dll");
+        var readerParameters = new ReaderParameters(ReadingMode.Deferred);
+        module = ModuleDefinition.ReadModule(path, readerParameters);
+    }
+
+    [Test]
+    public void SingleMapping()
+    {
+        TestSagaDefinition<SingleMappingSaga>();
+    }
+
+    [Test]
+    public void SingleMappingValueType()
+    {
+        TestSagaDefinition<SingleMappingValueTypeSaga>();
+    }
+
+    [Test]
+    public void DualMapping()
+    {
+        TestSagaDefinition<DualMappingSaga>();
+    }
+
+    [Test]
+    public void DontMapWithIntermediateBase()
+    {
+        // Won't map to a saga definition (result will be null) but won't throw either.
+        // Behavior is the same as SqlSaga. Throw will occur at runtime.
+        TestSagaDefinition<HasBaseSagaClass>();
+    }
+
+    [Test]
+    public void DontAllowMethodCallInMapping()
+    {
+        TestSagaDefinition<MethodCallInMappingSaga>();
+    }
+
+    [Test]
+    public void DontAllowPassingMapper()
+    {
+        TestSagaDefinition<PassingMapperSaga>();
+
+    }
+
+    [Test]
+    public void DontMapConflictingCorrelationIds()
+    {
+        TestSagaDefinition<ConflictingCorrelationSaga>();
+    }
+
+    [Test]
+    public void DontMapSwitchingLogic()
+    {
+        TestSagaDefinition<SwitchingLogicSaga>();
+
+    }
+
+    [Test]
+    public void DontMapDelegateCalls()
+    {
+        TestSagaDefinition<DelegateCallingSaga>();
+    }
+
+    [Test]
+    public void DontAllowForLoop()
+    {
+        TestSagaDefinition<ForLoopSaga>();
+    }
+
+    [Test]
+    public void DontAllowWhileLoop()
+    {
+        TestSagaDefinition<WhileLoopSaga>();
+    }
+
+    [Test]
+    public void AllowConcatenatingMsgProperties()
+    {
+        TestSagaDefinition<ConcatMsgPropertiesSaga>();
+    }
+
+    [Test]
+    public void AllowConcatenatingMsgPropertiesWithFormat()
+    {
+        TestSagaDefinition<ConcatMsgPropertiesWithFormatSaga>();
+    }
+
+    [Test]
+    public void AllowConcatenatingMsgPropertiesWithInterpolation()
+    {
+        TestSagaDefinition<ConcatMsgPropertiesWithInterpolationSaga>();
+    }
+
+    [Test]
+    public void AllowConcatenatingMsgPropertiesWithOtherMethods()
+    {
+        TestSagaDefinition<ConcatMsgPropertiesWithOtherMethods>();
+    }
+
+    [Test]
+    public void SupplyAdditionalMetadataViaAttribute()
+    {
+        TestSagaDefinition<MetadataInAttributeSaga>();
+    }
+
+    [Test]
+    public void TestSagaInVB()
+    {
+        var vbPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "VBTestCode.dll");
+        var vbModule = ModuleDefinition.ReadModule(vbPath, new ReaderParameters(ReadingMode.Deferred));
+
+        TestSagaDefinition<VBTestCode.VBMultiTestSaga>(vbModule);
+    }
+
+    private void TestSagaDefinition<TSagaType>(ModuleDefinition moduleToUse = null)
+    {
+        moduleToUse = moduleToUse ?? module;
+
+        var dataType = moduleToUse.GetTypeDefinition<TSagaType>();
+        var instructions = InstructionAnalyzer.GetConfigureHowToFindSagaInstructions(dataType);
+
+        var results = new SagaInspectionResults
+        {
+            HasUnmanagedCalls = InstructionAnalyzer.CallsUnmanagedMethods(instructions),
+            HasUnexpectedCalls = InstructionAnalyzer.CallsUnexpectedMethods(instructions),
+            HasBranchingLogic = InstructionAnalyzer.ContainsBranchingLogic(instructions)
+        };
+
+        try
+        {
+            SagaDefinitionReader.TryGetSagaDefinition(dataType, out results.SagaDefinition);
+        }
+        catch (Exception x)
+        {
+            results.Exception = x.Message;
+        }
+       
+        TestApprover.VerifyWithJson(results);
+    }
+
+    class SagaInspectionResults
+    {
+        public bool HasUnmanagedCalls;
+        public bool HasUnexpectedCalls;
+        public bool HasBranchingLogic;
+        // ReSharper disable NotAccessedField.Local
+        public SagaDefinition SagaDefinition;
+        public string Exception;
+        // ReSharper restore NotAccessedField.Local
+    }
+
+
+
+
+}

--- a/src/ScriptBuilder.Tests/Saga/EnsureSqlSagaNotDecoratedBySqlSagaAttribute.cs
+++ b/src/ScriptBuilder.Tests/Saga/EnsureSqlSagaNotDecoratedBySqlSagaAttribute.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.IO;
+using Mono.Cecil;
+using NServiceBus;
+using NServiceBus.Persistence.Sql;
+using NUnit.Framework;
+
+
+[TestFixture]
+public class EnsureSqlSagaNotDecoratedBySqlSagaAttribute
+{
+    [Test]
+    public void ThrowIfAttributeExists()
+    {
+        var path = Path.Combine(TestContext.CurrentContext.TestDirectory, "ScriptBuilder.Tests.dll");
+        var readerParameters = new ReaderParameters(ReadingMode.Deferred);
+        var module = ModuleDefinition.ReadModule(path, readerParameters);
+        var dataType = module.GetTypeDefinition<SqlSagaWithAttribute>();
+
+        var ex = Assert.Throws<Exception>(() => SagaDefinitionReader.TryGetSagaDefinition(dataType, out _));
+        Assert.IsTrue(ex.Message.Contains("attribute is invalid"));
+    }
+
+    [SqlSaga]
+    public class SqlSagaWithAttribute : SqlSaga<SqlSagaWithAttribute.SagaData>
+    {
+        public class SagaData : ContainSagaData
+        {
+            public string Correlation { get; set; }
+        }
+
+        protected override string CorrelationPropertyName => "Correlation";
+
+        protected override void ConfigureMapping(IMessagePropertyMapper mapper)
+        {
+        }
+    }
+}

--- a/src/ScriptBuilder.Tests/Saga/SagaDefinitionReaderTest.cs
+++ b/src/ScriptBuilder.Tests/Saga/SagaDefinitionReaderTest.cs
@@ -23,7 +23,7 @@ public class SagaDefinitionReaderTest: IDisposable
         var sagaType = module.GetTypeDefinition<WithGenericSaga<int>>();
         var exception = Assert.Throws<ErrorsException>(() =>
         {
-            SagaDefinitionReader.TryGetSqlSagaDefinition(sagaType, out _);
+            SagaDefinitionReader.TryGetSagaDefinition(sagaType, out _);
         });
         Assert.IsNotNull(exception.Message);
         TestApprover.Verify(exception.Message);
@@ -50,7 +50,7 @@ public class SagaDefinitionReaderTest: IDisposable
         var sagaType = module.GetTypeDefinition<AbstractSaga>();
         var exception = Assert.Throws<ErrorsException>(() =>
         {
-            SagaDefinitionReader.TryGetSqlSagaDefinition(sagaType, out _);
+            SagaDefinitionReader.TryGetSagaDefinition(sagaType, out _);
         });
         Assert.IsNotNull(exception.Message);
         TestApprover.Verify(exception.Message);
@@ -65,33 +65,10 @@ public class SagaDefinitionReaderTest: IDisposable
     }
 
     [Test]
-    public void NonSqlSaga()
-    {
-        var sagaType = module.GetTypeDefinition<NonSqlSagaSaga>();
-        var exception = Assert.Throws<ErrorsException>(() =>
-        {
-            SagaDefinitionReader.TryGetSqlSagaDefinition(sagaType, out _);
-        });
-        Assert.IsNotNull(exception.Message);
-        TestApprover.Verify(exception.Message);
-    }
-
-    public class NonSqlSagaSaga : Saga<NonSqlSagaSaga.SagaData>
-    {
-        public class SagaData : ContainSagaData
-        {
-        }
-
-        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
-        {
-        }
-    }
-
-    [Test]
     public void Simple()
     {
         var sagaType = module.GetTypeDefinition<SimpleSaga>();
-        SagaDefinitionReader.TryGetSqlSagaDefinition(sagaType, out var definition);
+        SagaDefinitionReader.TryGetSagaDefinition(sagaType, out var definition);
 
         Assert.IsNotNull(definition);
         TestApprover.VerifyWithJson(definition);
@@ -120,7 +97,7 @@ public class SagaDefinitionReaderTest: IDisposable
         var sagaType = module.GetTypeDefinition<WithReadonlyPropertySaga>();
         var exception = Assert.Throws<ErrorsException>(() =>
         {
-            SagaDefinitionReader.TryGetSqlSagaDefinition(sagaType, out _);
+            SagaDefinitionReader.TryGetSagaDefinition(sagaType, out _);
         });
         Assert.IsNotNull(exception.Message);
         TestApprover.Verify(exception.Message);
@@ -144,7 +121,7 @@ public class SagaDefinitionReaderTest: IDisposable
     public void WithNoTransitionalCorrelation()
     {
         var sagaType = module.GetTypeDefinition<WithNoTransitionalCorrelationSaga>();
-        SagaDefinitionReader.TryGetSqlSagaDefinition(sagaType, out var definition);
+        SagaDefinitionReader.TryGetSagaDefinition(sagaType, out var definition);
         Assert.IsNotNull(definition);
         TestApprover.VerifyWithJson(definition);
     }
@@ -167,7 +144,7 @@ public class SagaDefinitionReaderTest: IDisposable
     public void WithTableSuffix()
     {
         var sagaType = module.GetTypeDefinition<TableSuffixSaga>();
-        SagaDefinitionReader.TryGetSqlSagaDefinition(sagaType, out var definition);
+        SagaDefinitionReader.TryGetSagaDefinition(sagaType, out var definition);
         Assert.IsNotNull(definition);
         TestApprover.VerifyWithJson(definition);
     }
@@ -191,7 +168,7 @@ public class SagaDefinitionReaderTest: IDisposable
     public void WithNoCorrelation()
     {
         var sagaType = module.GetTypeDefinition<WithNoCorrelationSaga>();
-        SagaDefinitionReader.TryGetSqlSagaDefinition(sagaType, out var definition);
+        SagaDefinitionReader.TryGetSagaDefinition(sagaType, out var definition);
         Assert.IsNotNull(definition);
         TestApprover.VerifyWithJson(definition);
     }
@@ -213,7 +190,7 @@ public class SagaDefinitionReaderTest: IDisposable
     public void WithStatementBodyProperty()
     {
         var sagaType = module.GetTypeDefinition<WithStatementBodyPropertySaga>();
-        SagaDefinitionReader.TryGetSqlSagaDefinition(sagaType, out var definition);
+        SagaDefinitionReader.TryGetSagaDefinition(sagaType, out var definition);
         Assert.IsNotNull(definition);
         TestApprover.VerifyWithJson(definition);
     }

--- a/src/ScriptBuilder.Tests/ScriptBuilder.Tests.csproj
+++ b/src/ScriptBuilder.Tests/ScriptBuilder.Tests.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <ProjectReference Include="..\ScriptBuilder\ScriptBuilder.csproj" />
     <ProjectReference Include="..\SqlPersistence\SqlPersistence.csproj" />
+    <ProjectReference Include="..\VBTestCode\VBTestCode.vbproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ScriptBuilder/Saga/AllSagaDefinitionReader.cs
+++ b/src/ScriptBuilder/Saga/AllSagaDefinitionReader.cs
@@ -20,7 +20,7 @@ class AllSagaDefinitionReader
         {
             try
             {
-                if (SagaDefinitionReader.TryGetSqlSagaDefinition(type, out var definition))
+                if (SagaDefinitionReader.TryGetSagaDefinition(type, out var definition))
                 {
                     sagas.Add(definition);
                 }

--- a/src/ScriptBuilder/Saga/InstructionAnalyzer.cs
+++ b/src/ScriptBuilder/Saga/InstructionAnalyzer.cs
@@ -1,0 +1,178 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using NServiceBus.Persistence.Sql;
+
+static class InstructionAnalyzer
+{
+    static HashSet<string> allowedMethods;
+
+    static InstructionAnalyzer()
+    {
+        allowedMethods = new HashSet<string>(new[]
+        {
+            "System.Array::Empty",
+            "System.Type::GetTypeFromHandle",
+            "System.Reflection.MethodBase::GetMethodFromHandle",
+            "System.Linq.Expressions.Expression::Convert",
+            "System.Linq.Expressions.Expression::Parameter",
+            "System.Linq.Expressions.Expression::Property",
+            "System.Linq.Expressions.Expression::Lambda",
+            "System.Linq.Expressions.Expression::Add",
+            "System.Linq.Expressions.Expression::Constant"
+        }, StringComparer.Ordinal);
+    }
+
+    public static IList<Instruction> GetConfigureHowToFindSagaInstructions(TypeDefinition sagaTypeDefinition)
+    {
+        var configureMethod = sagaTypeDefinition.Methods.FirstOrDefault(m => m.Name == "ConfigureHowToFindSaga");
+        if (configureMethod == null)
+        {
+            throw new ErrorsException("Saga does not contain a ConfigureHowToFindSaga method.");
+        }
+
+        return configureMethod.Body.Instructions;
+    }
+
+    public static bool ContainsBranchingLogic(IList<Instruction> instructions)
+    {
+        return instructions.Any(instruction => instruction.OpCode.FlowControl == FlowControl.Branch
+            || instruction.OpCode.FlowControl == FlowControl.Cond_Branch);
+    }
+
+    public static string GetCorrelationId(IList<Instruction> instructions, string sagaDataTypeName)
+    {
+        var loadInstructionsOnSagaData = instructions
+            .Where(instruction => instruction.OpCode.Code == Code.Ldtoken)
+            .Select(instruction => new
+            {
+                Instruction = instruction,
+                MethodDefinition = instruction.Operand as MethodDefinition
+            })
+            // Some Ldtokens have operands of type TypeDefinition, for loading types
+            .Where(x => x.MethodDefinition != null)
+            // We don't care about the ones where we're loading something from the message
+            .Where(x => x.MethodDefinition.DeclaringType.FullName == sagaDataTypeName)
+            .ToArray();
+
+        if (loadInstructionsOnSagaData.Any(i => !i.MethodDefinition.Name.StartsWith("get_")))
+        {
+            // After having an expression on the saga data, we shouldn't be doing anything
+            // except accessing properties
+            throw new ErrorsException("ToSaga() expression in Saga's ConfigureHowToFindSaga method should point to a saga data property.");
+        }
+
+        var correlationList = loadInstructionsOnSagaData
+            .Select(i => i.MethodDefinition.Name.Substring(4))
+            .Distinct()
+            .ToArray();
+
+        if (correlationList.Length > 1)
+        {
+            throw new ErrorsException("Saga can only have one correlation property identified by .ToSaga() expressions. Fix mappings in ConfigureHowToFindSaga to map to a single correlation property or decorate the saga with [SqlSaga] attribute.");
+        }
+
+        return correlationList.FirstOrDefault();
+    }
+
+    public static bool CallsUnmanagedMethods(IList<Instruction> instructions)
+    {
+        // OpCode Calli is for calling into unmanaged code. Certainly don't need to be doing that inside
+        // a ConfigureHowToFindSaga method: https://msdn.microsoft.com/en-us/library/d81ee808.aspx
+        return instructions.Any(instruction => instruction.OpCode.Code == Code.Calli);
+    }
+
+    public static bool CallsUnexpectedMethods(IList<Instruction> instructions)
+    {
+        var methodRefs = instructions
+            .Where(instruction => instruction.OpCode.Code == Code.Call || instruction.OpCode.Code == Code.Callvirt)
+            .Select(instruction => instruction.Operand as MethodReference)
+            .ToArray();
+
+        if (methodRefs.Any(methodRef => methodRef == null))
+        {
+            // Should not happen, all call/callvirt should have a MethodReference as an operand
+            throw new Exception("Can't determine method call type for MSIL instruction");
+        }
+
+        var interestingCalls = methodRefs
+            .Where(methodRef => !allowedMethods.Contains($"{methodRef.DeclaringType.FullName}::{methodRef.Name}"))
+            .Select(methodRef => new MethodRefClassifier
+            {
+                MethodRef = methodRef,
+                IsConfigureMapping = IsConfigureMappingMethodCall(methodRef),
+                IsToSaga = IsToSagaMethodCall(methodRef),
+                IsExpressionCall = IsExpressionCall(methodRef)
+            })
+            .Reverse()  // <----- Note on reversal below
+            .ToArray();
+
+        /* The ability to do Call expressions is necessary on the message mapping side in order to be able to,
+         * for instance, concatenate 2 message properties together into one value to look up in the saga data,
+         * i.e. ConfigureMapping(msg => $"{msg.PropA}/{msg.PropB}), and honestly in the message mapping portion
+         * we don't really care. But in the saga data portion, we want to be more conservative. Because of the way
+         * IL works, you have to get your arguments set up before you invoke the method with the pointers to
+         * arguments stored in registers, so that means everything related to ConfigureMapping comes BEFORE that call,
+         * and everything relating to ToSaga (where the correlation id will come from) comes before THAT call. By
+         * reversing the order of the methods that are left, we can see ConfigureMapping and ToSaga as signposts to
+         * determine whether the upcoming calls are either allowed or not.
+         */
+
+        var expressionCallsAllowed = false;
+        foreach (var item in interestingCalls)
+        {
+            if (item.IsConfigureMapping)
+            {
+                // This expression call (and those after) came before ConfigureMapping, meaning it's an argument of ConfigureMapping. It's OK.
+                expressionCallsAllowed = true;
+            }
+            else if (item.IsToSaga)
+            {
+                // This expression call (and those after) came before ToSaga, meaning it's an argument of ToSaga. Don't allow it.
+                expressionCallsAllowed = false;
+            }
+
+            item.ExpressionCallsAllowed = expressionCallsAllowed;
+        }
+
+        var badCalls = interestingCalls
+            .Where(item => !item.IsConfigureMapping && !item.IsToSaga)
+            .Where(item => !(item.IsExpressionCall && item.ExpressionCallsAllowed.Value))
+            .ToArray();
+
+        return badCalls.Length > 0;
+    }
+
+    class MethodRefClassifier
+    {
+        public MethodReference MethodRef { get; set; }
+        public bool IsConfigureMapping { get; set; }
+        public bool IsToSaga { get; set; }
+        public bool IsExpressionCall { get; set; }
+        public bool? ExpressionCallsAllowed { get; set; }
+    }
+
+    static bool IsConfigureMappingMethodCall(MethodReference methodRef)
+    {
+        // FullName would be NServiceBus.SagaPropertyMapper<SagaData>
+        return methodRef.Name == "ConfigureMapping" 
+               && methodRef.DeclaringType.FullName.StartsWith("NServiceBus.SagaPropertyMapper`");
+    }
+
+    static bool IsToSagaMethodCall(MethodReference methodRef)
+    {
+        // FullName would be NServiceBus.ToSagaExpression<SagaData,MessageType>
+        // Don't validate the entire thing because we won't know the message type, and could be called multiple times
+        return methodRef.Name == "ToSaga"
+               && methodRef.DeclaringType.FullName.StartsWith("NServiceBus.ToSagaExpression`");
+    }
+
+    static bool IsExpressionCall(MethodReference methodRef)
+    {
+        return methodRef.DeclaringType.FullName == "System.Linq.Expressions.Expression"
+               && methodRef.Name == "Call";
+    }
+
+}

--- a/src/ScriptBuilderTask.Tests/ScriptBuilderTask.Tests.csproj
+++ b/src/ScriptBuilderTask.Tests/ScriptBuilderTask.Tests.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)Test.snk</AssemblyOriginatorKeyFile>
-    <Optimize>false</Optimize>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/src/SqlPersistence.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/SqlPersistence.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -73,6 +73,14 @@ namespace NServiceBus.Persistence.Sql
         protected override void ConfigureHowToFindSaga(NServiceBus.IConfigureHowToFindSagaWithMessage mapper) { }
         protected abstract void ConfigureMapping(NServiceBus.Persistence.Sql.IMessagePropertyMapper mapper);
     }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.All, Inherited=false)]
+    public sealed class SqlSagaAttribute : System.Attribute
+    {
+        public SqlSagaAttribute(string correlationProperty = null, string transitionalCorrelationProperty = null, string tableSuffix = null) { }
+        public string CorrelationProperty { get; }
+        public string TableSuffix { get; }
+        public string TransitionalCorrelationProperty { get; }
+    }
     [System.ObsoleteAttribute("Use `persistence.SqlDialect<SqlDialect.DialectType>()` instead. Will be removed i" +
         "n version 5.0.0.", true)]
     public enum SqlVariant

--- a/src/SqlPersistence/Saga/SagaInfoCache.cs
+++ b/src/SqlPersistence/Saga/SagaInfoCache.cs
@@ -49,7 +49,7 @@ class SagaInfoCache
             {
                 throw new Exception($"The saga data '{sagaDataType.FullName}' is being used by both '{existing.SagaType}' and '{metadata.SagaType.FullName}'. Saga data can only be used by one saga.");
             }
-            var sagaInfo = BuildSagaInfo(sagaDataType, metadata.SagaType);
+            var sagaInfo = BuildSagaInfo(sagaDataType, metadata);
             cache[sagaDataType] = sagaInfo;
             if (sagaInfo.CorrelationProperty != null && !metadata.TryGetCorrelationProperty(out var _))
             {
@@ -67,12 +67,12 @@ class SagaInfoCache
         throw new Exception($"Could not find RuntimeSagaInfo for {sagaDataType.FullName}.");
     }
 
-    RuntimeSagaInfo BuildSagaInfo(Type sagaDataType, Type sagaType)
+    RuntimeSagaInfo BuildSagaInfo(Type sagaDataType, SagaMetadata metadata)
     {
         return new RuntimeSagaInfo(
             sagaDataType: sagaDataType,
             versionSpecificSettings: versionSpecificSettings,
-            sagaType: sagaType,
+            metadata: metadata,
             jsonSerializer: jsonSerializer,
             readerCreator: readerCreator,
             writerCreator: writerCreator,

--- a/src/SqlPersistence/Saga/SqlSaga.cs
+++ b/src/SqlPersistence/Saga/SqlSaga.cs
@@ -24,16 +24,6 @@
             }
         }
 
-        void VerifyBase()
-        {
-            var baseTypeFullName = GetType().BaseType.FullName;
-            var fullName = typeof(SqlSaga<>).FullName;
-            if (!baseTypeFullName.StartsWith(fullName))
-            {
-                throw new Exception($"Implementations of {fullName} must inherit from it directly. Deep class hierarchies are not supported.");
-            }
-        }
-
         /// <summary>
         /// Gets the name of the correlation property for <typeparamref name="TSagaData"/>.
         /// </summary>
@@ -70,7 +60,6 @@
         protected override void ConfigureHowToFindSaga(IConfigureHowToFindSagaWithMessage mapper)
         {
             VerifyNoConfigureHowToFindSaga();
-            VerifyBase();
             var propertyMapper = new PropertyMapper<TSagaData>(mapper, GetExpression(), GetType());
             ConfigureMapping(propertyMapper);
         }

--- a/src/SqlPersistence/Saga/SqlSagaAttribute.cs
+++ b/src/SqlPersistence/Saga/SqlSagaAttribute.cs
@@ -1,0 +1,47 @@
+﻿using System;
+
+namespace NServiceBus.Persistence.Sql
+{
+    /// <summary>
+    /// Exposes extra configuration options for storing <see cref="Saga{TSagaData}"/>.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, Inherited = false)]
+    public sealed class SqlSagaAttribute : Attribute
+    {
+        /// <summary>
+        /// Provides a means to identify the Saga correlation property if it cannot be determined by inspecting the ConfigureHowToFindSaga method.
+        /// Specifying the CorrelationProperty using this attribute will skip the inspection of the ConfigureHowToFindSaga method altogether.
+        /// </summary>
+        public string CorrelationProperty { get; }
+
+        /// <summary>
+        /// Used to transition between different properties for saga correlation.
+        /// </summary>
+        public string TransitionalCorrelationProperty { get; }
+
+        /// <summary>
+        /// The name of the table to use when storing the current <see cref="Saga{TSagaData}"/>.
+        /// Will be appended to the value specified in <see cref="SqlPersistenceConfig.TablePrefix"/>.
+        /// </summary>
+        public string TableSuffix { get; }
+
+        /// <summary>
+        /// Exposes extra configuration options for storing <see cref="Saga{TSagaData}"/>.
+        /// </summary>
+        /// <param name="correlationProperty">Identifies the Saga correlation property if it cannot be determined by inspecting the ConfigureHowToFindSaga method.</param>
+        /// <param name="transitionalCorrelationProperty">Used to transition between different properties for saga correlation.</param>
+        /// <param name="tableSuffix">
+        /// The name of the table to use when storing the current <see cref="Saga{TSagaData}"/>.
+        /// Will be appended to the value specified in <see cref="SqlPersistenceConfig.TablePrefix"/>.
+        /// </param>
+        public SqlSagaAttribute(
+            string correlationProperty = null,
+            string transitionalCorrelationProperty = null,
+            string tableSuffix = null)
+        {
+            CorrelationProperty = correlationProperty;
+            TransitionalCorrelationProperty = transitionalCorrelationProperty;
+            TableSuffix = tableSuffix;
+        }
+    }
+}

--- a/src/VBTestCode/Messages.vb
+++ b/src/VBTestCode/Messages.vb
@@ -1,0 +1,26 @@
+﻿Imports NServiceBus
+
+Public Class MessageA
+    Implements ICommand
+
+    Public Property Correlation As String
+End Class
+
+Public Class MessageB
+    Implements ICommand
+
+    Public Property Correlation As String
+End Class
+
+Public Class MessageC
+    Implements ICommand
+
+    Public Property Part1 As String
+    Public Property Part2 As String
+End Class
+
+Public Class MessageD
+    Implements ICommand
+
+    Public Property DifferentName As String
+End Class

--- a/src/VBTestCode/VBMultiTestSaga.vb
+++ b/src/VBTestCode/VBMultiTestSaga.vb
@@ -1,0 +1,18 @@
+Imports NServiceBus
+
+Public Class VBMultiTestSaga
+    Inherits Saga(Of VBMultiTestSaga.SagaData)
+
+    Public Class SagaData
+        Inherits ContainSagaData
+
+        Public Property Correlation As String
+    End Class
+
+    Protected Overrides Sub ConfigureHowToFindSaga(ByVal mapper As SagaPropertyMapper(Of SagaData))
+        mapper.ConfigureMapping(Of MessageA)(Function(msg) msg.Correlation).ToSaga(Function(saga) saga.Correlation)
+        mapper.ConfigureMapping(Of MessageD)(Function(msg) msg.DifferentName).ToSaga(Function(saga) saga.Correlation)
+        mapper.ConfigureMapping(Of MessageC)(Function(msg) msg.Part1 + msg.Part2 + $"{msg.Part1}{msg.Part2}" + String.Format("{0}{1}", msg.Part1, msg.Part2)) _
+            .ToSaga(Function(saga) saga.Correlation)
+    End Sub
+End Class

--- a/src/VBTestCode/VBTestCode.vbproj
+++ b/src/VBTestCode/VBTestCode.vbproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>$(SolutionDir)Test.snk</AssemblyOriginatorKeyFile>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NServiceBus" Version="7.*" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Connects to https://github.com/Particular/PlatformDevelopment/issues/2020

Enables use of normal `Saga<T>` API, throwing an error at build time if the user does anything far outside the ordinary and we can't determine correlation id from the ConfigureHowToFindSaga method, in which case, the user can either fix it, decorate with a (restored) [SqlSaga] attribute, or use `SqlSaga<T>`.

`SqlSaga<T>` is still supported and likely will continue to be so for a long time.