### PR TITLE
Adds a Deconstruct extension method on ISqlStorageSession

### DIFF
--- a/src/SqlPersistence.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/SqlPersistence.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -83,7 +83,7 @@ namespace NServiceBus.Persistence.Sql
     }
     [System.ObsoleteAttribute("Use `persistence.SqlDialect<SqlDialect.DialectType>()` instead. Will be removed i" +
         "n version 5.0.0.", true)]
-    public enum SqlVariant
+    public enum SqlVariant : int
     {
         MsSqlServer = 0,
         MySql = 1,
@@ -127,6 +127,13 @@ namespace NServiceBus.Persistence.Sql
     public class TimeoutSettings
     {
         public void ConnectionBuilder(System.Func<System.Data.Common.DbConnection> connectionBuilder) { }
+    }
+}
+namespace NServiceBus.Persistence.Sql.SynchronizedStorage
+{
+    public class static SqlStorageSessionTupleExtensions
+    {
+        public static void Deconstruct(this NServiceBus.Persistence.Sql.ISqlStorageSession session, out System.Data.Common.DbConnection connection, out System.Data.Common.DbTransaction transaction) { }
     }
 }
 namespace NServiceBus

--- a/src/SqlPersistence.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/SqlPersistence.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -83,7 +83,7 @@ namespace NServiceBus.Persistence.Sql
     }
     [System.ObsoleteAttribute("Use `persistence.SqlDialect<SqlDialect.DialectType>()` instead. Will be removed i" +
         "n version 5.0.0.", true)]
-    public enum SqlVariant : int
+    public enum SqlVariant
     {
         MsSqlServer = 0,
         MySql = 1,

--- a/src/SqlPersistence/SynchronizedStorage/SqlStorageSessionTupleExtensions.cs
+++ b/src/SqlPersistence/SynchronizedStorage/SqlStorageSessionTupleExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System.Data.Common;
+    
+namespace NServiceBus.Persistence.Sql.SynchronizedStorage
+{
+    /// <summary>
+    /// Tuple deconstructor extension method for <see cref="ISqlStorageSession"/>.
+    /// </summary>
+    public static class SqlStorageSessionTupleExtensions
+    {
+        /// <summary>
+        /// Tuple deconstructor.
+        /// </summary>
+        /// <param name="session">Session that this deconstructor works on.</param>
+        /// <param name="connection">The current database connection (first tuple argument).</param>
+        /// <param name="transaction">The current database transaction (second tuple argument).</param>
+        public static void Deconstruct(this ISqlStorageSession session, out DbConnection connection, out DbTransaction transaction)
+        {
+            connection = session.Connection;
+            transaction = session.Transaction;
+        }
+    }
+}


### PR DESCRIPTION
Adds tuple deconstruction of its Connection and Transaction properties.

Enables:
```csharp
var (connection, transaction) = context.SynchronizedStorageSession.SqlPersistenceSession();
```