### PR TITLE
Remove long names from tests

### DIFF
--- a/src/AcceptanceTestHelper/RuntimeSagaDefinitionReader.cs
+++ b/src/AcceptanceTestHelper/RuntimeSagaDefinitionReader.cs
@@ -73,6 +73,11 @@ public static class RuntimeSagaDefinitionReader
         var tableSuffixOverride = GetSagaMetadataProperty(sagaType, saga, "TableSuffix", att => att.TableSuffix);
         var tableSuffix = tableSuffixOverride ?? sagaType.Name;
 
+        if (sqlDialect == BuildSqlDialect.Oracle)
+        {
+            tableSuffix = tableSuffix.Substring(0, Math.Min(27, tableSuffix.Length));
+        }
+
         return new SagaDefinition(
             tableSuffix: tableSuffix,
             name: sagaType.FullName,

--- a/src/OracleAcceptanceTests/ConfigureEndpointSqlPersistence.cs
+++ b/src/OracleAcceptanceTests/ConfigureEndpointSqlPersistence.cs
@@ -20,21 +20,20 @@ public class ConfigureEndpointSqlPersistence : IConfigureEndpointTestExecution
         {
             endpointName = endpointName.Substring(lastDot + 1) + Math.Abs(endpointName.GetHashCode());
         }
-        var tablePrefix = TableNameCleaner.Clean(endpointName).Substring(0, Math.Min(endpointName.Length, 124));
+        var tablePrefix = TableNameCleaner.Clean(endpointName).Substring(0, Math.Min(endpointName.Length, 24));
         Console.WriteLine($"Using EndpointName='{endpointName}', TablePrefix='{tablePrefix}'");
         endpointHelper = new ConfigureEndpointHelper(configuration, tablePrefix, OracleConnectionBuilder.Build, BuildSqlDialect.Oracle, FilterTableExists);
         var persistence = configuration.UsePersistence<SqlPersistence>();
-        var oracle = persistence.SqlDialect<SqlDialect.Oracle>();
-        oracle.EnableLongTableNames();
+        persistence.SqlDialect<SqlDialect.Oracle>();
         persistence.ConnectionBuilder(OracleConnectionBuilder.Build);
         persistence.TablePrefix($"{tablePrefix}_");
         var subscriptions = persistence.SubscriptionSettings();
         subscriptions.DisableCache();
         persistence.DisableInstaller();
 
-        //Force Saga table names to 127 characters to fit in Oracle
+        //Force Saga table names to 27 characters to fit in Oracle
         var sagaSettings = persistence.SagaSettings();
-        sagaSettings.NameFilter(sagaName => sagaName.Substring(0, Math.Min(127, sagaName.Length)));
+        sagaSettings.NameFilter(sagaName => sagaName.Substring(0, Math.Min(27, sagaName.Length)));
 
         return Task.FromResult(0);
     }


### PR DESCRIPTION
This PR restores the prior behavior of the Oracle tests to shorten endpoint and saga names.