### PR TITLE
Enable long table names in Oracle

### DIFF
--- a/src/AcceptanceTestHelper/RuntimeSagaDefinitionReader.cs
+++ b/src/AcceptanceTestHelper/RuntimeSagaDefinitionReader.cs
@@ -73,11 +73,6 @@ public static class RuntimeSagaDefinitionReader
         var tableSuffixOverride = GetSagaMetadataProperty(sagaType, saga, "TableSuffix", att => att.TableSuffix);
         var tableSuffix = tableSuffixOverride ?? sagaType.Name;
 
-        if (sqlDialect == BuildSqlDialect.Oracle)
-        {
-            tableSuffix = tableSuffix.Substring(0, Math.Min(27, tableSuffix.Length));
-        }
-
         return new SagaDefinition(
             tableSuffix: tableSuffix,
             name: sagaType.FullName,

--- a/src/OracleAcceptanceTests/ConfigureEndpointSqlPersistence.cs
+++ b/src/OracleAcceptanceTests/ConfigureEndpointSqlPersistence.cs
@@ -32,9 +32,9 @@ public class ConfigureEndpointSqlPersistence : IConfigureEndpointTestExecution
         subscriptions.DisableCache();
         persistence.DisableInstaller();
 
-        //Force Saga table names to 27 characters to fit in Oracle
+        //Force Saga table names to 127 characters to fit in Oracle
         var sagaSettings = persistence.SagaSettings();
-        sagaSettings.NameFilter(sagaName => sagaName.Substring(0, Math.Min(27, sagaName.Length)));
+        sagaSettings.NameFilter(sagaName => sagaName.Substring(0, Math.Min(127, sagaName.Length)));
 
         return Task.FromResult(0);
     }

--- a/src/OracleAcceptanceTests/ConfigureEndpointSqlPersistence.cs
+++ b/src/OracleAcceptanceTests/ConfigureEndpointSqlPersistence.cs
@@ -20,11 +20,12 @@ public class ConfigureEndpointSqlPersistence : IConfigureEndpointTestExecution
         {
             endpointName = endpointName.Substring(lastDot + 1) + Math.Abs(endpointName.GetHashCode());
         }
-        var tablePrefix = TableNameCleaner.Clean(endpointName).Substring(0, Math.Min(endpointName.Length, 24));
+        var tablePrefix = TableNameCleaner.Clean(endpointName).Substring(0, Math.Min(endpointName.Length, 124));
         Console.WriteLine($"Using EndpointName='{endpointName}', TablePrefix='{tablePrefix}'");
         endpointHelper = new ConfigureEndpointHelper(configuration, tablePrefix, OracleConnectionBuilder.Build, BuildSqlDialect.Oracle, FilterTableExists);
         var persistence = configuration.UsePersistence<SqlPersistence>();
-        persistence.SqlDialect<SqlDialect.Oracle>();
+        var oracle = persistence.SqlDialect<SqlDialect.Oracle>();
+        oracle.EnableLongTableNames();
         persistence.ConnectionBuilder(OracleConnectionBuilder.Build);
         persistence.TablePrefix($"{tablePrefix}_");
         var subscriptions = persistence.SubscriptionSettings();

--- a/src/ScriptBuilder.Tests/ApprovalFiles/OutboxScriptBuilderTest.BuildCreateScript.ForScenario.Oracle.approved.txt
+++ b/src/ScriptBuilder.Tests/ApprovalFiles/OutboxScriptBuilderTest.BuildCreateScript.ForScenario.Oracle.approved.txt
@@ -1,9 +1,9 @@
 ﻿declare
-  tableName varchar2(30) := UPPER(:tablePrefix) || 'OD';
-  pkName varchar2(30) := tableName || '_PK';
-  indexName varchar2(30) := tableName || '_IX';
-  createTable varchar2(500);
-  createIndex varchar2(500);
+  tableName varchar2(128) := UPPER(:tablePrefix) || 'OD';
+  pkName varchar2(128) := tableName || '_PK';
+  indexName varchar2(128) := tableName || '_IX';
+  createTable varchar2(750);
+  createIndex varchar2(750);
   n number(10);
 begin
   select count(*) into n from user_tables where table_name = tableName;

--- a/src/ScriptBuilder.Tests/ApprovalFiles/OutboxScriptBuilderTest.BuildDropScript.ForScenario.Oracle.approved.txt
+++ b/src/ScriptBuilder.Tests/ApprovalFiles/OutboxScriptBuilderTest.BuildDropScript.ForScenario.Oracle.approved.txt
@@ -1,6 +1,6 @@
 ﻿declare
-  tableName varchar2(30) := UPPER(:tablePrefix) || 'OD';
-  dropTable varchar2(50);
+  tableName varchar2(128) := UPPER(:tablePrefix) || 'OD';
+  dropTable varchar2(150);
   n number(10);
 begin
   select count(*) into n from user_tables where table_name = tableName;

--- a/src/ScriptBuilder.Tests/ApprovalFiles/SubscriptionScriptBuilderTest.BuildCreateScript.ForScenario.Oracle.approved.txt
+++ b/src/ScriptBuilder.Tests/ApprovalFiles/SubscriptionScriptBuilderTest.BuildCreateScript.ForScenario.Oracle.approved.txt
@@ -1,6 +1,6 @@
 ﻿declare
-  tableName varchar2(30) := UPPER(:tablePrefix) || 'SS';
-  createTable varchar2(500);
+  tableName varchar2(128) := UPPER(:tablePrefix) || 'SS';
+  createTable varchar2(750);
   n number(10);
 begin
   select count(*) into n from user_tables where table_name = tableName;

--- a/src/ScriptBuilder.Tests/ApprovalFiles/SubscriptionScriptBuilderTest.BuildDropScript.ForScenario.Oracle.approved.txt
+++ b/src/ScriptBuilder.Tests/ApprovalFiles/SubscriptionScriptBuilderTest.BuildDropScript.ForScenario.Oracle.approved.txt
@@ -1,6 +1,6 @@
 ﻿declare
-  tableName varchar2(30) := UPPER(:tablePrefix) || 'SS';
-  dropTable varchar2(50);
+  tableName varchar2(128) := UPPER(:tablePrefix) || 'SS';
+  dropTable varchar2(150);
   n number(10);
 begin
   select count(*) into n from user_tables where table_name = tableName;

--- a/src/ScriptBuilder.Tests/ApprovalFiles/TimeoutScriptBuilderTest.BuildCreateScript.ForScenario.Oracle.approved.txt
+++ b/src/ScriptBuilder.Tests/ApprovalFiles/TimeoutScriptBuilderTest.BuildCreateScript.ForScenario.Oracle.approved.txt
@@ -1,8 +1,8 @@
 ﻿declare
-  tableName varchar2(30) := UPPER(:tablePrefix) || 'TO';
-  timeIndex varchar2(30) := tableName || '_TK';
-  sagaIndex varchar2(30) := tableName || '_SK';
-  sqlStatement varchar2(500);
+  tableName varchar2(128) := UPPER(:tablePrefix) || 'TO';
+  timeIndex varchar2(128) := tableName || '_TK';
+  sagaIndex varchar2(128) := tableName || '_SK';
+  sqlStatement varchar2(750);
   n number(10);
 begin
   select count(*) into n from user_tables where table_name = tableName;

--- a/src/ScriptBuilder.Tests/ApprovalFiles/TimeoutScriptBuilderTest.BuildDropScript.ForScenario.Oracle.approved.txt
+++ b/src/ScriptBuilder.Tests/ApprovalFiles/TimeoutScriptBuilderTest.BuildDropScript.ForScenario.Oracle.approved.txt
@@ -1,6 +1,6 @@
 ﻿declare
-  tableName varchar2(30) := UPPER(:tablePrefix) || 'TO';
-  dropTable varchar2(50);
+  tableName varchar2(128) := UPPER(:tablePrefix) || 'TO';
+  dropTable varchar2(150);
   n number(10);
 begin
   select count(*) into n from user_tables where table_name = tableName;

--- a/src/ScriptBuilder/Outbox/Create_Oracle.sql
+++ b/src/ScriptBuilder/Outbox/Create_Oracle.sql
@@ -1,9 +1,9 @@
 ﻿declare
-  tableName varchar2(30) := UPPER(:tablePrefix) || 'OD';
-  pkName varchar2(30) := tableName || '_PK';
-  indexName varchar2(30) := tableName || '_IX';
-  createTable varchar2(500);
-  createIndex varchar2(500);
+  tableName varchar2(128) := UPPER(:tablePrefix) || 'OD';
+  pkName varchar2(128) := tableName || '_PK';
+  indexName varchar2(128) := tableName || '_IX';
+  createTable varchar2(750);
+  createIndex varchar2(750);
   n number(10);
 begin
   select count(*) into n from user_tables where table_name = tableName;

--- a/src/ScriptBuilder/Outbox/Drop_Oracle.sql
+++ b/src/ScriptBuilder/Outbox/Drop_Oracle.sql
@@ -1,6 +1,6 @@
 ﻿declare
-  tableName varchar2(30) := UPPER(:tablePrefix) || 'OD';
-  dropTable varchar2(50);
+  tableName varchar2(128) := UPPER(:tablePrefix) || 'OD';
+  dropTable varchar2(150);
   n number(10);
 begin
   select count(*) into n from user_tables where table_name = tableName;

--- a/src/ScriptBuilder/Saga/Writers/OracleSagaScriptWriter.cs
+++ b/src/ScriptBuilder/Saga/Writers/OracleSagaScriptWriter.cs
@@ -14,9 +14,9 @@ class OracleSagaScriptWriter : ISagaScriptWriter
     {
         writer = textWriter;
         this.saga = saga;
-        if (saga.TableSuffix.Length > 27)
+        if (saga.TableSuffix.Length > 127)
         {
-            throw new Exception($"Saga '{saga.TableSuffix}' contains more than 27 characters, which is not supported by SQL persistence using Oracle. Either disable Oracle script generation using the SqlPersistenceSettings assembly attribute, shorten the name of the saga, or specify an alternate table name by overriding the SqlSaga's TableSuffix property.");
+            throw new Exception($"Saga '{saga.TableSuffix}' contains more than 127 characters, which is not supported by SQL persistence using Oracle. Either disable Oracle script generation using the SqlPersistenceSettings assembly attribute, shorten the name of the saga, or specify an alternate table name by overriding the SqlSaga's TableSuffix property.");
         }
         if (Encoding.UTF8.GetBytes(saga.TableSuffix).Length != saga.TableSuffix.Length)
         {

--- a/src/ScriptBuilder/Subscription/Create_Oracle.sql
+++ b/src/ScriptBuilder/Subscription/Create_Oracle.sql
@@ -1,6 +1,6 @@
 ﻿declare
-  tableName varchar2(30) := UPPER(:tablePrefix) || 'SS';
-  createTable varchar2(500);
+  tableName varchar2(128) := UPPER(:tablePrefix) || 'SS';
+  createTable varchar2(750);
   n number(10);
 begin
   select count(*) into n from user_tables where table_name = tableName;

--- a/src/ScriptBuilder/Subscription/Drop_Oracle.sql
+++ b/src/ScriptBuilder/Subscription/Drop_Oracle.sql
@@ -1,6 +1,6 @@
 ﻿declare
-  tableName varchar2(30) := UPPER(:tablePrefix) || 'SS';
-  dropTable varchar2(50);
+  tableName varchar2(128) := UPPER(:tablePrefix) || 'SS';
+  dropTable varchar2(150);
   n number(10);
 begin
   select count(*) into n from user_tables where table_name = tableName;

--- a/src/ScriptBuilder/Timeout/Create_Oracle.sql
+++ b/src/ScriptBuilder/Timeout/Create_Oracle.sql
@@ -1,8 +1,8 @@
 ﻿declare
-  tableName varchar2(30) := UPPER(:tablePrefix) || 'TO';
-  timeIndex varchar2(30) := tableName || '_TK';
-  sagaIndex varchar2(30) := tableName || '_SK';
-  sqlStatement varchar2(500);
+  tableName varchar2(128) := UPPER(:tablePrefix) || 'TO';
+  timeIndex varchar2(128) := tableName || '_TK';
+  sagaIndex varchar2(128) := tableName || '_SK';
+  sqlStatement varchar2(750);
   n number(10);
 begin
   select count(*) into n from user_tables where table_name = tableName;

--- a/src/ScriptBuilder/Timeout/Drop_Oracle.sql
+++ b/src/ScriptBuilder/Timeout/Drop_Oracle.sql
@@ -1,6 +1,6 @@
 ﻿declare
-  tableName varchar2(30) := UPPER(:tablePrefix) || 'TO';
-  dropTable varchar2(50);
+  tableName varchar2(128) := UPPER(:tablePrefix) || 'TO';
+  dropTable varchar2(150);
   n number(10);
 begin
   select count(*) into n from user_tables where table_name = tableName;

--- a/src/SqlPersistence.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/SqlPersistence.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -129,6 +129,7 @@ namespace NServiceBus
         public static void ConnectionBuilder(this NServiceBus.PersistenceExtensions<NServiceBus.SqlPersistence> configuration, System.Func<System.Data.Common.DbConnection> connectionBuilder) { }
         public static void DisableInstaller(this NServiceBus.PersistenceExtensions<NServiceBus.SqlPersistence> configuration) { }
         public static void DoNotUseSqlServerTransportConnection(this NServiceBus.SqlDialectSettings<NServiceBus.SqlDialect.MsSqlServer> dialectSettings) { }
+        public static void EnableLongTableNames(this NServiceBus.SqlDialectSettings<NServiceBus.SqlDialect.Oracle> dialectSettings) { }
         public static void JsonBParameterModifier(this NServiceBus.SqlDialectSettings<NServiceBus.SqlDialect.PostgreSql> dialectSettings, System.Action<System.Data.Common.DbParameter> modifier) { }
         public static void MultiTenantConnectionBuilder(this NServiceBus.PersistenceExtensions<NServiceBus.SqlPersistence> configuration, System.Func<NServiceBus.Transport.IncomingMessage, string> captureTenantId, System.Func<string, System.Data.Common.DbConnection> buildConnectionFromTenantData) { }
         public static void MultiTenantConnectionBuilder(this NServiceBus.PersistenceExtensions<NServiceBus.SqlPersistence> configuration, string tenantIdHeaderName, System.Func<string, System.Data.Common.DbConnection> buildConnectionFromTenantData) { }

--- a/src/SqlPersistence.Tests/Dialect/OracleDialectTests.cs
+++ b/src/SqlPersistence.Tests/Dialect/OracleDialectTests.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using NServiceBus;
+using NUnit.Framework;
+
+[TestFixture]
+public class OracleDialectTests
+{
+    SqlDialect.Oracle dialect;
+
+    [SetUp]
+    public void SetUp()
+    {
+        dialect = new SqlDialect.Oracle();
+    }
+
+    [Test]
+    public void AcceptsValidTablePrefix() =>
+        Assert.DoesNotThrow(() => dialect.ValidateTablePrefix("ThisIsAValidTablePrefix"));
+
+    [Test]
+    public void ThrowsForLongTablePrefix() =>
+        Assert.Throws<Exception>(
+            () => dialect.ValidateTablePrefix("ThisIsATablePrefixThatIsTooLong")
+        );
+
+    [Test]
+    public void AcceptsLongTablePrefixIfLongTableNamesEnabled()
+    {
+        dialect.EnableLongTableNames = true;
+        Assert.DoesNotThrow(
+            () => dialect.ValidateTablePrefix("ThisIsATablePrefixThatIsTooLong")
+        );
+    }
+
+    [Test]
+    public void ThrowsForVeryLongTablePrefixEvenIfLongTableNamesEnabled()
+    {
+        dialect.EnableLongTableNames = true;
+        Assert.Throws<Exception>(
+        () => dialect.ValidateTablePrefix("ThisIsATablePrefixWhichIsLongerThan128CharactersBecauseThatIsTheLimitOfTheLatestOracleServerOnceUponAMidnightDrearyWhileIPonderedWeakAndWeary")
+        );
+    }
+
+    [Test]
+    public void AcceptsValidSagaName() =>
+        Assert.DoesNotThrow(
+            () => dialect.GetSagaTableName(null, "ThisIsAValidSagaName")
+        );
+
+    [Test]
+    public void ThrowsForLongSagaName() =>
+        Assert.Throws<Exception>(
+            () => dialect.GetSagaTableName(null, "ThisIsASagaNameWhichIsOver27CharactersAndIsTooLong")
+        );
+
+    [Test]
+    public void AcceptsLongSagaNameWhenLongTableNamesEnabled()
+    {
+        dialect.EnableLongTableNames = true;
+        Assert.DoesNotThrow(
+            () => dialect.GetSagaTableName(null, "ThisIsASagaNameWhichIsOver27CharactersAndIsTooLong")
+        );
+    }
+
+    [Test]
+    public void ThrowsForVeryLongSagaNameEvenIfLongTableNamesEnabled()
+    {
+        dialect.EnableLongTableNames = true;
+        Assert.Throws<Exception>(
+            () => dialect.GetSagaTableName(null, "ThisISagaNameWhichIsLongerThan128CharactersBecauseThatIsTheLimitOfTheLatestOracleServerOverManyQuaintAndCuriousVolumeOfForgottenLore")
+        );
+    }
+}

--- a/src/SqlPersistence/Config/SqlPersistenceConfig_SqlDialect_Oracle.cs
+++ b/src/SqlPersistence/Config/SqlPersistenceConfig_SqlDialect_Oracle.cs
@@ -13,5 +13,18 @@ namespace NServiceBus
             Guard.AgainstSqlDelimiters(nameof(schema), schema);
             dialectSettings.TypedDialect.Schema = schema;
         }
+
+        /// <summary>
+        /// Increases the maximum table name size from 30 bytes to 128 bytes.
+        /// </summary>
+        /// <remarks>
+        /// Requires Oracle 12.2 or higher.
+        /// </remarks>
+        public static void EnableLongTableNames(this SqlDialectSettings<SqlDialect.Oracle> dialectSettings)
+        {
+            Guard.AgainstNull(nameof(dialectSettings), dialectSettings);
+
+            dialectSettings.TypedDialect.EnableLongTableNames = true;
+        }
     }
 }

--- a/src/SqlPersistence/Saga/SqlDialect_Oracle.cs
+++ b/src/SqlPersistence/Saga/SqlDialect_Oracle.cs
@@ -11,9 +11,11 @@ namespace NServiceBus
         {
             internal override string GetSagaTableName(string tablePrefix, string tableSuffix)
             {
-                if (tableSuffix.Length > 27)
+                const int sagaNameSuffixLength = 3;
+                var tableSuffixNameLimit = TableNameMax - sagaNameSuffixLength;
+                if (tableSuffix.Length > tableSuffixNameLimit)
                 {
-                    throw new Exception($"Saga '{tableSuffix}' contains more than 27 characters, which is not supported by SQL persistence using Oracle. Either disable Oracle script generation using the SqlPersistenceSettings assembly attribute, shorten the name of the saga, or specify an alternate table name by overriding the SqlSaga's TableSuffix property.");
+                    throw new Exception($"Saga '{tableSuffix}' contains more than {tableSuffixNameLimit} characters, which is not supported by SQL persistence using Oracle. Either disable Oracle script generation using the SqlPersistenceSettings assembly attribute, shorten the name of the saga, or specify an alternate table name by overriding the SqlSaga's TableSuffix property.");
                 }
                 if (Encoding.UTF8.GetBytes(tableSuffix).Length != tableSuffix.Length)
                 {


### PR DESCRIPTION
Fixes https://github.com/Particular/NServiceBus.Persistence.Sql/issues/198

Oracle 12.2 raised the table name maximum from 30 bytes to 128 bytes. Enabling this feature will allow longer table names. This raises the limit for endpoint name and saga names.

```csharp
var persistence = endpointConfiguration.UsePersistence<SqlPersistence>();
var oracle = persistence.SqlVariant(SqlVariant.Oracle);
oracle.EnableLongTableNames();
```

NOTE: The script generated at runtime will also allow for longer names and no longer checks to see if names fit within the smaller limit. These issues will still be detected at runtime when the endpoint starts.