### PR TITLE
Changed the DefaultValueHandling for saga state serialization to Include

### DIFF
--- a/src/SqlPersistence/Serializer.cs
+++ b/src/SqlPersistence/Serializer.cs
@@ -13,7 +13,7 @@ static class Serializer
         var settings = new JsonSerializerSettings
         {
             Formatting = Formatting.Indented,
-            DefaultValueHandling = DefaultValueHandling.Ignore
+            DefaultValueHandling = DefaultValueHandling.Include // or just remove as Include is the default
         };
         JsonSerializer = JsonSerializer.Create(settings);
     }


### PR DESCRIPTION
Resolves #668

Alternatively `Include` can be set via `UsePersistence<SqlPersistence, StorageType.Sagas>().SagaSettings().JsonSettings(...)` if changing the default to `Include` has side-effects that should not be introduced in a patch release.

```c#
var currentSettings = new JsonSerializerSettings
{
    DefaultValueHandling = DefaultValueHandling.Include
};
var persistence = endpointConfiguration.UsePersistence<SqlPersistence, StorageType.Sagas>();
var sagaSettings = persistence.SagaSettings();
sagaSettings.JsonSettings(currentSettings);
```