### PR TITLE
Fixed InvalidCastException when using Microsoft.Data.SqlClient

### DIFF
--- a/src/SqlPersistence/Config/SqlDialect_MsSqlServer.cs
+++ b/src/SqlPersistence/Config/SqlDialect_MsSqlServer.cs
@@ -34,11 +34,18 @@ namespace NServiceBus
                 //TODO: do ArraySegment fro outbox
                 if (value is ArraySegment<char> charSegment)
                 {
-                    var sqlParameter = (SqlParameter)parameter;
-
-                    sqlParameter.Value = charSegment.Array;
-                    sqlParameter.Offset = charSegment.Offset;
-                    sqlParameter.Size = charSegment.Count;
+                    if (parameter is SqlParameter sqlParameter) {
+                        sqlParameter.Value = charSegment.Array;
+                        sqlParameter.Offset = charSegment.Offset;
+                        sqlParameter.Size = charSegment.Count;
+                    }
+                    #if NETSTANDARD2_0
+                    else if (parameter is Microsoft.Data.SqlClient.SqlParameter msSqlParameter) {
+                        msSqlParameter.Value = charSegment.Array;
+                        msSqlParameter.Offset = charSegment.Offset;
+                        msSqlParameter.Size = charSegment.Count;
+                    }
+                    #endif
                 }
                 else
                 {

--- a/src/SqlPersistence/SqlPersistence.csproj
+++ b/src/SqlPersistence/SqlPersistence.csproj
@@ -16,7 +16,8 @@
     <PackageReference Include="Obsolete.Fody" Version="4.3.2" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="0.5.0" PrivateAssets="All" />
     <PackageReference Include="System.Data.SqlClient" Version="4.4.3" />
-  </ItemGroup>
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.0" Condition="$(TargetFramework)=='netstandard2.0'" />
+ </ItemGroup>
 
   <ItemGroup>
     <Compile Include="..\Guard.cs" />


### PR DESCRIPTION
Fixes the InvalidCastException that occurs when initializing the NServiceBus Persistance with an SqlConnection instance from the Microsoft.Data.SqlClient package.

See this issue/comment for a description of the problem:
https://github.com/Particular/NServiceBus.SqlServer/issues/506#issuecomment-570193933