### PR TITLE
Non-clustered primary key on saga table prevents deadlocks

### DIFF
--- a/src/ScriptBuilder.Tests/ApprovalFiles/SagaScriptBuilderTest.CreateWithCorrelation.ForScenario.MsSqlServer.approved.txt
+++ b/src/ScriptBuilder.Tests/ApprovalFiles/SagaScriptBuilderTest.CreateWithCorrelation.ForScenario.MsSqlServer.approved.txt
@@ -21,7 +21,7 @@ begin
 declare @createTable nvarchar(max);
 set @createTable = '
     create table ' + @tableName + '(
-        Id uniqueidentifier not null primary key,
+        Id uniqueidentifier not null primary key nonclustered,
         Metadata nvarchar(max) not null,
         Data nvarchar(max) not null,
         PersistenceVersion varchar(23) not null,

--- a/src/ScriptBuilder.Tests/ApprovalFiles/SagaScriptBuilderTest.CreateWithCorrelationAndTransitional.ForScenario.MsSqlServer.approved.txt
+++ b/src/ScriptBuilder.Tests/ApprovalFiles/SagaScriptBuilderTest.CreateWithCorrelationAndTransitional.ForScenario.MsSqlServer.approved.txt
@@ -21,7 +21,7 @@ begin
 declare @createTable nvarchar(max);
 set @createTable = '
     create table ' + @tableName + '(
-        Id uniqueidentifier not null primary key,
+        Id uniqueidentifier not null primary key nonclustered,
         Metadata nvarchar(max) not null,
         Data nvarchar(max) not null,
         PersistenceVersion varchar(23) not null,

--- a/src/ScriptBuilder/Saga/Writers/MsSqlServerSagaScriptWriter.cs
+++ b/src/ScriptBuilder/Saga/Writers/MsSqlServerSagaScriptWriter.cs
@@ -175,7 +175,7 @@ begin
 declare @createTable nvarchar(max);
 set @createTable = '
     create table ' + @tableName + '(
-        Id uniqueidentifier not null primary key,
+        Id uniqueidentifier not null primary key nonclustered,
         Metadata nvarchar(max) not null,
         Data nvarchar(max) not null,
         PersistenceVersion varchar(23) not null,


### PR DESCRIPTION
Missing from this PR is a schema updater and/or a schema validator to log at endpoint instance start if the RK index is still clustered.

----


While testing it seems that under high concurrent load the clustered index can cause unneeded deadlocks because SQL tried to obtain a lock on the primary key for the SELECT FOR UPDATE query.

![image](https://user-images.githubusercontent.com/152998/117044156-67f21d80-ad0e-11eb-943b-ae8a8bc5c804.png)

and

![image](https://user-images.githubusercontent.com/152998/117044205-76d8d000-ad0e-11eb-9ac4-c81b23bd4a84.png)

Both are on the saga SELECT FOR UPDATE query.

After converting the primary key to a non clustered index I have not experienced a deadlock anymore.
