### PR TITLE
Add padding to outbox data in SQL Server if outbox data size is between 4 and 8 KB

### DIFF
--- a/src/SqlPersistence/Outbox/SqlDialect.cs
+++ b/src/SqlPersistence/Outbox/SqlDialect.cs
@@ -9,5 +9,6 @@
         internal abstract string GetOutboxPessimisticBeginCommand(string tableName);
         internal abstract string GetOutboxPessimisticCompleteCommand(string tableName);
         internal abstract string GetOutboxCleanupCommand(string tableName);
+        internal virtual string AddOutboxPadding(string json) => json;
     }
 }

--- a/src/SqlPersistence/Outbox/SqlDialect_MsSqlServer.cs
+++ b/src/SqlPersistence/Outbox/SqlDialect_MsSqlServer.cs
@@ -86,7 +86,7 @@ where Dispatched = 'true' and
                 //We need to ensure the outbox content is at lest 8000 bytes long because otherwise SQL Server will attempt to
                 //store is inside the data page which will result in low space utilization.
 
-                //We tried using *varchar values of of the row* table option but while it did improve situation on on-premises 
+                //We tried using *varchar values out of the row* table option but while it did improve situation on on-premises 
                 //SQL Server it didn't work as expected in SQL Azure where it caused LOB pages to be allocated (one for each record) 
                 //but never deallocated after the messages data is supposed to be removed.
 

--- a/src/SqlPersistence/Outbox/SqlDialect_MsSqlServer.cs
+++ b/src/SqlPersistence/Outbox/SqlDialect_MsSqlServer.cs
@@ -86,7 +86,10 @@ where Dispatched = 'true' and
                 //We need to ensure the outbox content is at lest 8000 bytes long because otherwise SQL Server will attempt to
                 //store is inside the data page which will result in low space utilization.
 
-We tried using *varchar values of of the row* table option but while it did improve situation on on-premises SQL Server it didn't work as expected in SQL Azure where it caused LOB pages to be allocated (one for each record) but never deallocated after the messages data is supposed to be removed.
+                //We tried using *varchar values of of the row* table option but while it did improve situation on on-premises 
+                //SQL Server it didn't work as expected in SQL Azure where it caused LOB pages to be allocated (one for each record) 
+                //but never deallocated after the messages data is supposed to be removed.
+
                 //We use 4000 instead of 8000 in the condition because the SQL Persistence uses nvarchar data type which encodes
                 //strings at UTF-16 (2 bytes per character)
 

--- a/src/SqlPersistence/Outbox/SqlDialect_MsSqlServer.cs
+++ b/src/SqlPersistence/Outbox/SqlDialect_MsSqlServer.cs
@@ -86,6 +86,7 @@ where Dispatched = 'true' and
                 //We need to ensure the outbox content is at lest 8000 bytes long because otherwise SQL Server will attempt to
                 //store is inside the data page which will result in low space utilization.
 
+We tried using *varchar values of of the row* table option but while it did improve situation on on-premises SQL Server it didn't work as expected in SQL Azure where it caused LOB pages to be allocated (one for each record) but never deallocated after the messages data is supposed to be removed.
                 //We use 4000 instead of 8000 in the condition because the SQL Persistence uses nvarchar data type which encodes
                 //strings at UTF-16 (2 bytes per character)
 


### PR DESCRIPTION
This PR attempts to address an issue with the outbox on SQL Server. The issue is caused by SQL Server refusing to attempt to store outbox records which are larger than half of the page size even if the target page is almost empty. This behavior leads to wasted space in the outbox table.