### PR TITLE
LangVersion fixed to `latest` for VbTests

### DIFF
--- a/src/VBTestCode/VBTestCode.vbproj
+++ b/src/VBTestCode/VBTestCode.vbproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <LangVersion>latest</LangVersion>
     <TargetFrameworks>net452;netcoreapp2.1</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)Test.snk</AssemblyOriginatorKeyFile>


### PR DESCRIPTION
It looks that when we [fixed](https://github.com/Particular/NServiceBus.Persistence.Sql/commit/484eb3646b2df4b714a59f04b136d25a5bb54bfc) the LangVersion for the solution recently we missed the fact that VisualBasic has different ranges.

This PR is setting the LangVersion for VbTests to `latest`.  I think this is an easy fix and doesn't and it influences only the test project. An alternative would be to fix the version to some concrete number e.g. `16` but I AFAIK that doesn't really make any difference.