### PR TITLE
Recreate db before test run

### DIFF
--- a/src/MsSqlAcceptanceTests/SetUpFixture.cs
+++ b/src/MsSqlAcceptanceTests/SetUpFixture.cs
@@ -1,0 +1,11 @@
+using NUnit.Framework;
+
+[SetUpFixture]
+public class SetUpFixture
+{
+    [OneTimeSetUp]
+    public void SetUp()
+    {
+        MsSqlConnectionBuilder.DropAndCreateDb();
+    }
+}

--- a/src/TestHelper/MsSqlConnectionBuilder.cs
+++ b/src/TestHelper/MsSqlConnectionBuilder.cs
@@ -7,12 +7,7 @@ public static class MsSqlConnectionBuilder
 
     public static SqlConnection Build()
     {
-        var connection = Environment.GetEnvironmentVariable("SQLServerConnectionString");
-        if (string.IsNullOrWhiteSpace(connection))
-        {
-            return new SqlConnection(ConnectionString);
-        }
-        return new SqlConnection(connection);
+        return new SqlConnection(GetConnectionString());
     }
 
     public static bool IsSql2016OrHigher()
@@ -22,5 +17,44 @@ public static class MsSqlConnectionBuilder
             connection.Open();
             return Version.Parse(connection.ServerVersion).Major >= 13;
         }
+    }
+
+    public static void DropAndCreateDb()
+    {
+        var connectionStringBuilder = new SqlConnectionStringBuilder(GetConnectionString());
+        var databaseName = connectionStringBuilder.InitialCatalog;
+
+        connectionStringBuilder.InitialCatalog = "master";
+
+        using (var connection = new SqlConnection(connectionStringBuilder.ToString()))
+        {
+            connection.Open();
+
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = $@"use master;
+if exists(select * from sysdatabases where name = '{databaseName}')
+begin
+    alter database {databaseName} set SINGLE_USER with rollback immediate;
+    drop database {databaseName};
+end;
+
+CREATE DATABASE {databaseName};";
+
+                command.ExecuteNonQuery();
+            }
+        }
+    }
+
+    static string GetConnectionString()
+    {
+        var connection = Environment.GetEnvironmentVariable("SQLServerConnectionString");
+
+        if (string.IsNullOrWhiteSpace(connection))
+        {
+            return ConnectionString;
+        }
+
+        return connection;
     }
 }


### PR DESCRIPTION
Recreates the database before test runs. This is to ensure that the tests still pass on the release branch after the collation changes have been implemented in https://github.com/Particular/NServiceBus.Persistence.Sql/pull/353