### PR TITLE
Make sure to only invoke persistence defaults once

### DIFF
--- a/src/SqlPersistence/SqlPersistence.cs
+++ b/src/SqlPersistence/SqlPersistence.cs
@@ -36,6 +36,13 @@
             });
             Defaults(s =>
             {
+                var defaultsAppliedSettingsKey = "NServiceBus.Persistence.Sql.DefaultApplied";
+
+                if (s.HasSetting(defaultsAppliedSettingsKey))
+                {
+                    return;
+                }
+
                 var dialect = s.GetSqlDialect();
                 var diagnostics = dialect.GetCustomDialectDiagnosticsInfo();
 
@@ -46,6 +53,8 @@
                 });
 
                 s.EnableFeatureByDefault<InstallerFeature>();
+
+                s.Set(defaultsAppliedSettingsKey, true);
             });
         }
 


### PR DESCRIPTION
This prevents the startup diagnostics to be added twice should the user make multiple calls to `.UsePersistence`.

Closes https://github.com/Particular/NServiceBus.Persistence.Sql/issues/349