### PR TITLE
Container verify friendly storage context (release-6.2)

### DIFF
--- a/src/SqlPersistence/SynchronizedStorage/CurrentSessionHolder.cs
+++ b/src/SqlPersistence/SynchronizedStorage/CurrentSessionHolder.cs
@@ -4,7 +4,14 @@ using NServiceBus.Persistence.Sql;
 
 class CurrentSessionHolder
 {
-    public ISqlStorageSession Current => pipelineContext.Value.Session;
+    public ISqlStorageSession Current
+    {
+        get
+        {
+            var context = pipelineContext.Value;
+            return (ISqlStorageSession)context?.Session ?? NoSqlStorageSession.Instance;
+        }
+    }
 
     public void SetCurrentSession(StorageSession session)
     {

--- a/src/SqlPersistence/SynchronizedStorage/NoSqlStorageSession.cs
+++ b/src/SqlPersistence/SynchronizedStorage/NoSqlStorageSession.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Data.Common;
+using System.Threading.Tasks;
+using NServiceBus.Persistence.Sql;
+
+class NoSqlStorageSession : ISqlStorageSession
+{
+    public static readonly NoSqlStorageSession Instance = new NoSqlStorageSession();
+    public DbTransaction Transaction => throw new InvalidOperationException("ISqlStorageSession not available, no message context.");
+    public DbConnection Connection => throw new InvalidOperationException("ISqlStorageSession not available, no message context.");
+    public void OnSaveChanges(Func<ISqlStorageSession, Task> callback) => throw new InvalidOperationException("ISqlStorageSession not available, no message context.");
+}


### PR DESCRIPTION
Backport of https://github.com/Particular/NServiceBus.Persistence.Sql/pull/798/files

Currently container registration for storage context can throw an exception. This makes is container friendly and throw an invalid operation exception when accessing the properties of the storage session instead of a NullReferenceException during container creation.
