### PR TITLE
Check for collation correctness

### DIFF
--- a/src/MsSqlAcceptanceTests/SetUpFixture.cs
+++ b/src/MsSqlAcceptanceTests/SetUpFixture.cs
@@ -1,0 +1,12 @@
+using NUnit.Framework;
+
+[SetUpFixture]
+public class SetUpFixture
+{
+    [OneTimeSetUp]
+    public void SetUp()
+    {
+        MsSqlConnectionBuilder.DropDbIfCollationIncorrect();
+        MsSqlConnectionBuilder.CreateDbIfNotExists();
+    }
+}

--- a/src/ScriptBuilder.Tests/ApprovalFiles/SagaScriptBuilderTest.CreateWithCorrelation.ForScenario.MsSqlServer.approved.txt
+++ b/src/ScriptBuilder.Tests/ApprovalFiles/SagaScriptBuilderTest.CreateWithCorrelation.ForScenario.MsSqlServer.approved.txt
@@ -54,7 +54,7 @@ end
 declare @dataType_CorrelationProperty nvarchar(max);
 set @dataType_CorrelationProperty = (
   select data_type
-  from information_schema.columns
+  from INFORMATION_SCHEMA.COLUMNS
   where
     table_name = @tableNameWithoutSchema and
     table_schema = @schema and
@@ -106,7 +106,7 @@ declare @dropPropertiesQuery nvarchar(max);
 select @dropPropertiesQuery =
 (
     select 'alter table ' + @tableName + ' drop column ' + column_name + ';'
-    from information_schema.columns
+    from INFORMATION_SCHEMA.COLUMNS
     where
         table_name = @tableNameWithoutSchema and
         table_schema = @schema and

--- a/src/ScriptBuilder.Tests/ApprovalFiles/SagaScriptBuilderTest.CreateWithCorrelationAndTransitional.ForScenario.MsSqlServer.approved.txt
+++ b/src/ScriptBuilder.Tests/ApprovalFiles/SagaScriptBuilderTest.CreateWithCorrelationAndTransitional.ForScenario.MsSqlServer.approved.txt
@@ -54,7 +54,7 @@ end
 declare @dataType_CorrelationProperty nvarchar(max);
 set @dataType_CorrelationProperty = (
   select data_type
-  from information_schema.columns
+  from INFORMATION_SCHEMA.COLUMNS
   where
     table_name = @tableNameWithoutSchema and
     table_schema = @schema and
@@ -107,7 +107,7 @@ end
 declare @dataType_TransitionalProperty nvarchar(max);
 set @dataType_TransitionalProperty = (
   select data_type
-  from information_schema.columns
+  from INFORMATION_SCHEMA.COLUMNS
   where
     table_name = @tableNameWithoutSchema and
     table_schema = @schema and
@@ -160,7 +160,7 @@ declare @dropPropertiesQuery nvarchar(max);
 select @dropPropertiesQuery =
 (
     select 'alter table ' + @tableName + ' drop column ' + column_name + ';'
-    from information_schema.columns
+    from INFORMATION_SCHEMA.COLUMNS
     where
         table_name = @tableNameWithoutSchema and
         table_schema = @schema and

--- a/src/ScriptBuilder/Saga/Writers/MsSqlServerSagaScriptWriter.cs
+++ b/src/ScriptBuilder/Saga/Writers/MsSqlServerSagaScriptWriter.cs
@@ -67,7 +67,7 @@ end
 declare @dataType_{name} nvarchar(max);
 set @dataType_{name} = (
   select data_type
-  from information_schema.columns
+  from INFORMATION_SCHEMA.COLUMNS
   where
     table_name = @tableNameWithoutSchema and
     table_schema = @schema and
@@ -122,7 +122,7 @@ declare @dropPropertiesQuery nvarchar(max);
 select @dropPropertiesQuery =
 (
     select 'alter table ' + @tableName + ' drop column ' + column_name + ';'
-    from information_schema.columns
+    from INFORMATION_SCHEMA.COLUMNS
     where
         table_name = @tableNameWithoutSchema and
         table_schema = @schema and


### PR DESCRIPTION
* Fixes #347 by changing information_schema.columns to uppercase
* Changes the tests to make sure the database is in a case sensitive collation
  * First checks if the exists but has incorrect collation. If yes, then it drops the db
  * Next checks if DB exists. If no, creates db with correct collation