### PR TITLE
Fix compile error

### DIFF
--- a/src/ScriptBuilder/ScriptBuilder.csproj
+++ b/src/ScriptBuilder/ScriptBuilder.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="NuGetPackager" Version="0.6.1" />
   </ItemGroup>
 
-  <Target Name="BeforeBuildPackages" BeforeTargets="BuildPackages">
+  <Target Name="BeforeBuildPackages" BeforeTargets="BuildPackages" DependsOnTargets="RunResolvePackageDependencies">
     <CreateItem Include="@(PackageDefinitions)" Condition="'%(Name)' == 'Mono.Cecil'">
        <Output TaskParameter="Include" ItemName="MonoCecilRef" />
     </CreateItem>

--- a/src/ScriptBuilderTask/ScriptBuilderTask.csproj
+++ b/src/ScriptBuilderTask/ScriptBuilderTask.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="NuGetPackager" Version="0.6.1" />
   </ItemGroup>
   
-  <Target Name="BeforeBuildPackages" BeforeTargets="BuildPackages">
+  <Target Name="BeforeBuildPackages" BeforeTargets="BuildPackages" DependsOnTargets="RunResolvePackageDependencies">
     <CreateItem Include="@(PackageDefinitions)" Condition="'%(Name)' == 'Mono.Cecil'">
        <Output TaskParameter="Include" ItemName="MonoCecilRef" />
     </CreateItem>


### PR DESCRIPTION
The build failure was caused by a newer version of the SDK. See https://github.com/dotnet/sdk/issues/2342 for details on the problem and the workaround.

Note that the build will still fail for the PR due to a bug in GitVersion. In theory, it will be fine once merged into `support-2.2`. 