### PR TITLE
Use official package for ScriptDom dependency

### DIFF
--- a/src/ScriptBuilder.Tests/ScriptBuilder.Tests.csproj
+++ b/src/ScriptBuilder.Tests/ScriptBuilder.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net46;netcoreapp3.1</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)Test.snk</AssemblyOriginatorKeyFile>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
@@ -15,14 +15,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Microsoft.SqlServer.DACFx" Version="150.4769.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
     <PackageReference Include="Particular.Approvals" Version="0.2.0" />
     <PackageReference Include="PublicApiGenerator" Version="9.3.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
-    <PackageReference Include="Microsoft.SqlServer.TransactSql.ScriptDom" Version="14.0.3811.1" />
   </ItemGroup>
 
 </Project>

--- a/src/ScriptBuilder.Tests/SqlValidator.cs
+++ b/src/ScriptBuilder.Tests/SqlValidator.cs
@@ -1,28 +1,27 @@
-#if NETFRAMEWORK
-using Microsoft.SqlServer.TransactSql.ScriptDom;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-#endif
+using Microsoft.SqlServer.TransactSql.ScriptDom;
 
 public static class SqlValidator
 {
     public static void Validate(string sql)
     {
-#if NETFRAMEWORK
         var parser = new TSql140Parser(false);
         IList<ParseError> errors;
+
         using (var reader = new StringReader(sql))
         {
             parser.Parse(reader, out errors);
         }
+
         if (errors == null || errors.Count == 0)
         {
             return;
         }
+
         var message = $"Sql errors:{string.Join("\r\n", errors.Select(error => error.Message))}";
         throw new Exception(message);
-#endif
     }
 }


### PR DESCRIPTION
This PR switches the ScriptBuilder.Tests project over to using the official Microsoft package to bring in the Microsoft.SqlServer.TransactSql.ScriptDom dependency,

This has a few impacts:
- The official package does bring in more stuff than just ScriptDom, but that shouldn't actually be a problem.
- The official package has a `net46` minumum, so I had to bump the test project up.
- The tests can actually be run on .NET Core now.