### PR TITLE
Align classes with namespace rules

### DIFF
--- a/src/MsSqlMicrosoftDataClientAcceptanceTests/ConfigureEndpointSqlPersistence.cs
+++ b/src/MsSqlMicrosoftDataClientAcceptanceTests/ConfigureEndpointSqlPersistence.cs
@@ -2,7 +2,6 @@
 using System.Threading.Tasks;
 using NServiceBus;
 using NServiceBus.AcceptanceTesting.Support;
-using NServiceBus.Persistence.Sql;
 using NServiceBus.Persistence.Sql.ScriptBuilder;
 
 public class ConfigureEndpointSqlPersistence : IConfigureEndpointTestExecution

--- a/src/MsSqlMicrosoftDataClientAcceptanceTests/When_using_multi_tenant.cs
+++ b/src/MsSqlMicrosoftDataClientAcceptanceTests/When_using_multi_tenant.cs
@@ -8,7 +8,6 @@ using NServiceBus.AcceptanceTests;
 using NServiceBus.AcceptanceTests.EndpointTemplates;
 using NServiceBus.Configuration.AdvancedExtensibility;
 using NServiceBus.Features;
-using NServiceBus.Persistence.Sql;
 using NServiceBus.Persistence.Sql.ScriptBuilder;
 using NServiceBus.Transport;
 using NUnit.Framework;

--- a/src/MsSqlMicrosoftDataClientSqlTransportAcceptanceTests/ConfigureEndpointSqlPersistence.cs
+++ b/src/MsSqlMicrosoftDataClientSqlTransportAcceptanceTests/ConfigureEndpointSqlPersistence.cs
@@ -2,7 +2,6 @@
 using System.Threading.Tasks;
 using NServiceBus;
 using NServiceBus.AcceptanceTesting.Support;
-using NServiceBus.Persistence.Sql;
 using NServiceBus.Persistence.Sql.ScriptBuilder;
 
 public class ConfigureEndpointSqlPersistence : IConfigureEndpointTestExecution

--- a/src/MsSqlSystemDataClientAcceptanceTests/ConfigureEndpointSqlPersistence.cs
+++ b/src/MsSqlSystemDataClientAcceptanceTests/ConfigureEndpointSqlPersistence.cs
@@ -2,7 +2,6 @@
 using System.Threading.Tasks;
 using NServiceBus;
 using NServiceBus.AcceptanceTesting.Support;
-using NServiceBus.Persistence.Sql;
 using NServiceBus.Persistence.Sql.ScriptBuilder;
 
 public class ConfigureEndpointSqlPersistence : IConfigureEndpointTestExecution

--- a/src/MsSqlSystemDataClientAcceptanceTests/When_using_multi_tenant.cs
+++ b/src/MsSqlSystemDataClientAcceptanceTests/When_using_multi_tenant.cs
@@ -8,7 +8,6 @@ using NServiceBus.AcceptanceTests;
 using NServiceBus.AcceptanceTests.EndpointTemplates;
 using NServiceBus.Configuration.AdvancedExtensibility;
 using NServiceBus.Features;
-using NServiceBus.Persistence.Sql;
 using NServiceBus.Persistence.Sql.ScriptBuilder;
 using NServiceBus.Transport;
 using NUnit.Framework;

--- a/src/MsSqlSystemDataClientSqlTransportAcceptanceTests/ConfigureEndpointSqlPersistence.cs
+++ b/src/MsSqlSystemDataClientSqlTransportAcceptanceTests/ConfigureEndpointSqlPersistence.cs
@@ -2,7 +2,6 @@
 using System.Threading.Tasks;
 using NServiceBus;
 using NServiceBus.AcceptanceTesting.Support;
-using NServiceBus.Persistence.Sql;
 using NServiceBus.Persistence.Sql.ScriptBuilder;
 
 public class ConfigureEndpointSqlPersistence : IConfigureEndpointTestExecution

--- a/src/MySqlAcceptanceTests/ConfigureEndpointSqlPersistence.cs
+++ b/src/MySqlAcceptanceTests/ConfigureEndpointSqlPersistence.cs
@@ -2,7 +2,6 @@
 using System.Threading.Tasks;
 using NServiceBus;
 using NServiceBus.AcceptanceTesting.Support;
-using NServiceBus.Persistence.Sql;
 using NServiceBus.Persistence.Sql.ScriptBuilder;
 
 public class ConfigureEndpointSqlPersistence : IConfigureEndpointTestExecution

--- a/src/OracleAcceptanceTests/ConfigureEndpointSqlPersistence.cs
+++ b/src/OracleAcceptanceTests/ConfigureEndpointSqlPersistence.cs
@@ -2,7 +2,6 @@
 using System.Threading.Tasks;
 using NServiceBus;
 using NServiceBus.AcceptanceTesting.Support;
-using NServiceBus.Persistence.Sql;
 using NServiceBus.Persistence.Sql.ScriptBuilder;
 
 public class ConfigureEndpointSqlPersistence : IConfigureEndpointTestExecution

--- a/src/PostgreSqlAcceptanceTests/ConfigureEndpointSqlPersistence.cs
+++ b/src/PostgreSqlAcceptanceTests/ConfigureEndpointSqlPersistence.cs
@@ -4,7 +4,6 @@ using Npgsql;
 using NpgsqlTypes;
 using NServiceBus;
 using NServiceBus.AcceptanceTesting.Support;
-using NServiceBus.Persistence.Sql;
 using NServiceBus.Persistence.Sql.ScriptBuilder;
 
 public class ConfigureEndpointSqlPersistence : IConfigureEndpointTestExecution

--- a/src/SqlPersistence.Tests/APIApprovals.cs
+++ b/src/SqlPersistence.Tests/APIApprovals.cs
@@ -1,4 +1,4 @@
-﻿using NServiceBus.Persistence.Sql;
+﻿using NServiceBus;
 using NUnit.Framework;
 using Particular.Approvals;
 using PublicApiGenerator;

--- a/src/SqlPersistence.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/SqlPersistence.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -32,10 +32,6 @@ namespace NServiceBus.Persistence.Sql
         public static System.Threading.Tasks.Task Install(NServiceBus.SqlDialect sqlDialect, string tablePrefix, System.Func<System.Data.Common.DbConnection> connectionBuilder, string scriptDirectory, bool shouldInstallOutbox = True, bool shouldInstallSagas = True, bool shouldInstallSubscriptions = True, bool shouldInstallTimeouts = True) { }
         public static System.Threading.Tasks.Task Install(NServiceBus.SqlDialect sqlDialect, string tablePrefix, System.Func<System.Type, System.Data.Common.DbConnection> connectionBuilder, string scriptDirectory, bool shouldInstallOutbox = True, bool shouldInstallSagas = True, bool shouldInstallSubscriptions = True, bool shouldInstallTimeouts = True) { }
     }
-    public class SqlPersistence : NServiceBus.Persistence.PersistenceDefinition
-    {
-        public SqlPersistence() { }
-    }
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.All)]
     public sealed class SqlPersistenceSettingsAttribute : System.Attribute
     {
@@ -69,6 +65,10 @@ namespace NServiceBus.Persistence.Sql
         public string TableSuffix { get; }
         public string TransitionalCorrelationProperty { get; }
     }
+    public class static SqlStorageSessionTupleExtensions
+    {
+        public static void Deconstruct(this NServiceBus.Persistence.Sql.ISqlStorageSession session, out System.Data.Common.DbConnection connection, out System.Data.Common.DbTransaction transaction) { }
+    }
     public class SubscriptionSettings
     {
         public void CacheFor(System.TimeSpan timeSpan) { }
@@ -78,13 +78,6 @@ namespace NServiceBus.Persistence.Sql
     public class TimeoutSettings
     {
         public void ConnectionBuilder(System.Func<System.Data.Common.DbConnection> connectionBuilder) { }
-    }
-}
-namespace NServiceBus.Persistence.Sql.SynchronizedStorage
-{
-    public class static SqlStorageSessionTupleExtensions
-    {
-        public static void Deconstruct(this NServiceBus.Persistence.Sql.ISqlStorageSession session, out System.Data.Common.DbConnection connection, out System.Data.Common.DbTransaction transaction) { }
     }
 }
 namespace NServiceBus
@@ -119,23 +112,27 @@ namespace NServiceBus
     {
         public SqlDialectSettings() { }
     }
+    public class SqlPersistence : NServiceBus.Persistence.PersistenceDefinition
+    {
+        public SqlPersistence() { }
+    }
     public class static SqlPersistenceConfig
     {
-        public static void ConnectionBuilder(this NServiceBus.PersistenceExtensions<NServiceBus.Persistence.Sql.SqlPersistence> configuration, System.Func<System.Data.Common.DbConnection> connectionBuilder) { }
-        public static void DisableInstaller(this NServiceBus.PersistenceExtensions<NServiceBus.Persistence.Sql.SqlPersistence> configuration) { }
+        public static void ConnectionBuilder(this NServiceBus.PersistenceExtensions<NServiceBus.SqlPersistence> configuration, System.Func<System.Data.Common.DbConnection> connectionBuilder) { }
+        public static void DisableInstaller(this NServiceBus.PersistenceExtensions<NServiceBus.SqlPersistence> configuration) { }
         public static void DoNotUseSqlServerTransportConnection(this NServiceBus.SqlDialectSettings<NServiceBus.SqlDialect.MsSqlServer> dialectSettings) { }
         public static void JsonBParameterModifier(this NServiceBus.SqlDialectSettings<NServiceBus.SqlDialect.PostgreSql> dialectSettings, System.Action<System.Data.Common.DbParameter> modifier) { }
-        public static void MultiTenantConnectionBuilder(this NServiceBus.PersistenceExtensions<NServiceBus.Persistence.Sql.SqlPersistence> configuration, string tenantIdHeaderName, System.Func<string, System.Data.Common.DbConnection> buildConnectionFromTenantData) { }
-        public static void MultiTenantConnectionBuilder(this NServiceBus.PersistenceExtensions<NServiceBus.Persistence.Sql.SqlPersistence> configuration, System.Func<NServiceBus.Transport.IncomingMessage, string> captureTenantId, System.Func<string, System.Data.Common.DbConnection> buildConnectionFromTenantData) { }
-        public static NServiceBus.Persistence.Sql.SagaSettings SagaSettings(this NServiceBus.PersistenceExtensions<NServiceBus.Persistence.Sql.SqlPersistence> configuration) { }
+        public static void MultiTenantConnectionBuilder(this NServiceBus.PersistenceExtensions<NServiceBus.SqlPersistence> configuration, string tenantIdHeaderName, System.Func<string, System.Data.Common.DbConnection> buildConnectionFromTenantData) { }
+        public static void MultiTenantConnectionBuilder(this NServiceBus.PersistenceExtensions<NServiceBus.SqlPersistence> configuration, System.Func<NServiceBus.Transport.IncomingMessage, string> captureTenantId, System.Func<string, System.Data.Common.DbConnection> buildConnectionFromTenantData) { }
+        public static NServiceBus.Persistence.Sql.SagaSettings SagaSettings(this NServiceBus.PersistenceExtensions<NServiceBus.SqlPersistence> configuration) { }
         public static void Schema(this NServiceBus.SqlDialectSettings<NServiceBus.SqlDialect.MsSqlServer> dialectSettings, string schema) { }
         public static void Schema(this NServiceBus.SqlDialectSettings<NServiceBus.SqlDialect.Oracle> dialectSettings, string schema) { }
         public static void Schema(this NServiceBus.SqlDialectSettings<NServiceBus.SqlDialect.PostgreSql> dialectSettings, string schema) { }
-        public static NServiceBus.SqlDialectSettings<T> SqlDialect<T>(this NServiceBus.PersistenceExtensions<NServiceBus.Persistence.Sql.SqlPersistence> configuration)
+        public static NServiceBus.SqlDialectSettings<T> SqlDialect<T>(this NServiceBus.PersistenceExtensions<NServiceBus.SqlPersistence> configuration)
             where T : NServiceBus.SqlDialect, new () { }
-        public static NServiceBus.Persistence.Sql.SubscriptionSettings SubscriptionSettings(this NServiceBus.PersistenceExtensions<NServiceBus.Persistence.Sql.SqlPersistence> configuration) { }
-        public static void TablePrefix(this NServiceBus.PersistenceExtensions<NServiceBus.Persistence.Sql.SqlPersistence> configuration, string tablePrefix) { }
-        public static NServiceBus.Persistence.Sql.TimeoutSettings TimeoutSettings(this NServiceBus.PersistenceExtensions<NServiceBus.Persistence.Sql.SqlPersistence> configuration) { }
+        public static NServiceBus.Persistence.Sql.SubscriptionSettings SubscriptionSettings(this NServiceBus.PersistenceExtensions<NServiceBus.SqlPersistence> configuration) { }
+        public static void TablePrefix(this NServiceBus.PersistenceExtensions<NServiceBus.SqlPersistence> configuration, string tablePrefix) { }
+        public static NServiceBus.Persistence.Sql.TimeoutSettings TimeoutSettings(this NServiceBus.PersistenceExtensions<NServiceBus.SqlPersistence> configuration) { }
     }
     public class static SqlPersistenceOutboxSettingsExtensions
     {

--- a/src/SqlPersistence.Tests/ConventionTests.cs
+++ b/src/SqlPersistence.Tests/ConventionTests.cs
@@ -1,5 +1,5 @@
 using System;
-using NServiceBus.Persistence.Sql;
+using NServiceBus;
 using NUnit.Framework;
 
 [TestFixture]

--- a/src/SqlPersistence/Config/SqlPersistenceConfig.cs
+++ b/src/SqlPersistence/Config/SqlPersistenceConfig.cs
@@ -1,7 +1,5 @@
 namespace NServiceBus
 {
-    using Persistence.Sql;
-
     /// <summary>
     /// SQL persistence specific configuration option. Provides extension methods to <see cref="PersistenceExtensions{T,S}"/> for <see cref="SqlPersistence"/>.
     /// </summary>

--- a/src/SqlPersistence/Config/SqlPersistenceConfig_Connection.cs
+++ b/src/SqlPersistence/Config/SqlPersistenceConfig_Connection.cs
@@ -3,7 +3,6 @@ namespace NServiceBus
     using System;
     using System.Data.Common;
     using Configuration.AdvancedExtensibility;
-    using Persistence.Sql;
     using Settings;
     using Transport;
 

--- a/src/SqlPersistence/Config/SqlPersistenceConfig_Enabled.cs
+++ b/src/SqlPersistence/Config/SqlPersistenceConfig_Enabled.cs
@@ -1,7 +1,6 @@
 namespace NServiceBus
 {
     using Configuration.AdvancedExtensibility;
-    using Persistence.Sql;
 
     public static partial class SqlPersistenceConfig
     {

--- a/src/SqlPersistence/Config/SqlPersistenceConfig_SqlDialect.cs
+++ b/src/SqlPersistence/Config/SqlPersistenceConfig_SqlDialect.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using Configuration.AdvancedExtensibility;
-    using Persistence.Sql;
     using Settings;
 
     public static partial class SqlPersistenceConfig

--- a/src/SqlPersistence/Config/SqlPersistenceConfig_TablePrefix.cs
+++ b/src/SqlPersistence/Config/SqlPersistenceConfig_TablePrefix.cs
@@ -1,7 +1,6 @@
 namespace NServiceBus
 {
     using Configuration.AdvancedExtensibility;
-    using Persistence.Sql;
     using Settings;
 
     public static partial class SqlPersistenceConfig

--- a/src/SqlPersistence/SqlPersistence.cs
+++ b/src/SqlPersistence/SqlPersistence.cs
@@ -1,7 +1,9 @@
-﻿namespace NServiceBus.Persistence.Sql
+﻿namespace NServiceBus
 {
     using Settings;
     using Features;
+    using Persistence;
+    using Persistence.Sql;
 
     /// <summary>
     /// The <see cref="PersistenceDefinition"/> for the SQL Persistence.

--- a/src/SqlPersistence/SynchronizedStorage/SqlStorageSessionTupleExtensions.cs
+++ b/src/SqlPersistence/SynchronizedStorage/SqlStorageSessionTupleExtensions.cs
@@ -1,7 +1,7 @@
-﻿using System.Data.Common;
-    
-namespace NServiceBus.Persistence.Sql.SynchronizedStorage
+﻿namespace NServiceBus.Persistence.Sql
 {
+    using System.Data.Common;
+
     /// <summary>
     /// Tuple deconstructor extension method for <see cref="ISqlStorageSession"/>.
     /// </summary>


### PR DESCRIPTION
This shifts the namespaces of a couple classes to better match our namespace rules. 

There are still others that probably aren't in the right namespace still, but changing them was more involved than I think we want to get into right now.