### PR TITLE
Recreate db before test run

### DIFF
--- a/src/MsSqlAcceptanceTests/SetUpFixture.cs
+++ b/src/MsSqlAcceptanceTests/SetUpFixture.cs
@@ -1,0 +1,11 @@
+using NUnit.Framework;
+
+[SetUpFixture]
+public class SetUpFixture
+{
+    [OneTimeSetUp]
+    public void SetUp()
+    {
+        MsSqlConnectionBuilder.DropAndCreateDb();
+    }
+}


### PR DESCRIPTION
Recreates the database before test runs. This is to ensure that the tests still pass on the release branch after the collation changes have been implemented in https://github.com/Particular/NServiceBus.Persistence.Sql/pull/353