### PR TITLE
Put targets file in buildTransitive also

### DIFF
--- a/src/ScriptBuilder.Tests/ScriptBuilder.Tests.csproj
+++ b/src/ScriptBuilder.Tests/ScriptBuilder.Tests.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
-    <PackageReference Include="Microsoft.SqlServer.TransactSql.ScriptDom" Version="14.*" />
+    <PackageReference Include="Microsoft.SqlServer.TransactSql.ScriptDom" Version="14.0.3811.1" />
   </ItemGroup>
 
 </Project>

--- a/src/SqlPersistence/SqlPersistence.csproj
+++ b/src/SqlPersistence/SqlPersistence.csproj
@@ -30,6 +30,7 @@
 
   <ItemGroup>
     <None Include="..\ScriptBuilderTask\NServiceBus.Persistence.Sql.targets" Pack="true" PackagePath="build" Visible="false" />
+    <None Include="..\ScriptBuilderTask\NServiceBus.Persistence.Sql.targets" Pack="true" PackagePath="buildTransitive" Visible="false" />
     <None Include="..\..\binaries\net452\NServiceBus.Persistence.Sql.ScriptBuilderTask.???" Pack="true" PackagePath="netclassic" Visible="false" />
     <None Include="..\..\binaries\netstandard1.5\NServiceBus.Persistence.Sql.ScriptBuilderTask.???" Pack="true" PackagePath="netstandard" Visible="false" />
   </ItemGroup>

--- a/src/TestHelper/TestHelper.csproj
+++ b/src/TestHelper/TestHelper.csproj
@@ -7,13 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Npgsql " Version="4.*" />
-    <PackageReference Include="MySql.Data" Version="8.*" ExcludeAssets="contentFiles" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.*" />
+    <PackageReference Include="Npgsql" Version="4.0.10" />
+    <PackageReference Include="MySql.Data" Version="8.0.17" ExcludeAssets="contentFiles" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
-    <PackageReference Include="Oracle.ManagedDataAccess" Version="12.*" />
+    <PackageReference Include="Oracle.ManagedDataAccess" Version="12.2.1100" />
   </ItemGroup>
 
 </Project>

--- a/src/VBTestCode/VBTestCode.vbproj
+++ b/src/VBTestCode/VBTestCode.vbproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="7.*" />
+    <PackageReference Include="NServiceBus" Version="7.1.10" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
NuGet 5.0 introduced support for a `buildTransitive` folder that ensures that any props or targets files in it are transitively referenced across project references.

Add the targets file to this folder means that any sagas that are in a project that only has a transitive reference to the persistence package will also have their scripts created.

This means that anyone using NuGet 5.0, for example from VS 2019 or the .NET Core 3.0 SDK, will get the expected behavior.

And if for some reason they don't want the saga scripts to be created, the [already documented](https://docs.particular.net/persistence/sql/controlling-script-generation#disabling-script-generation) way of disabling it still works.