### PR TITLE
Simplify the targets file

### DIFF
--- a/src/ScriptBuilderTask/NServiceBus.Persistence.Sql.targets
+++ b/src/ScriptBuilderTask/NServiceBus.Persistence.Sql.targets
@@ -9,7 +9,7 @@
   <UsingTask
     TaskName="NServiceBus.Persistence.Sql.SqlPersistenceScriptBuilderTask"
     AssemblyFile="$(SqlPersistenceScriptBuilderTaskPath)"
-    Condition="'$(SqlPersistenceGenerateScripts)' != 'false'"/>
+    Condition="'$(SqlPersistenceGenerateScripts)' != 'false'" />
 
   <Target Name="SqlPersistenceScriptBuilder"
           AfterTargets="AfterCompile"
@@ -19,48 +19,18 @@
       AssemblyPath="$(ProjectDir)@(IntermediateAssembly)"
       IntermediateDirectory="$(ProjectDir)$(IntermediateOutputPath)"
       ProjectDirectory="$(ProjectDir)"
-      SolutionDirectory="$(SqlPersistenceSolutionDir)"/>
+      SolutionDirectory="$(SqlPersistenceSolutionDir)" />
 
-  </Target>
-
-  <Target Name="AddSqlPersistenceScriptsToGetCopyToOutputDirectoryItems"
-          BeforeTargets="GetCopyToOutputDirectoryItems"
-          Condition="'$(SqlPersistenceGenerateScripts)' != 'false' AND (('$(UsingMicrosoftNETSdk)' == 'true' AND '$(DesignTimeBuild)' != 'true') OR ('$(UsingMicrosoftNETSdk)' != 'true' AND '$(BuildingProject)' == 'true'))">
-
-    <PropertyGroup>
-      <SqlPersistenceScriptDirectory>$(ProjectDir)$(IntermediateOutputPath)NServiceBus.Persistence.Sql\</SqlPersistenceScriptDirectory>
-    </PropertyGroup>
+  <PropertyGroup>
+    <SqlPersistenceScriptDirectory>$(ProjectDir)$(IntermediateOutputPath)NServiceBus.Persistence.Sql\</SqlPersistenceScriptDirectory>
+  </PropertyGroup>
 
     <ItemGroup>
       <SqlPersistenceScripts Include="$(SqlPersistenceScriptDirectory)**\*.sql" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <_SourceItemsToCopyToOutputDirectoryAlways Include="@(SqlPersistenceScripts)">
+      <ContentWithTargetPath Include="@(SqlPersistenceScripts)">
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         <TargetPath>NServiceBus.Persistence.Sql\%(RecursiveDir)%(Filename)%(Extension)</TargetPath>
-      </_SourceItemsToCopyToOutputDirectoryAlways>
-    </ItemGroup>
-
-  </Target>
-
-  <Target Name="AddSqlPersistenceScriptsToGetCopyToPublishDirectoryItems"
-          BeforeTargets="GetCopyToPublishDirectoryItems"
-          Condition="'$(SqlPersistenceGenerateScripts)' != 'false' AND (('$(UsingMicrosoftNETSdk)' == 'true' AND '$(DesignTimeBuild)' != 'true') OR ('$(UsingMicrosoftNETSdk)' != 'true' AND '$(BuildingProject)' == 'true'))">
-
-    <PropertyGroup>
-      <SqlPersistenceScriptDirectory>$(ProjectDir)$(IntermediateOutputPath)NServiceBus.Persistence.Sql\</SqlPersistenceScriptDirectory>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <SqlPersistenceScriptsForPublish Include="$(SqlPersistenceScriptDirectory)**\*.sql" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <_SourceItemsToCopyToPublishDirectoryAlways Include="@(SqlPersistenceScriptsForPublish)">
-        <CopyToPublishDirectory>Always</CopyToPublishDirectory>
-        <TargetPath>NServiceBus.Persistence.Sql\%(RecursiveDir)%(Filename)%(Extension)</TargetPath>
-      </_SourceItemsToCopyToPublishDirectoryAlways>
+      </ContentWithTargetPath>
     </ItemGroup>
 
   </Target>


### PR DESCRIPTION
This simplifies the targets file used to generate the scripts at build time by changing how the scripts get copied into the bin folder.

Adding them to the `ContentWithTargetPath` item group means they'll be properly copied to the bin folder and included in publish output.