### PR TITLE
Backtrack obsoletion warning for script runner

### DIFF
--- a/src/SqlPersistence.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/SqlPersistence.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -29,9 +29,7 @@ namespace NServiceBus.Persistence.Sql
     }
     public class static ScriptRunner
     {
-        [System.ObsoleteAttribute(@"Timeout Manager is being deprecated. See upgrade guide for guidance on migrating to transport native delayed delivery. Use `Install(SqlDialect sqlDialect, string tablePrefix, Func<DbConnection> connectionBuilder, string scriptDirectory, bool shouldInstallOutbox, bool shouldInstallSagas, bool shouldInstallSubscriptions)` instead. Will be treated as an error from version 7.0.0. Will be removed in version 8.0.0.", false)]
         public static System.Threading.Tasks.Task Install(NServiceBus.SqlDialect sqlDialect, string tablePrefix, System.Func<System.Data.Common.DbConnection> connectionBuilder, string scriptDirectory, bool shouldInstallOutbox = True, bool shouldInstallSagas = True, bool shouldInstallSubscriptions = True, bool shouldInstallTimeouts = True) { }
-        [System.ObsoleteAttribute(@"Timeout Manager is being deprecated. See upgrade guide for guidance on migrating to transport native delayed delivery. Use `Install(SqlDialect sqlDialect, string tablePrefix, Func<Type, DbConnection> connectionBuilder, string scriptDirectory, bool shouldInstallOutbox, bool shouldInstallSagas, bool shouldInstallSubscriptions)` instead. Will be treated as an error from version 7.0.0. Will be removed in version 8.0.0.", false)]
         public static System.Threading.Tasks.Task Install(NServiceBus.SqlDialect sqlDialect, string tablePrefix, System.Func<System.Type, System.Data.Common.DbConnection> connectionBuilder, string scriptDirectory, bool shouldInstallOutbox = True, bool shouldInstallSagas = True, bool shouldInstallSubscriptions = True, bool shouldInstallTimeouts = True) { }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.All)]

--- a/src/SqlPersistence/ScriptRunner.cs
+++ b/src/SqlPersistence/ScriptRunner.cs
@@ -20,11 +20,6 @@
         /// <remarks>
         /// Designed to be used in a manual installation without the requirement of starting a full NServiceBus endpoint.
         /// </remarks>
-        [ObsoleteEx(
-            Message = "Timeout Manager is being deprecated. See upgrade guide for guidance on migrating to transport native delayed delivery.",
-            TreatAsErrorFromVersion = "7",
-            RemoveInVersion = "8",
-            ReplacementTypeOrMember = "Install(SqlDialect sqlDialect, string tablePrefix, Func<DbConnection> connectionBuilder, string scriptDirectory, bool shouldInstallOutbox, bool shouldInstallSagas, bool shouldInstallSubscriptions)")]
         public static Task Install(SqlDialect sqlDialect, string tablePrefix, Func<DbConnection> connectionBuilder, string scriptDirectory, bool shouldInstallOutbox = true, bool shouldInstallSagas = true, bool shouldInstallSubscriptions = true, bool shouldInstallTimeouts = true)
         {
             return Install(sqlDialect, tablePrefix, x => connectionBuilder(), scriptDirectory, shouldInstallOutbox, shouldInstallSagas, shouldInstallSubscriptions, shouldInstallTimeouts);
@@ -36,11 +31,6 @@
         /// <remarks>
         /// Designed to be used in a manual installation without the requirement of starting a full NServiceBus endpoint.
         /// </remarks>
-        [ObsoleteEx(
-            Message = "Timeout Manager is being deprecated. See upgrade guide for guidance on migrating to transport native delayed delivery.",
-            TreatAsErrorFromVersion = "7",
-            RemoveInVersion = "8",
-            ReplacementTypeOrMember = "Install(SqlDialect sqlDialect, string tablePrefix, Func<Type, DbConnection> connectionBuilder, string scriptDirectory, bool shouldInstallOutbox, bool shouldInstallSagas, bool shouldInstallSubscriptions)")]
         public static async Task Install(SqlDialect sqlDialect, string tablePrefix, Func<Type, DbConnection> connectionBuilder, string scriptDirectory, bool shouldInstallOutbox = true, bool shouldInstallSagas = true, bool shouldInstallSubscriptions = true, bool shouldInstallTimeouts = true)
         {
             Guard.AgainstNull(nameof(sqlDialect), sqlDialect);


### PR DESCRIPTION
In 6.4.0 we obsoleted an API on `ScriptRunner` with the intent to guide users away from using the optional parameter to generate timeout scripts (as the timeout manager is being removed). Unfortunately, we cannot obsolete a single parameter so this affected all users of the API, regardless of whether they were using the parameter or not.

We tried to fix this by [providing an overload that does not include the obsoleted parameter](https://github.com/Particular/NServiceBus.Persistence.Sql/pull/861) but the compiler cannot differentiate between these overloads if no parameters are provided.

For customers that were not providing the parameter explicitly, they will not notice that the parameter has been dropped in v7.

Customers that are providing the parameter explicitly are most likely setting it to `false` which is the behaviour in v7 without the parameter.