### PR TITLE
Vendor tests grouped in namespaces to run setup fixture per vendor

### DIFF
--- a/src/SqlPersistence.Tests/Outbox/MySqlOutboxPersisterTests.cs
+++ b/src/SqlPersistence.Tests/Outbox/MySqlOutboxPersisterTests.cs
@@ -1,23 +1,26 @@
-using System;
-using System.Data.Common;
-using NServiceBus.Persistence.Sql.ScriptBuilder;
-using NUnit.Framework;
-
-[TestFixture(false, false)]
-[TestFixture(true, false)]
-[TestFixture(false, true)]
-[TestFixture(true, true)]
-public class MySqlOutboxPersisterTests : OutboxPersisterTests
+namespace MySql
 {
-    public MySqlOutboxPersisterTests(bool pessimistic, bool transactionScope) 
-        : base(BuildSqlDialect.MySql, null, pessimistic, transactionScope)
-    {
-    }
+    using System;
+    using System.Data.Common;
+    using NServiceBus.Persistence.Sql.ScriptBuilder;
+    using NUnit.Framework;
 
-    protected override bool SupportsSchemas() => false;
-
-    protected override Func<string, DbConnection> GetConnection()
+    [TestFixture(false, false)]
+    [TestFixture(true, false)]
+    [TestFixture(false, true)]
+    [TestFixture(true, true)]
+    public class MySqlOutboxPersisterTests : OutboxPersisterTests
     {
-        return x => MySqlConnectionBuilder.Build();
+        public MySqlOutboxPersisterTests(bool pessimistic, bool transactionScope)
+            : base(BuildSqlDialect.MySql, null, pessimistic, transactionScope)
+        {
+        }
+
+        protected override bool SupportsSchemas() => false;
+
+        protected override Func<string, DbConnection> GetConnection()
+        {
+            return x => MySqlConnectionBuilder.Build();
+        }
     }
 }

--- a/src/SqlPersistence.Tests/Outbox/OracleOutboxPersisterTests.cs
+++ b/src/SqlPersistence.Tests/Outbox/OracleOutboxPersisterTests.cs
@@ -1,46 +1,51 @@
-using System;
-using System.Data.Common;
-using NServiceBus.Persistence.Sql.ScriptBuilder;
-using NUnit.Framework;
 using Oracle.ManagedDataAccess.Client;
 
-[TestFixture(false, false)]
-[TestFixture(true, false)]
-[TestFixture(false, true)]
-[TestFixture(true, true)]
-public class OracleOutboxPersisterTests : OutboxPersisterTests
+namespace Oracle
 {
-    public OracleOutboxPersisterTests(bool pessimistic, bool transactionScope) 
-        : base(BuildSqlDialect.Oracle, "Particular2", pessimistic, transactionScope)
-    {
-    }
+    using System;
+    using System.Data.Common;
+    using NServiceBus.Persistence.Sql.ScriptBuilder;
+    using NUnit.Framework;
 
-    protected override bool SupportsSchemas() => true;
-
-    protected override Func<string, DbConnection> GetConnection()
+    [TestFixture(false, false)]
+    [TestFixture(true, false)]
+    [TestFixture(false, true)]
+    [TestFixture(true, true)]
+    public class OracleOutboxPersisterTests : OutboxPersisterTests
     {
-        return schema =>
+        public OracleOutboxPersisterTests(bool pessimistic, bool transactionScope)
+            : base(BuildSqlDialect.Oracle, "Particular2", pessimistic, transactionScope)
         {
-            var key = schema == null
-                ? "OracleConnectionString"
-                : $"OracleConnectionString_{schema}";
+        }
 
-            var connection = Environment.GetEnvironmentVariable(key);
-            if (string.IsNullOrWhiteSpace(connection))
+        protected override bool SupportsSchemas() => true;
+
+        protected override Func<string, DbConnection> GetConnection()
+        {
+            return schema =>
             {
-                throw new Exception($"{key} environment variable is empty");
-            }
-            return new OracleConnection(connection);
-        };
-    }
+                var key = schema == null
+                    ? "OracleConnectionString"
+                    : $"OracleConnectionString_{schema}";
 
-    protected override string GetTablePrefix()
-    {
-        return "OUTBOX PERSISTER";
-    }
+                var connection = Environment.GetEnvironmentVariable(key);
+                if (string.IsNullOrWhiteSpace(connection))
+                {
+                    throw new Exception($"{key} environment variable is empty");
+                }
 
-    protected override string GetTableSuffix()
-    {
-        return "_OD";
+                return new OracleConnection(connection);
+            };
+        }
+
+        protected override string GetTablePrefix()
+        {
+            return "OUTBOX PERSISTER";
+        }
+
+        protected override string GetTableSuffix()
+        {
+            return "_OD";
+        }
     }
 }

--- a/src/SqlPersistence.Tests/Outbox/PostgreSqlOutboxPersisterTests.cs
+++ b/src/SqlPersistence.Tests/Outbox/PostgreSqlOutboxPersisterTests.cs
@@ -1,21 +1,25 @@
-using System;
-using System.Data.Common;
-using NServiceBus.Persistence.Sql.ScriptBuilder;
-using NUnit.Framework;
-
-[TestFixture(false, false)]
-[TestFixture(true, false)]
-[TestFixture(false, true)]
-[TestFixture(true, true)]
-public class PostgreSqlOutboxPersisterTests : OutboxPersisterTests
+namespace PostgreSql
 {
-    public PostgreSqlOutboxPersisterTests(bool pessimistic, bool transactionScope) 
-        : base(BuildSqlDialect.PostgreSql, "SchemaName", pessimistic, transactionScope)
-    {
-    }
 
-    protected override Func<string, DbConnection> GetConnection()
+    using System;
+    using System.Data.Common;
+    using NServiceBus.Persistence.Sql.ScriptBuilder;
+    using NUnit.Framework;
+
+    [TestFixture(false, false)]
+    [TestFixture(true, false)]
+    [TestFixture(false, true)]
+    [TestFixture(true, true)]
+    public class PostgreSqlOutboxPersisterTests : OutboxPersisterTests
     {
-        return x => PostgreSqlConnectionBuilder.Build();
+        public PostgreSqlOutboxPersisterTests(bool pessimistic, bool transactionScope)
+            : base(BuildSqlDialect.PostgreSql, "SchemaName", pessimistic, transactionScope)
+        {
+        }
+
+        protected override Func<string, DbConnection> GetConnection()
+        {
+            return x => PostgreSqlConnectionBuilder.Build();
+        }
     }
 }

--- a/src/SqlPersistence.Tests/Outbox/SqlServerMicrosoftDataClientOutboxPersisterTests.cs
+++ b/src/SqlPersistence.Tests/Outbox/SqlServerMicrosoftDataClientOutboxPersisterTests.cs
@@ -1,21 +1,24 @@
-using System;
-using System.Data.Common;
-using NServiceBus.Persistence.Sql.ScriptBuilder;
-using NUnit.Framework;
-
-[TestFixture(false, false)]
-[TestFixture(true, false)]
-[TestFixture(false, true)]
-[TestFixture(true, true)]
-public class SqlServerMicrosoftDataClientOutboxPersisterTests : OutboxPersisterTests
+namespace SqlServerMicrosoftData
 {
-    public SqlServerMicrosoftDataClientOutboxPersisterTests(bool pessimistic, bool transactionScope) 
-        : base(BuildSqlDialect.MsSqlServer, "schema_name", pessimistic, transactionScope)
-    {
-    }
+    using System;
+    using System.Data.Common;
+    using NServiceBus.Persistence.Sql.ScriptBuilder;
+    using NUnit.Framework;
 
-    protected override Func<string, DbConnection> GetConnection()
+    [TestFixture(false, false)]
+    [TestFixture(true, false)]
+    [TestFixture(false, true)]
+    [TestFixture(true, true)]
+    public class SqlServerMicrosoftDataClientOutboxPersisterTests : OutboxPersisterTests
     {
-        return x => MsSqlMicrosoftDataClientConnectionBuilder.Build();
+        public SqlServerMicrosoftDataClientOutboxPersisterTests(bool pessimistic, bool transactionScope)
+            : base(BuildSqlDialect.MsSqlServer, "schema_name", pessimistic, transactionScope)
+        {
+        }
+
+        protected override Func<string, DbConnection> GetConnection()
+        {
+            return x => MsSqlMicrosoftDataClientConnectionBuilder.Build();
+        }
     }
 }

--- a/src/SqlPersistence.Tests/Outbox/SqlServerSystemDataClientOutboxPersisterTests.cs
+++ b/src/SqlPersistence.Tests/Outbox/SqlServerSystemDataClientOutboxPersisterTests.cs
@@ -1,21 +1,24 @@
-using System;
-using System.Data.Common;
-using NServiceBus.Persistence.Sql.ScriptBuilder;
-using NUnit.Framework;
-
-[TestFixture(false, false)]
-[TestFixture(true, false)]
-[TestFixture(false, true)]
-[TestFixture(true, true)]
-public class SqlServerSystemDataClientOutboxPersisterTests : OutboxPersisterTests
+namespace SqlServerSystemData
 {
-    public SqlServerSystemDataClientOutboxPersisterTests(bool pessimistic, bool transactionScope) 
-        : base(BuildSqlDialect.MsSqlServer, "schema_name", pessimistic, transactionScope)
-    {
-    }
+    using System;
+    using System.Data.Common;
+    using NServiceBus.Persistence.Sql.ScriptBuilder;
+    using NUnit.Framework;
 
-    protected override Func<string, DbConnection> GetConnection()
+    [TestFixture(false, false)]
+    [TestFixture(true, false)]
+    [TestFixture(false, true)]
+    [TestFixture(true, true)]
+    public class SqlServerSystemDataClientOutboxPersisterTests : OutboxPersisterTests
     {
-        return x => MsSqlSystemDataClientConnectionBuilder.Build();
+        public SqlServerSystemDataClientOutboxPersisterTests(bool pessimistic, bool transactionScope)
+            : base(BuildSqlDialect.MsSqlServer, "schema_name", pessimistic, transactionScope)
+        {
+        }
+
+        protected override Func<string, DbConnection> GetConnection()
+        {
+            return x => MsSqlSystemDataClientConnectionBuilder.Build();
+        }
     }
 }

--- a/src/SqlPersistence.Tests/Saga/MySqlSagaPersisterTests.cs
+++ b/src/SqlPersistence.Tests/Saga/MySqlSagaPersisterTests.cs
@@ -1,44 +1,46 @@
-using System;
-using System.Data.Common;
-using NServiceBus.Persistence.Sql.ScriptBuilder;
+namespace MySql
+{
+    using System;
+    using System.Data.Common;
+    using NServiceBus.Persistence.Sql.ScriptBuilder;
 
 #if RELEASE
 using NUnit.Framework;
 // So this test does not run on CI as server install does not support unicode
 [Explicit("MySqlUnicode")]
 #endif
-public class MySqlSagaPersisterTests : SagaPersisterTests
-{
-    public MySqlSagaPersisterTests() : base(BuildSqlDialect.MySql, null)
+    public class MySqlSagaPersisterTests : SagaPersisterTests
     {
-    }
-
-    protected override bool SupportsSchemas() => false;
-
-    protected override Func<string, DbConnection> GetConnection()
-    {
-        return x =>
+        public MySqlSagaPersisterTests() : base(BuildSqlDialect.MySql, null)
         {
-            var connection = MySqlConnectionBuilder.Build();
-            connection.Open();
-            return connection;
-        };
-    }
+        }
 
-    protected override string GetPropertyWhereClauseExists(string schema, string table, string propertyName)
-    {
-        return $@"
+        protected override bool SupportsSchemas() => false;
+
+        protected override Func<string, DbConnection> GetConnection()
+        {
+            return x =>
+            {
+                var connection = MySqlConnectionBuilder.Build();
+                connection.Open();
+                return connection;
+            };
+        }
+
+        protected override string GetPropertyWhereClauseExists(string schema, string table, string propertyName)
+        {
+            return $@"
 select count(*)
 from information_schema.columns
 where table_schema = database() and
       column_name = '{propertyName}' and
       table_name = '{table}';
 ";
-    }
+        }
 
-    protected override bool IsConcurrencyException(Exception innerException)
-    {
-        return innerException.Message.Contains("Duplicate entry ");
+        protected override bool IsConcurrencyException(Exception innerException)
+        {
+            return innerException.Message.Contains("Duplicate entry ");
+        }
     }
-
 }

--- a/src/SqlPersistence.Tests/Saga/OracleSagaPersisterTests.cs
+++ b/src/SqlPersistence.Tests/Saga/OracleSagaPersisterTests.cs
@@ -1,72 +1,76 @@
-﻿using System;
-using System.Data.Common;
-using NServiceBus.Persistence.Sql.ScriptBuilder;
-using NUnit.Framework;
-using Oracle.ManagedDataAccess.Client;
-
-[TestFixture]
-public class OracleSagaPersisterTests : SagaPersisterTests
+﻿namespace Oracle
 {
-    public OracleSagaPersisterTests() : base(BuildSqlDialect.Oracle, "Particular2")
-    {
-    }
+    using System;
+    using System.Data.Common;
+    using NServiceBus.Persistence.Sql.ScriptBuilder;
+    using NUnit.Framework;
+    using Oracle.ManagedDataAccess.Client;
 
-    protected override bool SupportsSchemas() => true;
-
-    protected override Func<string, DbConnection> GetConnection()
+    [TestFixture]
+    public class OracleSagaPersisterTests : SagaPersisterTests
     {
-        return schema =>
+        public OracleSagaPersisterTests() : base(BuildSqlDialect.Oracle, "Particular2")
         {
-            var key = schema == null
-                ? "OracleConnectionString"
-                : $"OracleConnectionString_{schema}";
+        }
 
-            var connectionString = Environment.GetEnvironmentVariable(key);
-            if (string.IsNullOrWhiteSpace(connectionString))
+        protected override bool SupportsSchemas() => true;
+
+        protected override Func<string, DbConnection> GetConnection()
+        {
+            return schema =>
             {
-                throw new Exception($"{key} environment variable is empty");
-            }
-            var connection = new OracleConnection(connectionString);
-            connection.Open();
-            return connection;
-        };
-    }
+                var key = schema == null
+                    ? "OracleConnectionString"
+                    : $"OracleConnectionString_{schema}";
 
-    protected override string TestTableName(string testName, string tableSuffix)
-    {
-        return $"{tableSuffix.ToUpper()}";
-    }
+                var connectionString = Environment.GetEnvironmentVariable(key);
+                if (string.IsNullOrWhiteSpace(connectionString))
+                {
+                    throw new Exception($"{key} environment variable is empty");
+                }
 
-    protected override string CorrelationPropertyName(string propertyName)
-    {
-        return $"CORR_{propertyName.ToUpper()}";
-    }
+                var connection = new OracleConnection(connectionString);
+                connection.Open();
+                return connection;
+            };
+        }
 
-    protected override string GetPropertyWhereClauseExists(string schema, string table, string propertyName)
-    {
-        return $@"
+        protected override string TestTableName(string testName, string tableSuffix)
+        {
+            return $"{tableSuffix.ToUpper()}";
+        }
+
+        protected override string CorrelationPropertyName(string propertyName)
+        {
+            return $"CORR_{propertyName.ToUpper()}";
+        }
+
+        protected override string GetPropertyWhereClauseExists(string schema, string table, string propertyName)
+        {
+            return $@"
 select count(*)
 from all_tab_columns
 where table_name = '{table}' and
       column_name = '{propertyName}'
 ";
-    }
-
-    protected override bool IsConcurrencyException(Exception innerException)
-    {
-        // ORA-00001: unique constraint (TESTUSER.SAGAWITHCORRELATION_CP) violated
-        return innerException.Message.Contains("ORA-00001");
-    }
-
-    protected override bool SupportsUnicodeIdentifiers { get; } = false;
-
-    protected override bool LoadTypeForSagaMetadata(Type type)
-    {
-        if (type == typeof(SagaWithWeirdCharactersಠ_ಠ))
-        {
-            return false;
         }
 
-        return true;
+        protected override bool IsConcurrencyException(Exception innerException)
+        {
+            // ORA-00001: unique constraint (TESTUSER.SAGAWITHCORRELATION_CP) violated
+            return innerException.Message.Contains("ORA-00001");
+        }
+
+        protected override bool SupportsUnicodeIdentifiers { get; } = false;
+
+        protected override bool LoadTypeForSagaMetadata(Type type)
+        {
+            if (type == typeof(SagaWithWeirdCharactersಠ_ಠ))
+            {
+                return false;
+            }
+
+            return true;
+        }
     }
 }

--- a/src/SqlPersistence.Tests/Saga/PostgreSqlSagaPersisterTests.cs
+++ b/src/SqlPersistence.Tests/Saga/PostgreSqlSagaPersisterTests.cs
@@ -1,37 +1,40 @@
-using System;
-using System.Data.Common;
-using NServiceBus.Persistence.Sql.ScriptBuilder;
-
-public class PostgreSqlSagaPersisterTests : SagaPersisterTests
+namespace PostgreSql
 {
-    public PostgreSqlSagaPersisterTests() : base(BuildSqlDialect.PostgreSql, "SchemaName")
-    {
-    }
+    using System;
+    using System.Data.Common;
+    using NServiceBus.Persistence.Sql.ScriptBuilder;
 
-    protected override Func<string, DbConnection> GetConnection()
+    public class PostgreSqlSagaPersisterTests : SagaPersisterTests
     {
-        return x =>
+        public PostgreSqlSagaPersisterTests() : base(BuildSqlDialect.PostgreSql, "SchemaName")
         {
-            var connection = PostgreSqlConnectionBuilder.Build();
-            connection.Open();
-            return connection;
-        };
-    }
+        }
 
-    protected override string GetPropertyWhereClauseExists(string schema, string table, string propertyName)
-    {
-        return $@"
+        protected override Func<string, DbConnection> GetConnection()
+        {
+            return x =>
+            {
+                var connection = PostgreSqlConnectionBuilder.Build();
+                connection.Open();
+                return connection;
+            };
+        }
+
+        protected override string GetPropertyWhereClauseExists(string schema, string table, string propertyName)
+        {
+            return $@"
 select count(*)
 from information_schema.columns
 where
 table_name = '{table}' and
 column_name = '{propertyName}';
 ";
-    }
+        }
 
-    protected override bool IsConcurrencyException(Exception innerException)
-    {
-        return innerException.Message.Contains("duplicate key value violates unique constraint");
-    }
+        protected override bool IsConcurrencyException(Exception innerException)
+        {
+            return innerException.Message.Contains("duplicate key value violates unique constraint");
+        }
 
+    }
 }

--- a/src/SqlPersistence.Tests/Saga/SqlServerMicrosoftDataClientSagaPersisterTests.cs
+++ b/src/SqlPersistence.Tests/Saga/SqlServerMicrosoftDataClientSagaPersisterTests.cs
@@ -1,36 +1,39 @@
-using System;
-using System.Data.Common;
-using NServiceBus.Persistence.Sql.ScriptBuilder;
-using NUnit.Framework;
-
-[TestFixture]
-public class SqlServerMicrosoftDataClientSagaPersisterTests : SagaPersisterTests
+namespace SqlServerMicrosoftData
 {
-    public SqlServerMicrosoftDataClientSagaPersisterTests() : base(BuildSqlDialect.MsSqlServer, "schema_name")
-    {
-    }
+    using System;
+    using System.Data.Common;
+    using NServiceBus.Persistence.Sql.ScriptBuilder;
+    using NUnit.Framework;
 
-    protected override Func<string, DbConnection> GetConnection()
+    [TestFixture]
+    public class SqlServerMicrosoftDataClientSagaPersisterTests : SagaPersisterTests
     {
-        return x =>
+        public SqlServerMicrosoftDataClientSagaPersisterTests() : base(BuildSqlDialect.MsSqlServer, "schema_name")
         {
-            var connection = MsSqlMicrosoftDataClientConnectionBuilder.Build();
-            connection.Open();
-            return connection;
-        };
-    }
+        }
 
-    protected override string GetPropertyWhereClauseExists(string schema, string table, string propertyName)
-    {
-        return $@"
+        protected override Func<string, DbConnection> GetConnection()
+        {
+            return x =>
+            {
+                var connection = MsSqlMicrosoftDataClientConnectionBuilder.Build();
+                connection.Open();
+                return connection;
+            };
+        }
+
+        protected override string GetPropertyWhereClauseExists(string schema, string table, string propertyName)
+        {
+            return $@"
 select 1 from sys.columns
 where Name = N'{propertyName}'
 and Object_ID = Object_ID(N'{schema}.{table}')
 ";
-    }
+        }
 
-    protected override bool IsConcurrencyException(Exception innerException)
-    {
-        return innerException.Message.Contains("Cannot insert duplicate key row in object ");
+        protected override bool IsConcurrencyException(Exception innerException)
+        {
+            return innerException.Message.Contains("Cannot insert duplicate key row in object ");
+        }
     }
 }

--- a/src/SqlPersistence.Tests/Saga/SqlServerSystemDataClientSagaPersisterTests.cs
+++ b/src/SqlPersistence.Tests/Saga/SqlServerSystemDataClientSagaPersisterTests.cs
@@ -1,36 +1,39 @@
-using System;
-using System.Data.Common;
-using NServiceBus.Persistence.Sql.ScriptBuilder;
-using NUnit.Framework;
-
-[TestFixture]
-public class SqlServerSystemDataClientSagaPersisterTests : SagaPersisterTests
+namespace SqlServerSystemData
 {
-    public SqlServerSystemDataClientSagaPersisterTests() : base(BuildSqlDialect.MsSqlServer, "schema_name")
-    {
-    }
+    using System;
+    using System.Data.Common;
+    using NServiceBus.Persistence.Sql.ScriptBuilder;
+    using NUnit.Framework;
 
-    protected override Func<string, DbConnection> GetConnection()
+    [TestFixture]
+    public class SqlServerSystemDataClientSagaPersisterTests : SagaPersisterTests
     {
-        return x =>
+        public SqlServerSystemDataClientSagaPersisterTests() : base(BuildSqlDialect.MsSqlServer, "schema_name")
         {
-            var connection = MsSqlSystemDataClientConnectionBuilder.Build();
-            connection.Open();
-            return connection;
-        };
-    }
+        }
 
-    protected override string GetPropertyWhereClauseExists(string schema, string table, string propertyName)
-    {
-        return $@"
+        protected override Func<string, DbConnection> GetConnection()
+        {
+            return x =>
+            {
+                var connection = MsSqlSystemDataClientConnectionBuilder.Build();
+                connection.Open();
+                return connection;
+            };
+        }
+
+        protected override string GetPropertyWhereClauseExists(string schema, string table, string propertyName)
+        {
+            return $@"
 select 1 from sys.columns
 where Name = N'{propertyName}'
 and Object_ID = Object_ID(N'{schema}.{table}')
 ";
-    }
+        }
 
-    protected override bool IsConcurrencyException(Exception innerException)
-    {
-        return innerException.Message.Contains("Cannot insert duplicate key row in object ");
+        protected override bool IsConcurrencyException(Exception innerException)
+        {
+            return innerException.Message.Contains("Cannot insert duplicate key row in object ");
+        }
     }
 }

--- a/src/SqlPersistence.Tests/SetUpFixture.cs
+++ b/src/SqlPersistence.Tests/SetUpFixture.cs
@@ -1,32 +1,105 @@
 using NUnit.Framework;
 
-[SetUpFixture]
-public class SetUpFixture
+namespace PostgreSql
 {
-    [OneTimeSetUp]
-    public void SetUp()
+    [SetUpFixture]
+    public class SetUpFixture
     {
-        using (var connection = MsSqlSystemDataClientConnectionBuilder.Build())
+        [OneTimeSetUp]
+        public void Setup()
         {
-            connection.Open();
-            using (var command = connection.CreateCommand())
+            using (var connection = PostgreSqlConnectionBuilder.Build())
             {
-                command.CommandText = @"
+                connection.Open();
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText = @"create schema if not exists ""SchemaName"";";
+                    command.ExecuteNonQuery();
+                }
+            }
+        }
+    }
+}
+
+namespace SqlServerSystemData
+{
+    [SetUpFixture]
+    public class SetUpFixture
+    {
+        [OneTimeSetUp]
+        public void Setup()
+        {
+            using (var connection = MsSqlSystemDataClientConnectionBuilder.Build())
+            {
+                connection.Open();
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText = @"
 if not exists (
     select  *
     from sys.schemas
     where name = 'schema_name')
 exec('create schema schema_name');";
-                command.ExecuteNonQuery();
+                    command.ExecuteNonQuery();
+                }
             }
         }
-        using (var connection = PostgreSqlConnectionBuilder.Build())
+    }
+}
+
+namespace SqlServerMicrosoftData
+{
+    [SetUpFixture]
+    public class SetUpFixture
+    {
+        [OneTimeSetUp]
+        public void Setup()
         {
-            connection.Open();
-            using (var command = connection.CreateCommand())
+            using (var connection = MsSqlMicrosoftDataClientConnectionBuilder.Build())
             {
-                command.CommandText = @"create schema if not exists ""SchemaName"";";
-                command.ExecuteNonQuery();
+                connection.Open();
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText = @"
+if not exists (
+    select  *
+    from sys.schemas
+    where name = 'schema_name')
+exec('create schema schema_name');";
+                    command.ExecuteNonQuery();
+                }
+            }
+        }
+    }
+}
+
+namespace MySql
+{
+    [SetUpFixture]
+    public class SetUpFixture
+    {
+        [OneTimeSetUp]
+        public void Setup()
+        {
+            using (var connection = MySqlConnectionBuilder.Build())
+            {
+                connection.Open();
+            }
+        }
+    }
+}
+
+namespace Oracle
+{
+    [SetUpFixture]
+    public class SetUpFixture
+    {
+        [OneTimeSetUp]
+        public void Setup()
+        {
+            using (var connection = OracleConnectionBuilder.Build())
+            {
+                connection.Open();
             }
         }
     }

--- a/src/SqlPersistence.Tests/Subscription/MySqlServerSubscriptionPersisterTests.cs
+++ b/src/SqlPersistence.Tests/Subscription/MySqlServerSubscriptionPersisterTests.cs
@@ -1,19 +1,22 @@
-using System;
-using System.Data.Common;
-using NServiceBus.Persistence.Sql.ScriptBuilder;
-using NUnit.Framework;
-
-[TestFixture]
-public class MySqlServerSubscriptionPersisterTests : SubscriptionPersisterTests
+namespace MySql
 {
-    public MySqlServerSubscriptionPersisterTests() : base(BuildSqlDialect.MySql, null)
-    {
-    }
+    using System;
+    using System.Data.Common;
+    using NServiceBus.Persistence.Sql.ScriptBuilder;
+    using NUnit.Framework;
 
-    protected override bool SupportsSchemas() => false;
-
-    protected override Func<string, DbConnection> GetConnection()
+    [TestFixture]
+    public class MySqlServerSubscriptionPersisterTests : SubscriptionPersisterTests
     {
-        return x => MySqlConnectionBuilder.Build();
+        public MySqlServerSubscriptionPersisterTests() : base(BuildSqlDialect.MySql, null)
+        {
+        }
+
+        protected override bool SupportsSchemas() => false;
+
+        protected override Func<string, DbConnection> GetConnection()
+        {
+            return x => MySqlConnectionBuilder.Build();
+        }
     }
 }

--- a/src/SqlPersistence.Tests/Subscription/OracleSubscriptionPersisterTests.cs
+++ b/src/SqlPersistence.Tests/Subscription/OracleSubscriptionPersisterTests.cs
@@ -1,37 +1,41 @@
-using System;
-using System.Data.Common;
-using NServiceBus.Persistence.Sql.ScriptBuilder;
-using NUnit.Framework;
-using Oracle.ManagedDataAccess.Client;
-
-[TestFixture]
-public class OracleSubscriptionPersisterTests : SubscriptionPersisterTests
+namespace Oracle
 {
-    public OracleSubscriptionPersisterTests() : base(BuildSqlDialect.Oracle, "Particular2")
-    {
-    }
+    using System;
+    using System.Data.Common;
+    using NServiceBus.Persistence.Sql.ScriptBuilder;
+    using NUnit.Framework;
+    using Oracle.ManagedDataAccess.Client;
 
-    protected override bool SupportsSchemas() => true;
-
-    protected override Func<string, DbConnection> GetConnection()
+    [TestFixture]
+    public class OracleSubscriptionPersisterTests : SubscriptionPersisterTests
     {
-        return schema =>
+        public OracleSubscriptionPersisterTests() : base(BuildSqlDialect.Oracle, "Particular2")
         {
-            var key = schema == null
-                ? "OracleConnectionString"
-                : $"OracleConnectionString_{schema}";
+        }
 
-            var connection = Environment.GetEnvironmentVariable(key);
-            if (string.IsNullOrWhiteSpace(connection))
+        protected override bool SupportsSchemas() => true;
+
+        protected override Func<string, DbConnection> GetConnection()
+        {
+            return schema =>
             {
-                throw new Exception($"{key} environment variable is empty");
-            }
-            return new OracleConnection(connection);
-        };
-    }
+                var key = schema == null
+                    ? "OracleConnectionString"
+                    : $"OracleConnectionString_{schema}";
 
-    protected override string GetTablePrefix()
-    {
-        return "Subscription Tests";
+                var connection = Environment.GetEnvironmentVariable(key);
+                if (string.IsNullOrWhiteSpace(connection))
+                {
+                    throw new Exception($"{key} environment variable is empty");
+                }
+
+                return new OracleConnection(connection);
+            };
+        }
+
+        protected override string GetTablePrefix()
+        {
+            return "Subscription Tests";
+        }
     }
 }

--- a/src/SqlPersistence.Tests/Subscription/PostgreSqlSubscriptionPersisterTests.cs
+++ b/src/SqlPersistence.Tests/Subscription/PostgreSqlSubscriptionPersisterTests.cs
@@ -1,17 +1,21 @@
-using System;
-using System.Data.Common;
-using NServiceBus.Persistence.Sql.ScriptBuilder;
-using NUnit.Framework;
-
-[TestFixture]
-public class PostgreSqlSubscriptionPersisterTests : SubscriptionPersisterTests
+namespace PostgreSql
 {
-    public PostgreSqlSubscriptionPersisterTests() : base(BuildSqlDialect.PostgreSql, "SchemaName")
-    {
-    }
 
-    protected override Func<string, DbConnection> GetConnection()
+    using System;
+    using System.Data.Common;
+    using NServiceBus.Persistence.Sql.ScriptBuilder;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class PostgreSqlSubscriptionPersisterTests : SubscriptionPersisterTests
     {
-        return x => PostgreSqlConnectionBuilder.Build();
+        public PostgreSqlSubscriptionPersisterTests() : base(BuildSqlDialect.PostgreSql, "SchemaName")
+        {
+        }
+
+        protected override Func<string, DbConnection> GetConnection()
+        {
+            return x => PostgreSqlConnectionBuilder.Build();
+        }
     }
 }

--- a/src/SqlPersistence.Tests/Subscription/SqlServerMicrosoftDataClientSubscriptionPersisterTests.cs
+++ b/src/SqlPersistence.Tests/Subscription/SqlServerMicrosoftDataClientSubscriptionPersisterTests.cs
@@ -1,17 +1,21 @@
-using System;
-using System.Data.Common;
-using NServiceBus.Persistence.Sql.ScriptBuilder;
-using NUnit.Framework;
-
-[TestFixture]
-public class SqlServerMicrosoftDataClientSubscriptionPersisterTests : SubscriptionPersisterTests
+namespace SqlServerMicrosoftData
 {
-    public SqlServerMicrosoftDataClientSubscriptionPersisterTests() : base(BuildSqlDialect.MsSqlServer, "schema_name")
-    {
-    }
+    using System;
+    using System.Data.Common;
+    using NServiceBus.Persistence.Sql.ScriptBuilder;
+    using NUnit.Framework;
 
-    protected override Func<string, DbConnection> GetConnection()
+    [TestFixture]
+    public class SqlServerMicrosoftDataClientSubscriptionPersisterTests : SubscriptionPersisterTests
     {
-        return x => MsSqlMicrosoftDataClientConnectionBuilder.Build();
+        public SqlServerMicrosoftDataClientSubscriptionPersisterTests() : base(BuildSqlDialect.MsSqlServer,
+            "schema_name")
+        {
+        }
+
+        protected override Func<string, DbConnection> GetConnection()
+        {
+            return x => MsSqlMicrosoftDataClientConnectionBuilder.Build();
+        }
     }
 }

--- a/src/SqlPersistence.Tests/Subscription/SqlServerSystemDataClientSubscriptionPersisterTests.cs
+++ b/src/SqlPersistence.Tests/Subscription/SqlServerSystemDataClientSubscriptionPersisterTests.cs
@@ -1,17 +1,20 @@
-using System;
-using System.Data.Common;
-using NServiceBus.Persistence.Sql.ScriptBuilder;
-using NUnit.Framework;
-
-[TestFixture]
-public class SqlServerSystemDataClientSubscriptionPersisterTests : SubscriptionPersisterTests
+namespace SqlServerSystemData
 {
-    public SqlServerSystemDataClientSubscriptionPersisterTests() : base(BuildSqlDialect.MsSqlServer, "schema_name")
-    {
-    }
+    using System;
+    using System.Data.Common;
+    using NServiceBus.Persistence.Sql.ScriptBuilder;
+    using NUnit.Framework;
 
-    protected override Func<string, DbConnection> GetConnection()
+    [TestFixture]
+    public class SqlServerSystemDataClientSubscriptionPersisterTests : SubscriptionPersisterTests
     {
-        return x => MsSqlSystemDataClientConnectionBuilder.Build();
+        public SqlServerSystemDataClientSubscriptionPersisterTests() : base(BuildSqlDialect.MsSqlServer, "schema_name")
+        {
+        }
+
+        protected override Func<string, DbConnection> GetConnection()
+        {
+            return x => MsSqlSystemDataClientConnectionBuilder.Build();
+        }
     }
 }

--- a/src/SqlPersistence.Tests/SynchronizedStorage/MySqlAdaptTransportConnectionTests.cs
+++ b/src/SqlPersistence.Tests/SynchronizedStorage/MySqlAdaptTransportConnectionTests.cs
@@ -1,22 +1,25 @@
-using System;
-using System.Data.Common;
-using NServiceBus.Persistence.Sql.ScriptBuilder;
-
-class MySqlAdaptTransportConnectionTests : AdaptTransportConnectionTests
+namespace MySql
 {
-    public MySqlAdaptTransportConnectionTests() : base(BuildSqlDialect.MySql)
-    {
-    }
+    using System;
+    using System.Data.Common;
+    using NServiceBus.Persistence.Sql.ScriptBuilder;
 
-    protected override bool SupportsDistributedTransactions => false;
-
-    protected override Func<string, DbConnection> GetConnection()
+    class MySqlAdaptTransportConnectionTests : AdaptTransportConnectionTests
     {
-        return x =>
+        public MySqlAdaptTransportConnectionTests() : base(BuildSqlDialect.MySql)
         {
-            var connection = MySqlConnectionBuilder.Build();
-            connection.Open();
-            return connection;
-        };
+        }
+
+        protected override bool SupportsDistributedTransactions => false;
+
+        protected override Func<string, DbConnection> GetConnection()
+        {
+            return x =>
+            {
+                var connection = MySqlConnectionBuilder.Build();
+                connection.Open();
+                return connection;
+            };
+        }
     }
 }

--- a/src/SqlPersistence.Tests/SynchronizedStorage/OracleAdaptTransportConnectionTests.cs
+++ b/src/SqlPersistence.Tests/SynchronizedStorage/OracleAdaptTransportConnectionTests.cs
@@ -1,21 +1,24 @@
-#if NETFRAMEWORK
-using System;
-using System.Data.Common;
-using NServiceBus.Persistence.Sql.ScriptBuilder;
-
-class OracleAdaptTransportConnectionTests : AdaptTransportConnectionTests
+namespace Oracle
 {
-    public OracleAdaptTransportConnectionTests() : base(BuildSqlDialect.Oracle)
-    {
-    }
+#if NETFRAMEWORK
+    using System;
+    using System.Data.Common;
+    using NServiceBus.Persistence.Sql.ScriptBuilder;
 
-    protected override Func<string, DbConnection> GetConnection()
+    class OracleAdaptTransportConnectionTests : AdaptTransportConnectionTests
     {
-        return x =>
+        public OracleAdaptTransportConnectionTests() : base(BuildSqlDialect.Oracle)
         {
-            var connection = OracleConnectionBuilder.Build();
-            return connection;
-        };
+        }
+
+        protected override Func<string, DbConnection> GetConnection()
+        {
+            return x =>
+            {
+                var connection = OracleConnectionBuilder.Build();
+                return connection;
+            };
+        }
     }
-}
 #endif
+}

--- a/src/SqlPersistence.Tests/SynchronizedStorage/PostgreSqlAdaptTransportConnectionTests.cs
+++ b/src/SqlPersistence.Tests/SynchronizedStorage/PostgreSqlAdaptTransportConnectionTests.cs
@@ -1,21 +1,24 @@
-#if NETFRAMEWORK
-using System;
-using System.Data.Common;
-using NServiceBus.Persistence.Sql.ScriptBuilder;
-
-class PostgreSqlAdaptTransportConnectionTests : AdaptTransportConnectionTests
+namespace PostgreSql
 {
-    public PostgreSqlAdaptTransportConnectionTests() : base(BuildSqlDialect.PostgreSql)
-    {
-    }
+#if NETFRAMEWORK
+    using System;
+    using System.Data.Common;
+    using NServiceBus.Persistence.Sql.ScriptBuilder;
 
-    protected override Func<string, DbConnection> GetConnection()
+    class PostgreSqlAdaptTransportConnectionTests : AdaptTransportConnectionTests
     {
-        return x =>
+        public PostgreSqlAdaptTransportConnectionTests() : base(BuildSqlDialect.PostgreSql)
         {
-            var connection = PostgreSqlConnectionBuilder.Build();
-            return connection;
-        };
+        }
+
+        protected override Func<string, DbConnection> GetConnection()
+        {
+            return x =>
+            {
+                var connection = PostgreSqlConnectionBuilder.Build();
+                return connection;
+            };
+        }
     }
-}
 #endif
+}

--- a/src/SqlPersistence.Tests/SynchronizedStorage/SqlServerMicrosoftDataClientAdaptTransportConnectionTests.cs
+++ b/src/SqlPersistence.Tests/SynchronizedStorage/SqlServerMicrosoftDataClientAdaptTransportConnectionTests.cs
@@ -1,43 +1,47 @@
-using System;
-using System.Data.Common;
-using System.Threading.Tasks;
-using NServiceBus.Extensibility;
-using NServiceBus.Persistence.Sql.ScriptBuilder;
-using NServiceBus.Transport;
-using NUnit.Framework;
-
-class SqlServerMicrosoftDataClientAdaptTransportConnectionTests : AdaptTransportConnectionTests
+namespace SqlServerMicrosoftData
 {
-    public SqlServerMicrosoftDataClientAdaptTransportConnectionTests() : base(BuildSqlDialect.MsSqlServer)
-    {
-    }
+    using System;
+    using System.Data.Common;
+    using System.Threading.Tasks;
+    using NServiceBus.Extensibility;
+    using NServiceBus.Persistence.Sql.ScriptBuilder;
+    using NServiceBus.Transport;
+    using NUnit.Framework;
 
-    protected override Func<string, DbConnection> GetConnection()
+    class SqlServerMicrosoftDataClientAdaptTransportConnectionTests : AdaptTransportConnectionTests
     {
-        return x =>
+        public SqlServerMicrosoftDataClientAdaptTransportConnectionTests() : base(BuildSqlDialect.MsSqlServer)
         {
-            var connection = MsSqlMicrosoftDataClientConnectionBuilder.Build();
-            connection.Open();
-            return connection;
-        };
-    }
+        }
 
-    [Test]
-    public async Task Adapts_transport_connection()
-    {
-        var transportTransaction = new TransportTransaction();
+        protected override Func<string, DbConnection> GetConnection()
+        {
+            return x =>
+            {
+                var connection = MsSqlMicrosoftDataClientConnectionBuilder.Build();
+                connection.Open();
+                return connection;
+            };
+        }
 
-        var transportConnection = connectionManager.BuildNonContextual();
-        var transaction = transportConnection.BeginTransaction();
+        [Test]
+        public async Task Adapts_transport_connection()
+        {
+            var transportTransaction = new TransportTransaction();
 
-        transportTransaction.Set("System.Data.SqlClient.SqlConnection", transportConnection);
-        transportTransaction.Set("System.Data.SqlClient.SqlTransaction", transaction);
+            var transportConnection = connectionManager.BuildNonContextual();
+            var transaction = transportConnection.BeginTransaction();
 
-        var altConnectionManager = new ConnectionManager(() => throw new Exception("Should not be called"));
+            transportTransaction.Set("System.Data.SqlClient.SqlConnection", transportConnection);
+            transportTransaction.Set("System.Data.SqlClient.SqlTransaction", transaction);
 
-        var result = await sqlDialect.Convert().TryAdaptTransportConnection(transportTransaction, new ContextBag(), altConnectionManager,
-            (conn, tx, arg3) => new StorageSession(conn, tx, false, null));
+            var altConnectionManager = new ConnectionManager(() => throw new Exception("Should not be called"));
 
-        Assert.IsNotNull(result);
+            var result = await sqlDialect.Convert().TryAdaptTransportConnection(transportTransaction, new ContextBag(),
+                altConnectionManager,
+                (conn, tx, arg3) => new StorageSession(conn, tx, false, null));
+
+            Assert.IsNotNull(result);
+        }
     }
 }

--- a/src/SqlPersistence.Tests/SynchronizedStorage/SqlServerSystemDataClientAdaptTransportConnectionTests.cs
+++ b/src/SqlPersistence.Tests/SynchronizedStorage/SqlServerSystemDataClientAdaptTransportConnectionTests.cs
@@ -1,43 +1,47 @@
-using System;
-using System.Data.Common;
-using System.Threading.Tasks;
-using NServiceBus.Extensibility;
-using NServiceBus.Persistence.Sql.ScriptBuilder;
-using NServiceBus.Transport;
-using NUnit.Framework;
-
-class SqlServerSystemDataClientAdaptTransportConnectionTests : AdaptTransportConnectionTests
+namespace SqlServerSystemData
 {
-    public SqlServerSystemDataClientAdaptTransportConnectionTests() : base(BuildSqlDialect.MsSqlServer)
-    {
-    }
+    using System;
+    using System.Data.Common;
+    using System.Threading.Tasks;
+    using NServiceBus.Extensibility;
+    using NServiceBus.Persistence.Sql.ScriptBuilder;
+    using NServiceBus.Transport;
+    using NUnit.Framework;
 
-    protected override Func<string, DbConnection> GetConnection()
+    class SqlServerSystemDataClientAdaptTransportConnectionTests : AdaptTransportConnectionTests
     {
-        return x =>
+        public SqlServerSystemDataClientAdaptTransportConnectionTests() : base(BuildSqlDialect.MsSqlServer)
         {
-            var connection = MsSqlSystemDataClientConnectionBuilder.Build();
-            connection.Open();
-            return connection;
-        };
-    }
+        }
 
-    [Test]
-    public async Task Adapts_transport_connection()
-    {
-        var transportTransaction = new TransportTransaction();
+        protected override Func<string, DbConnection> GetConnection()
+        {
+            return x =>
+            {
+                var connection = MsSqlSystemDataClientConnectionBuilder.Build();
+                connection.Open();
+                return connection;
+            };
+        }
 
-        var transportConnection = connectionManager.BuildNonContextual();
-        var transaction = transportConnection.BeginTransaction();
+        [Test]
+        public async Task Adapts_transport_connection()
+        {
+            var transportTransaction = new TransportTransaction();
 
-        transportTransaction.Set("System.Data.SqlClient.SqlConnection", transportConnection);
-        transportTransaction.Set("System.Data.SqlClient.SqlTransaction", transaction);
+            var transportConnection = connectionManager.BuildNonContextual();
+            var transaction = transportConnection.BeginTransaction();
 
-        var altConnectionManager = new ConnectionManager(() => throw new Exception("Should not be called"));
+            transportTransaction.Set("System.Data.SqlClient.SqlConnection", transportConnection);
+            transportTransaction.Set("System.Data.SqlClient.SqlTransaction", transaction);
 
-        var result = await sqlDialect.Convert().TryAdaptTransportConnection(transportTransaction, new ContextBag(), altConnectionManager,
-            (conn, tx, arg3) => new StorageSession(conn, tx, false, null));
+            var altConnectionManager = new ConnectionManager(() => throw new Exception("Should not be called"));
 
-        Assert.IsNotNull(result);
+            var result = await sqlDialect.Convert().TryAdaptTransportConnection(transportTransaction, new ContextBag(),
+                altConnectionManager,
+                (conn, tx, arg3) => new StorageSession(conn, tx, false, null));
+
+            Assert.IsNotNull(result);
+        }
     }
 }


### PR DESCRIPTION
Previously only one setup fixture existed that setup environment for only 2 databases. Now all vendor-specific tests are grouped in a product namespace containing a SetUpFixture for each. This results in the ability run product-specific tests without a dependency on setup fixture of a different vendor.