### PR TITLE
Use interface for path that is used outside the customer saga finders

### DIFF
--- a/src/SqlPersistence/SqlPersistenceStorageSessionExtensions.cs
+++ b/src/SqlPersistence/SqlPersistenceStorageSessionExtensions.cs
@@ -22,7 +22,16 @@
             return GetSqlStorageSession(session);
         }
 
-        static StorageSession GetSqlStorageSession(this SynchronizedStorageSession session)
+        static ISqlStorageSession GetSqlStorageSession(this SynchronizedStorageSession session)
+        {
+            if (session is ISqlStorageSession storageSession)
+            {
+                return storageSession;
+            }
+            throw new Exception("Cannot access the SQL synchronized storage session. Either this endpoint has not been configured to use the SQL persistence or a different persistence type is used for sagas.");
+        }
+
+        static StorageSession GetInternalSqlStorageSession(this SynchronizedStorageSession session)
         {
             if (session is StorageSession storageSession)
             {
@@ -48,7 +57,7 @@
             Guard.AgainstNullAndEmpty(nameof(whereClause), whereClause);
 
             var writableContextBag = (ContextBag)context;
-            var sqlSession = session.GetSqlStorageSession();
+            var sqlSession = session.GetInternalSqlStorageSession();
 
             if (sqlSession.InfoCache == null)
             {

--- a/src/SqlPersistence/SqlPersistenceStorageSessionExtensions.cs
+++ b/src/SqlPersistence/SqlPersistenceStorageSessionExtensions.cs
@@ -1,11 +1,11 @@
 ﻿namespace NServiceBus
 {
     using System;
-    using Persistence;
-    using Persistence.Sql;
     using System.Data.Common;
     using System.Threading.Tasks;
     using Extensibility;
+    using Persistence;
+    using Persistence.Sql;
     using Sagas;
 
     /// <summary>
@@ -14,20 +14,17 @@
     public static class SqlPersistenceStorageSessionExtensions
     {
         /// <summary>
-        /// Gets the current context SqlPersistence <see cref="ISqlStorageSession"/>.
+        /// Gets the current context SqlPersistence <see cref="ISqlStorageSession" />.
         /// </summary>
         public static ISqlStorageSession SqlPersistenceSession(this SynchronizedStorageSession session)
         {
             Guard.AgainstNull(nameof(session), session);
-            return GetSqlStorageSession(session);
-        }
 
-        static ISqlStorageSession GetSqlStorageSession(this SynchronizedStorageSession session)
-        {
             if (session is ISqlStorageSession storageSession)
             {
                 return storageSession;
             }
+
             throw new Exception("Cannot access the SQL synchronized storage session. Either this endpoint has not been configured to use the SQL persistence or a different persistence type is used for sagas.");
         }
 
@@ -37,17 +34,21 @@
             {
                 return storageSession;
             }
+
             throw new Exception("Cannot access the SQL synchronized storage session. Either this endpoint has not been configured to use the SQL persistence or a different persistence type is used for sagas.");
         }
 
         /// <summary>
-        /// Retrieves a <see cref="IContainSagaData"/> instance. Used when implementing a <see cref="IFindSagas{T}"/>.
+        /// Retrieves a <see cref="IContainSagaData" /> instance. Used when implementing a <see cref="IFindSagas{T}" />.
         /// </summary>
-        /// <typeparam name="TSagaData">The <see cref="IContainSagaData"/> type to return.</typeparam>
-        /// <param name="session">Used to provide an extension point and access the current <see cref="DbConnection"/> and <see cref="DbTransaction"/>.</param>
+        /// <typeparam name="TSagaData">The <see cref="IContainSagaData" /> type to return.</typeparam>
+        /// <param name="session">
+        /// Used to provide an extension point and access the current <see cref="DbConnection" /> and
+        /// <see cref="DbTransaction" />.
+        /// </param>
         /// <param name="context">Used to append a concurrency value that can be verified when the SagaData is persisted.</param>
         /// <param name="whereClause">The SQL where clause to append to the retrieve saga SQL statement.</param>
-        /// <param name="appendParameters">Used to append <see cref="DbParameter"/>s used in the <paramref name="whereClause"/>.</param>
+        /// <param name="appendParameters">Used to append <see cref="DbParameter" />s used in the <paramref name="whereClause" />.</param>
         public static Task<TSagaData> GetSagaData<TSagaData>(this SynchronizedStorageSession session, ReadOnlyContextBag context, string whereClause, ParameterAppender appendParameters)
             where TSagaData : class, IContainSagaData
         {
@@ -63,6 +64,7 @@
             {
                 throw new Exception("Cannot load saga data because the Sagas feature is disabled in the endpoint.");
             }
+
             return SagaPersister.GetByWhereClause<TSagaData>(whereClause, session, writableContextBag, appendParameters, sqlSession.InfoCache);
         }
     }


### PR DESCRIPTION
This uses the interface that is already public for the path that is used in the handler to enable simple testing over the testable context. It doesn't solve the problem for the saga finder but at least gets customer unstuck in a simple way for the handlers. I don't think the custom finders are a problem given that we don't recommend to use them anyway