### PR TITLE
Use GeneratePathProperty to simplify project file

### DIFF
--- a/src/MsSqlAcceptanceTests.SqlTransport/MsSqlAcceptanceTests.SqlTransport.csproj
+++ b/src/MsSqlAcceptanceTests.SqlTransport/MsSqlAcceptanceTests.SqlTransport.csproj
@@ -11,23 +11,19 @@
     <ProjectReference Include="..\AcceptanceTestHelper\AcceptanceTestHelper.csproj" />
   </ItemGroup>
 
-  <PropertyGroup Label="This variable is needed to bring the acceptance testing framework w/o bringing the acceptance tests. See ItemGroup below where ATTs are excluded, but the framework is brought in. The variable helps to idenfity the location of the FW.">
-    <SourcePackageVersion>7.2.0</SourcePackageVersion>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="$(SourcePackageVersion)" />
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.2.0" GeneratePathProperty="true" />
     <PackageReference Include="NServiceBus.SqlServer" Version="4.0.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Remove="$(NuGetPackageRoot)nservicebus.acceptancetests.sources\**\*.cs" />
-    <Compile Include="$(NuGetPackageRoot)nservicebus.acceptancetests.sources\$(SourcePackageVersion)\contentFiles\cs\any\**\EndpointTemplates\*.cs" />
-    <Compile Include="$(NuGetPackageRoot)nservicebus.acceptancetests.sources\$(SourcePackageVersion)\contentFiles\cs\any\**\ScenarioDescriptors\*.cs" />
-    <Compile Include="$(NuGetPackageRoot)nservicebus.acceptancetests.sources\$(SourcePackageVersion)\contentFiles\cs\any\**\NServiceBusAcceptanceTest.cs" />
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\*.cs" />
+    <Compile Include="$(PkgNServiceBus_AcceptanceTests_Sources)\contentFiles\cs\any\**\EndpointTemplates\*.cs" />
+    <Compile Include="$(PkgNServiceBus_AcceptanceTests_Sources)\contentFiles\cs\any\**\ScenarioDescriptors\*.cs" />
+    <Compile Include="$(PkgNServiceBus_AcceptanceTests_Sources)\contentFiles\cs\any\**\NServiceBusAcceptanceTest.cs" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This gets rid of needing a special way to handle the version of the NServiceBus.AcceptanceTests.Sources package by using the new `GeneratePathProperty` feature.

Unfortunately, we can't merge this yet because it requires VS 2019 to use from inside VS, and our build agents haven't been updated yet.