### PR TITLE
Add development support scripts

### DIFF
--- a/dev/docker-mysql.cmd
+++ b/dev/docker-mysql.cmd
@@ -1,0 +1,1 @@
+@docker run --rm --name test-mysql -p 3306:3306 -e MYSQL_ROOT_PASSWORD=my-super-secret-password -e MYSQL_DATABASE=NServiceBus -e MYSQL_USER=nsbuser -e MYSQL_PASSWORD=nsbuser-super-secret-pwd -d mysql:latest

--- a/dev/docker-oracle.cmd
+++ b/dev/docker-oracle.cmd
@@ -1,0 +1,1 @@
+@docker run -d --name oracledb -p 1521:1521 -p 5500:5500 -e ORACLE_PWD=super-secret-password -e ORACLE_CHARACTERSET=AL32UTF8 oracle/database:18.4.0-xe

--- a/dev/docker-postgres.cmd
+++ b/dev/docker-postgres.cmd
@@ -1,0 +1,1 @@
+@docker run -d --name PostgresDb -v my_dbdata:/var/lib/postgresql/data -p 54320:5432 -e POSTGRES_PASSWORD=super-secret-password postgres:11

--- a/dev/docker-sql.cmd
+++ b/dev/docker-sql.cmd
@@ -1,0 +1,1 @@
+@docker run --name SqlServer -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=NServiceBusPwd!" -p 1433:1433 -d  mcr.microsoft.com/mssql/server:2017-latest

--- a/dev/env-connection-string-oracle.cmd
+++ b/dev/env-connection-string-oracle.cmd
@@ -1,0 +1,1 @@
+@setx OracleConnectionString "User Id=system;Password=super-secret-password;Data Source=localhost:1521/XEPDB1;"

--- a/dev/env-connection-strings.cmd
+++ b/dev/env-connection-strings.cmd
@@ -1,0 +1,3 @@
+@setx SQLServerConnectionString "Server=localhost;User Id=sa;Password=NServiceBusPwd!;Database=nservicebus;"
+@setx MySQLConnectionString "Server=localhost;Port=3306;Database=NServiceBus;Uid=nsbuser;Pwd=nsbuser-super-secret-pwd;AllowUserVariables=True;AutoEnlist=false"
+@setx PostgreSqlConnectionString "User ID=postgres;Password=super-secret-password;Host=localhost;Port=54320;Database=nservicebus;Pooling=true;"

--- a/dev/oracle-docker-image.md
+++ b/dev/oracle-docker-image.md
@@ -1,0 +1,12 @@
+# Oracle docker image
+
+In order to use Oracle in docker [you will have to create your image](https://github.com/oracle/docker-images/tree/master/OracleDatabase/SingleInstance#running-oracle-database-18c-express-edition-in-a-docker-container).
+
+Here is a summary of the process:
+
+1. Clone <https://github.com/oracle/docker-images/>
+2. Download [Oracle Database Express Edition (XE) Release 18.4.0.0.0 (18c)](https://www.oracle.com/database/technologies/xe-downloads.html)
+3. Move it to `$/OracleDatabase/SingleInstance/dockerfiles/18.4.0`
+4. Invoke `$/OracleDatabase/SingleInstance/dockerfiles/buildDockerImage.sh` (git bash or WSL) as `./buildDockerImage.sh -v 18.4.0 - x` (build express image)
+
+NOTE: This image is Oracle Database 18c Express Edition. This is different from the one on the build server, which is 11g.

--- a/readme.md
+++ b/readme.md
@@ -13,12 +13,14 @@ https://docs.particular.net/persistence/sql/
 There are tests targetting multiple database engines. These can be installed on your machine or run in a docker container.
 The tests require a connectionstring set up in environment variables (remember that Visual Studio and Rider load these at start up, so restarting the IDE might be necessary).
 
+For convenience, scripts have been provided in `/dev` folder.
+
 **For SQL Server**
 
 `docker run --name SqlServer -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=NServiceBusPwd!" -p 1433:1433 -d  mcr.microsoft.com/mssql/server:2017-latest`
 
 Add an environment variable called `SQLServerConnectionString` with the connection string:
-`Server=localhost;User Id=sa;Password=NServiceBusPwd!`
+`Server=localhost;User Id=sa;Password=NServiceBusPwd!;Database=nservicebus;`
 
 **For MySql**
 

--- a/readme.md
+++ b/readme.md
@@ -39,4 +39,10 @@ Add an environment variable called `PostgreSqlConnectionString` with the connect
 
 **For Oracle**
 
+NOTE: Requires [building your own docker image](/dev/oracle-docker-image.md)
+
+`docker run -d --name oracledb -p 1521:1521 -p 5500:5500 -e ORACLE_PWD=super-secret-password -e ORACLE_CHARACTERSET=AL32UTF8 oracle/database:18.4.0-xe`
+
 Add an environment variable called `OracleConnectionString` with the connection string:
+
+`User Id=system;Password=super-secret-password;Data Source=localhost:1521/XEPDB1;`


### PR DESCRIPTION
Adds scripts for all of the docker images and environment variables mentioned in the readme. This makes it much easier to set up your environment for development.

NOTE: Added a `;Database=nservicebus;` section to the SQL Connection string because the tests do not work without it. It includes the trailing `;` because the multi-tenant tests look for it.