### PR TITLE
Fix build

### DIFF
--- a/src/SqlPersistence.PersistenceTests/PersistenceTestsConfiguration.cs
+++ b/src/SqlPersistence.PersistenceTests/PersistenceTestsConfiguration.cs
@@ -165,7 +165,7 @@
             ISqlOutboxTransaction transactionFactory()
             {
                 return transactionScopeMode
-                    ? (ISqlOutboxTransaction)new TransactionScopeSqlOutboxTransaction(concurrencyControlStrategy, connectionManager, IsolationLevel.ReadCommitted)
+                    ? new TransactionScopeSqlOutboxTransaction(concurrencyControlStrategy, connectionManager, IsolationLevel.ReadCommitted)
                     : new AdoNetSqlOutboxTransaction(concurrencyControlStrategy, connectionManager, System.Data.IsolationLevel.ReadCommitted);
             }
 

--- a/src/SqlPersistence.PersistenceTests/SqlPersistence.PersistenceTests.csproj
+++ b/src/SqlPersistence.PersistenceTests/SqlPersistence.PersistenceTests.csproj
@@ -5,6 +5,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)Test.snk</AssemblyOriginatorKeyFile>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SqlPersistence.Tests/Infrastructure/OnlyOnWindowsAttribute.cs
+++ b/src/SqlPersistence.Tests/Infrastructure/OnlyOnWindowsAttribute.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+using OSPlatform = System.Runtime.InteropServices.OSPlatform;
+
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]
+class OnlyOnWindowsAttribute : Attribute, IApplyToContext
+{
+    public void ApplyToContext(TestExecutionContext context)
+    {
+        if (!IsOnWindows)
+        {
+            Assert.Ignore("Only on windows");
+        }
+    }
+
+    public static bool IsOnWindows => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+}

--- a/src/SqlPersistence.Tests/Outbox/OracleOutboxPersisterTests.cs
+++ b/src/SqlPersistence.Tests/Outbox/OracleOutboxPersisterTests.cs
@@ -10,6 +10,7 @@ namespace Oracle
     [TestFixture(true, false)]
     [TestFixture(false, true)]
     [TestFixture(true, true)]
+    [OnlyOnWindows]
     public class OracleOutboxPersisterTests : OutboxPersisterTests
     {
         public OracleOutboxPersisterTests(bool pessimistic, bool transactionScope)

--- a/src/SqlPersistence.Tests/Outbox/OutboxPersisterTests.cs
+++ b/src/SqlPersistence.Tests/Outbox/OutboxPersisterTests.cs
@@ -54,7 +54,7 @@ public abstract class OutboxPersisterTests
                 }
 
                 return transactionScope
-                    ? (ISqlOutboxTransaction)new TransactionScopeSqlOutboxTransaction(behavior, connectionManager, IsolationLevel.ReadCommitted)
+                    ? new TransactionScopeSqlOutboxTransaction(behavior, connectionManager, IsolationLevel.ReadCommitted)
                     : new AdoNetSqlOutboxTransaction(behavior, connectionManager, System.Data.IsolationLevel.ReadCommitted);
             },
             cleanupBatchSize: 5);

--- a/src/SqlPersistence.Tests/Saga/OracleSagaPersisterTests.cs
+++ b/src/SqlPersistence.Tests/Saga/OracleSagaPersisterTests.cs
@@ -6,7 +6,7 @@
     using NUnit.Framework;
     using Oracle.ManagedDataAccess.Client;
 
-    [TestFixture]
+    [TestFixture, OnlyOnWindows]
     public class OracleSagaPersisterTests : SagaPersisterTests
     {
         public OracleSagaPersisterTests() : base(BuildSqlDialect.Oracle, "Particular2")

--- a/src/SqlPersistence.Tests/SetUpFixture.cs
+++ b/src/SqlPersistence.Tests/SetUpFixture.cs
@@ -105,9 +105,12 @@ namespace Oracle
         [OneTimeSetUp]
         public void Setup()
         {
-            using (var connection = OracleConnectionBuilder.Build())
+            if (OnlyOnWindowsAttribute.IsOnWindows)
             {
-                connection.Open();
+                using (var connection = OracleConnectionBuilder.Build())
+                {
+                    connection.Open();
+                }
             }
         }
     }

--- a/src/SqlPersistence.Tests/SqlPersistence.Tests.csproj
+++ b/src/SqlPersistence.Tests/SqlPersistence.Tests.csproj
@@ -5,6 +5,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)Test.snk</AssemblyOriginatorKeyFile>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SqlPersistence.Tests/SqlPersistence.Tests.csproj
+++ b/src/SqlPersistence.Tests/SqlPersistence.Tests.csproj
@@ -22,11 +22,4 @@
     <PackageReference Include="PublicApiGenerator" Version="10.2.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <Compile Remove="Saga\OracleSagaPersisterTests.cs" />
-    <Compile Remove="Outbox\OracleOutboxPersisterTests.cs" />
-    <Compile Remove="Timeout\OracleTimeoutPersisterTests.cs" />
-    <Compile Remove="Subscription\OracleSubscriptionPersisterTests.cs" />
-  </ItemGroup>
-
 </Project>

--- a/src/SqlPersistence.Tests/Subscription/OracleSubscriptionPersisterTests.cs
+++ b/src/SqlPersistence.Tests/Subscription/OracleSubscriptionPersisterTests.cs
@@ -6,7 +6,7 @@ namespace Oracle
     using NUnit.Framework;
     using Oracle.ManagedDataAccess.Client;
 
-    [TestFixture]
+    [TestFixture, OnlyOnWindows]
     public class OracleSubscriptionPersisterTests : SubscriptionPersisterTests
     {
         public OracleSubscriptionPersisterTests() : base(BuildSqlDialect.Oracle, "Particular2")


### PR DESCRIPTION
`IDE0004 Cast is redundant` is being applied by mistake to a conditional operator expression for language versions prior to 9.

Additionally, enabled Oracle tests on .NET Core for Windows.