### PR TITLE
Fix build server issue for release 3.2

### DIFF
--- a/src/ScriptBuilder.Tests/APIApprovals.cs
+++ b/src/ScriptBuilder.Tests/APIApprovals.cs
@@ -12,7 +12,7 @@ public class APIApprovals
     {
         var combine = Path.Combine(TestContext.CurrentContext.TestDirectory, "NServiceBus.Persistence.Sql.ScriptBuilder.dll");
         var assembly = Assembly.LoadFile(combine);
-        var publicApi = ApiGenerator.GeneratePublicApi(assembly, excludeAttributes: new[] { "System.Runtime.Versioning.TargetFrameworkAttribute" });
+        var publicApi = ApiGenerator.GeneratePublicApi(assembly, excludeAttributes: new[] { "System.Runtime.Versioning.TargetFrameworkAttribute", "System.Reflection.AssemblyMetadataAttribute" });
         Approver.Verify(publicApi);
     }
 }

--- a/src/SqlPersistence.Tests/APIApprovals.cs
+++ b/src/SqlPersistence.Tests/APIApprovals.cs
@@ -12,7 +12,7 @@ public class APIApprovals
     {
         var combine = Path.Combine(TestContext.CurrentContext.TestDirectory, "NServiceBus.Persistence.Sql.dll");
         var assembly = Assembly.LoadFile(combine);
-        var publicApi = ApiGenerator.GeneratePublicApi(assembly, excludeAttributes: new[] { "System.Runtime.Versioning.TargetFrameworkAttribute" });
+        var publicApi = ApiGenerator.GeneratePublicApi(assembly, excludeAttributes: new[] { "System.Runtime.Versioning.TargetFrameworkAttribute", "System.Reflection.AssemblyMetadataAttribute" });
         Approver.Verify(publicApi);
     }
 }

--- a/src/TestHelper/TestHelper.csproj
+++ b/src/TestHelper/TestHelper.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Oracle.ManagedDataAccess" Version="12.*" />
-    <PackageReference Include="MySql.Data" Version="6.*" ExcludeAssets="contentFiles" />
+    <PackageReference Include="MySql.Data" Version="8.*" ExcludeAssets="contentFiles" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- There is [a bug](https://bugs.mysql.com/bug.php?id=97448) in version 6 of the MySql.Data client library that throws an exception when the server has multiple IP addresses. This bug has been [fixed in version 8](https://github.com/mysql/mysql-connector-net/commit/938d174fe2405c8df16b13eab2419521a1d40ab3). As this is only used in the tests and we do not take a direct dependency on it, it is safe to upgrade it.
- The compiler is adding a new attribute (`System.Reflection.AssemblyMetadataAttribute`) that is getting picked up by the API approval tests. This is one that we [frequently filter out](https://github.com/search?q=org%3AParticular+AssemblyMetadataAttribute&type=code).