### PR TITLE
Fix build error

### DIFF
--- a/src/ScriptBuilder.Tests/APIApprovals.cs
+++ b/src/ScriptBuilder.Tests/APIApprovals.cs
@@ -9,7 +9,7 @@ public class APIApprovals
     [Test]
     public void Approve()
     {
-        var publicApi = ApiGenerator.GeneratePublicApi(typeof(ScriptWriter).Assembly, excludeAttributes: new[] { "System.Runtime.Versioning.TargetFrameworkAttribute" });
+        var publicApi = ApiGenerator.GeneratePublicApi(typeof(ScriptWriter).Assembly, excludeAttributes: new[] { "System.Runtime.Versioning.TargetFrameworkAttribute", "System.Reflection.AssemblyMetadataAttribute" });
         Approver.Verify(publicApi);
     }
 }


### PR DESCRIPTION
The compiler is adding a new attribute (`System.Reflection.AssemblyMetadataAttribute`) that is getting picked up by the API approval tests.

This is one that we [frequently filter out](https://github.com/search?q=org%3AParticular+AssemblyMetadataAttribute&type=code).