### PR TITLE
Split script generation and content registration into separate targets

### DIFF
--- a/src/ScriptBuilderTask/NServiceBus.Persistence.Sql.targets
+++ b/src/ScriptBuilderTask/NServiceBus.Persistence.Sql.targets
@@ -35,8 +35,8 @@
     <ItemGroup>
       <SqlPersistenceScripts Include="$(SqlPersistenceScriptDirectory)**\*.sql" />
       <ContentWithTargetPath Include="@(SqlPersistenceScripts)">
-        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-        <CopyToPublishDirectory>Always</CopyToPublishDirectory>
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
         <TargetPath>NServiceBus.Persistence.Sql\%(RecursiveDir)%(Filename)%(Extension)</TargetPath>
       </ContentWithTargetPath>
     </ItemGroup>

--- a/src/ScriptBuilderTask/NServiceBus.Persistence.Sql.targets
+++ b/src/ScriptBuilderTask/NServiceBus.Persistence.Sql.targets
@@ -21,14 +21,22 @@
       ProjectDirectory="$(ProjectDir)"
       SolutionDirectory="$(SqlPersistenceSolutionDir)" />
 
-  <PropertyGroup>
-    <SqlPersistenceScriptDirectory>$(ProjectDir)$(IntermediateOutputPath)NServiceBus.Persistence.Sql\</SqlPersistenceScriptDirectory>
-  </PropertyGroup>
+  </Target>
+
+  <Target Name="SqlPersistenceAddScriptsToContent"
+          BeforeTargets="GetCopyToOutputDirectoryItems;GetCopyToPublishDirectoryItems"
+          AfterTargets="SqlPersistenceScriptBuilder"
+          Condition="'$(SqlPersistenceGenerateScripts)' != 'false' AND (('$(UsingMicrosoftNETSdk)' == 'true' AND '$(DesignTimeBuild)' != 'true') OR ('$(UsingMicrosoftNETSdk)' != 'true' AND '$(BuildingProject)' == 'true'))">
+
+    <PropertyGroup>
+      <SqlPersistenceScriptDirectory>$(ProjectDir)$(IntermediateOutputPath)NServiceBus.Persistence.Sql\</SqlPersistenceScriptDirectory>
+    </PropertyGroup>
 
     <ItemGroup>
       <SqlPersistenceScripts Include="$(SqlPersistenceScriptDirectory)**\*.sql" />
       <ContentWithTargetPath Include="@(SqlPersistenceScripts)">
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        <CopyToPublishDirectory>Always</CopyToPublishDirectory>
         <TargetPath>NServiceBus.Persistence.Sql\%(RecursiveDir)%(Filename)%(Extension)</TargetPath>
       </ContentWithTargetPath>
     </ItemGroup>

--- a/src/SqlPersistence/SqlPersistence.csproj
+++ b/src/SqlPersistence/SqlPersistence.csproj
@@ -27,8 +27,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\ScriptBuilderTask\NServiceBus.Persistence.Sql.targets" Pack="true" PackagePath="build" Visible="false" />
-    <None Include="..\ScriptBuilderTask\NServiceBus.Persistence.Sql.targets" Pack="true" PackagePath="buildTransitive" Visible="false" />
+    <None Include="..\ScriptBuilderTask\NServiceBus.Persistence.Sql.targets" Pack="true" PackagePath="build;buildTransitive" Visible="false" />
     <None Include="..\ScriptBuilderTask\bin\$(Configuration)\net452\NServiceBus.Persistence.Sql.ScriptBuilderTask.???" Pack="true" PackagePath="netclassic" Visible="false" />
     <None Include="..\ScriptBuilderTask\bin\$(Configuration)\netstandard1.5\NServiceBus.Persistence.Sql.ScriptBuilderTask.???" Pack="true" PackagePath="netstandard" Visible="false" />
   </ItemGroup>


### PR DESCRIPTION
This splits the existing MSBuild target into two. The first one runs as before, only when the project is built, and invokes the task to create the script files.

The new target adds the scripts to the `ContentWithTargetPath` item group. This will be run after the first target, but will also be invoked before the Publish targets.

This ensures that when a publish is executed with the  `--nobuild` option, the scripts will be properly registered as content that need to be included in the publish output.

Fixes #490