### PR TITLE
Adds ROWLOCK hint

### DIFF
--- a/src/SqlPersistence/Saga/SqlDialect_MsSqlServer.cs
+++ b/src/SqlPersistence/Saga/SqlDialect_MsSqlServer.cs
@@ -89,7 +89,7 @@ select
     Metadata,
     Data
 from {tableName}
-with (updlock)
+with (updlock,rowlock)
 where Id = @Id
 ";
             }
@@ -104,7 +104,7 @@ select
     Metadata,
     Data
 from {tableName}
-with (updlock)
+with (updlock,rowlock)
 where Correlation_{propertyName} = @propertyValue
 ";
             }
@@ -127,7 +127,7 @@ select
     Metadata,
     Data
 from {tableName}
-with (updlock)
+with (updlock,rowlock)
 where {whereClause}
 ";
             }


### PR DESCRIPTION
A customer is running into issues with lock escalation. I was wondering if this could be prevented by adding the ROWLOCK hint.

>ROWLOCK
>Specifies that row locks are taken when page or table locks are ordinarily taken. When specified in transactions operating at the SNAPSHOT isolation level, row locks are not taken unless ROWLOCK is combined with other table hints that require locks, such as UPDLOCK and HOLDLOCK.

https://docs.microsoft.com/en-us/sql/t-sql/queries/hints-transact-sql-table?view=sql-server-ver15