### PR TITLE
Support for SQL*Plus in Oracle dialect generated scripts

### DIFF
--- a/src/ScriptBuilder.Tests/ApprovalFiles/OutboxScriptBuilderTest.BuildCreateScript.ForScenario.Oracle.approved.txt
+++ b/src/ScriptBuilder.Tests/ApprovalFiles/OutboxScriptBuilderTest.BuildCreateScript.ForScenario.Oracle.approved.txt
@@ -1,5 +1,5 @@
 ﻿declare
-  tableName varchar2(30) := UPPER(:1) || 'OD';
+  tableName varchar2(30) := UPPER(:tablePrefix) || 'OD';
   pkName varchar2(30) := tableName || '_PK';
   indexName varchar2(30) := tableName || '_IX';
   createTable varchar2(500);

--- a/src/ScriptBuilder.Tests/ApprovalFiles/OutboxScriptBuilderTest.BuildDropScript.ForScenario.Oracle.approved.txt
+++ b/src/ScriptBuilder.Tests/ApprovalFiles/OutboxScriptBuilderTest.BuildDropScript.ForScenario.Oracle.approved.txt
@@ -1,5 +1,5 @@
 ﻿declare
-  tableName varchar2(30) := UPPER(:1) || 'OD';
+  tableName varchar2(30) := UPPER(:tablePrefix) || 'OD';
   dropTable varchar2(50);
   n number(10);
 begin

--- a/src/ScriptBuilder.Tests/ApprovalFiles/SubscriptionScriptBuilderTest.BuildCreateScript.ForScenario.Oracle.approved.txt
+++ b/src/ScriptBuilder.Tests/ApprovalFiles/SubscriptionScriptBuilderTest.BuildCreateScript.ForScenario.Oracle.approved.txt
@@ -1,5 +1,5 @@
 ﻿declare
-  tableName varchar2(30) := UPPER(:1) || 'SS';
+  tableName varchar2(30) := UPPER(:tablePrefix) || 'SS';
   createTable varchar2(500);
   n number(10);
 begin

--- a/src/ScriptBuilder.Tests/ApprovalFiles/SubscriptionScriptBuilderTest.BuildDropScript.ForScenario.Oracle.approved.txt
+++ b/src/ScriptBuilder.Tests/ApprovalFiles/SubscriptionScriptBuilderTest.BuildDropScript.ForScenario.Oracle.approved.txt
@@ -1,5 +1,5 @@
 ﻿declare
-  tableName varchar2(30) := UPPER(:1) || 'SS';
+  tableName varchar2(30) := UPPER(:tablePrefix) || 'SS';
   dropTable varchar2(50);
   n number(10);
 begin

--- a/src/ScriptBuilder.Tests/ApprovalFiles/TimeoutScriptBuilderTest.BuildCreateScript.ForScenario.Oracle.approved.txt
+++ b/src/ScriptBuilder.Tests/ApprovalFiles/TimeoutScriptBuilderTest.BuildCreateScript.ForScenario.Oracle.approved.txt
@@ -1,5 +1,5 @@
 ﻿declare
-  tableName varchar2(30) := UPPER(:1) || 'TO';
+  tableName varchar2(30) := UPPER(:tablePrefix) || 'TO';
   timeIndex varchar2(30) := tableName || '_TK';
   sagaIndex varchar2(30) := tableName || '_SK';
   sqlStatement varchar2(500);

--- a/src/ScriptBuilder.Tests/ApprovalFiles/TimeoutScriptBuilderTest.BuildDropScript.ForScenario.Oracle.approved.txt
+++ b/src/ScriptBuilder.Tests/ApprovalFiles/TimeoutScriptBuilderTest.BuildDropScript.ForScenario.Oracle.approved.txt
@@ -1,5 +1,5 @@
 ﻿declare
-  tableName varchar2(30) := UPPER(:1) || 'TO';
+  tableName varchar2(30) := UPPER(:tablePrefix) || 'TO';
   dropTable varchar2(50);
   n number(10);
 begin

--- a/src/ScriptBuilder/Outbox/Create_Oracle.sql
+++ b/src/ScriptBuilder/Outbox/Create_Oracle.sql
@@ -1,5 +1,5 @@
 ﻿declare
-  tableName varchar2(30) := UPPER(:1) || 'OD';
+  tableName varchar2(30) := UPPER(:tablePrefix) || 'OD';
   pkName varchar2(30) := tableName || '_PK';
   indexName varchar2(30) := tableName || '_IX';
   createTable varchar2(500);

--- a/src/ScriptBuilder/Outbox/Drop_Oracle.sql
+++ b/src/ScriptBuilder/Outbox/Drop_Oracle.sql
@@ -1,5 +1,5 @@
 ﻿declare
-  tableName varchar2(30) := UPPER(:1) || 'OD';
+  tableName varchar2(30) := UPPER(:tablePrefix) || 'OD';
   dropTable varchar2(50);
   n number(10);
 begin

--- a/src/ScriptBuilder/Subscription/Create_Oracle.sql
+++ b/src/ScriptBuilder/Subscription/Create_Oracle.sql
@@ -1,5 +1,5 @@
 ﻿declare
-  tableName varchar2(30) := UPPER(:1) || 'SS';
+  tableName varchar2(30) := UPPER(:tablePrefix) || 'SS';
   createTable varchar2(500);
   n number(10);
 begin

--- a/src/ScriptBuilder/Subscription/Drop_Oracle.sql
+++ b/src/ScriptBuilder/Subscription/Drop_Oracle.sql
@@ -1,5 +1,5 @@
 ﻿declare
-  tableName varchar2(30) := UPPER(:1) || 'SS';
+  tableName varchar2(30) := UPPER(:tablePrefix) || 'SS';
   dropTable varchar2(50);
   n number(10);
 begin

--- a/src/ScriptBuilder/Timeout/Create_Oracle.sql
+++ b/src/ScriptBuilder/Timeout/Create_Oracle.sql
@@ -1,5 +1,5 @@
 ﻿declare
-  tableName varchar2(30) := UPPER(:1) || 'TO';
+  tableName varchar2(30) := UPPER(:tablePrefix) || 'TO';
   timeIndex varchar2(30) := tableName || '_TK';
   sagaIndex varchar2(30) := tableName || '_SK';
   sqlStatement varchar2(500);

--- a/src/ScriptBuilder/Timeout/Drop_Oracle.sql
+++ b/src/ScriptBuilder/Timeout/Drop_Oracle.sql
@@ -1,5 +1,5 @@
 ﻿declare
-  tableName varchar2(30) := UPPER(:1) || 'TO';
+  tableName varchar2(30) := UPPER(:tablePrefix) || 'TO';
   dropTable varchar2(50);
   n number(10);
 begin


### PR DESCRIPTION
Fixes https://github.com/Particular/NServiceBus.Persistence.Sql/issues/362

Switches all Oracle dialect scripts to use `:tablePrefix` instead of `:1`. 

Our generated Oracle scripts all use positional binding variable `:1` for the table prefix which is incompatible with SQL*Plus which requires binding variables to have a valid identifier. All of our [code](https://github.com/Particular/NServiceBus.Persistence.Sql/blob/master/src/SqlPersistence/Config/SqlDialect.cs#L50) and [documentation](https://docs.particular.net/persistence/sql/install#manual-installation-mysql-oracle) already gives the first parameter this name.