### PR TITLE
Disable saga analyzers

### DIFF
--- a/src/AcceptanceTestsShared/.editorconfig
+++ b/src/AcceptanceTestsShared/.editorconfig
@@ -8,3 +8,20 @@ dotnet_diagnostic.PS0018.severity = none  # A task-returning method should have 
 
 # Justification: Tests don't support cancellation and don't need to forward IMessageHandlerContext.CancellationToken
 dotnet_diagnostic.NSB0002.severity = none
+
+# Justification: No saga analyzers here
+dotnet_diagnostic.NSB0003.severity = none
+dotnet_diagnostic.NSB0004.severity = none
+dotnet_diagnostic.NSB0005.severity = none
+dotnet_diagnostic.NSB0006.severity = none
+dotnet_diagnostic.NSB0007.severity = none
+dotnet_diagnostic.NSB0008.severity = none
+dotnet_diagnostic.NSB0009.severity = none
+dotnet_diagnostic.NSB0010.severity = none
+dotnet_diagnostic.NSB0011.severity = none
+dotnet_diagnostic.NSB0012.severity = none
+dotnet_diagnostic.NSB0013.severity = none
+dotnet_diagnostic.NSB0014.severity = none
+dotnet_diagnostic.NSB0015.severity = none
+dotnet_diagnostic.NSB0016.severity = none
+dotnet_diagnostic.NSB0017.severity = none

--- a/src/MsSqlMicrosoftDataClientAcceptanceTests/.editorconfig
+++ b/src/MsSqlMicrosoftDataClientAcceptanceTests/.editorconfig
@@ -8,3 +8,20 @@ dotnet_diagnostic.PS0018.severity = none  # A task-returning method should have 
 
 # Justification: Tests don't support cancellation and don't need to forward IMessageHandlerContext.CancellationToken
 dotnet_diagnostic.NSB0002.severity = none
+
+# Justification: No saga analyzers here
+dotnet_diagnostic.NSB0003.severity = none
+dotnet_diagnostic.NSB0004.severity = none
+dotnet_diagnostic.NSB0005.severity = none
+dotnet_diagnostic.NSB0006.severity = none
+dotnet_diagnostic.NSB0007.severity = none
+dotnet_diagnostic.NSB0008.severity = none
+dotnet_diagnostic.NSB0009.severity = none
+dotnet_diagnostic.NSB0010.severity = none
+dotnet_diagnostic.NSB0011.severity = none
+dotnet_diagnostic.NSB0012.severity = none
+dotnet_diagnostic.NSB0013.severity = none
+dotnet_diagnostic.NSB0014.severity = none
+dotnet_diagnostic.NSB0015.severity = none
+dotnet_diagnostic.NSB0016.severity = none
+dotnet_diagnostic.NSB0017.severity = none

--- a/src/MsSqlMicrosoftDataClientSqlTransportAcceptanceTests/.editorconfig
+++ b/src/MsSqlMicrosoftDataClientSqlTransportAcceptanceTests/.editorconfig
@@ -8,3 +8,20 @@ dotnet_diagnostic.PS0018.severity = none  # A task-returning method should have 
 
 # Justification: Tests don't support cancellation and don't need to forward IMessageHandlerContext.CancellationToken
 dotnet_diagnostic.NSB0002.severity = none
+
+# Justification: No saga analyzers here
+dotnet_diagnostic.NSB0003.severity = none
+dotnet_diagnostic.NSB0004.severity = none
+dotnet_diagnostic.NSB0005.severity = none
+dotnet_diagnostic.NSB0006.severity = none
+dotnet_diagnostic.NSB0007.severity = none
+dotnet_diagnostic.NSB0008.severity = none
+dotnet_diagnostic.NSB0009.severity = none
+dotnet_diagnostic.NSB0010.severity = none
+dotnet_diagnostic.NSB0011.severity = none
+dotnet_diagnostic.NSB0012.severity = none
+dotnet_diagnostic.NSB0013.severity = none
+dotnet_diagnostic.NSB0014.severity = none
+dotnet_diagnostic.NSB0015.severity = none
+dotnet_diagnostic.NSB0016.severity = none
+dotnet_diagnostic.NSB0017.severity = none

--- a/src/MsSqlSystemDataClientAcceptanceTests/.editorconfig
+++ b/src/MsSqlSystemDataClientAcceptanceTests/.editorconfig
@@ -8,3 +8,20 @@ dotnet_diagnostic.PS0018.severity = suggestion  # A task-returning method should
 
 # Justification: Tests don't support cancellation and don't need to forward IMessageHandlerContext.CancellationToken
 dotnet_diagnostic.NSB0002.severity = suggestion
+
+# Justification: No saga analyzers here
+dotnet_diagnostic.NSB0003.severity = none
+dotnet_diagnostic.NSB0004.severity = none
+dotnet_diagnostic.NSB0005.severity = none
+dotnet_diagnostic.NSB0006.severity = none
+dotnet_diagnostic.NSB0007.severity = none
+dotnet_diagnostic.NSB0008.severity = none
+dotnet_diagnostic.NSB0009.severity = none
+dotnet_diagnostic.NSB0010.severity = none
+dotnet_diagnostic.NSB0011.severity = none
+dotnet_diagnostic.NSB0012.severity = none
+dotnet_diagnostic.NSB0013.severity = none
+dotnet_diagnostic.NSB0014.severity = none
+dotnet_diagnostic.NSB0015.severity = none
+dotnet_diagnostic.NSB0016.severity = none
+dotnet_diagnostic.NSB0017.severity = none

--- a/src/MsSqlSystemDataClientSqlTransportAcceptanceTests/.editorconfig
+++ b/src/MsSqlSystemDataClientSqlTransportAcceptanceTests/.editorconfig
@@ -8,3 +8,20 @@ dotnet_diagnostic.PS0018.severity = suggestion  # A task-returning method should
 
 # Justification: Tests don't support cancellation and don't need to forward IMessageHandlerContext.CancellationToken
 dotnet_diagnostic.NSB0002.severity = suggestion
+
+# Justification: No saga analyzers here
+dotnet_diagnostic.NSB0003.severity = none
+dotnet_diagnostic.NSB0004.severity = none
+dotnet_diagnostic.NSB0005.severity = none
+dotnet_diagnostic.NSB0006.severity = none
+dotnet_diagnostic.NSB0007.severity = none
+dotnet_diagnostic.NSB0008.severity = none
+dotnet_diagnostic.NSB0009.severity = none
+dotnet_diagnostic.NSB0010.severity = none
+dotnet_diagnostic.NSB0011.severity = none
+dotnet_diagnostic.NSB0012.severity = none
+dotnet_diagnostic.NSB0013.severity = none
+dotnet_diagnostic.NSB0014.severity = none
+dotnet_diagnostic.NSB0015.severity = none
+dotnet_diagnostic.NSB0016.severity = none
+dotnet_diagnostic.NSB0017.severity = none

--- a/src/MySqlAcceptanceTests/.editorconfig
+++ b/src/MySqlAcceptanceTests/.editorconfig
@@ -8,3 +8,20 @@ dotnet_diagnostic.PS0018.severity = suggestion  # A task-returning method should
 
 # Justification: Tests don't support cancellation and don't need to forward IMessageHandlerContext.CancellationToken
 dotnet_diagnostic.NSB0002.severity = suggestion
+
+# Justification: No saga analyzers here
+dotnet_diagnostic.NSB0003.severity = none
+dotnet_diagnostic.NSB0004.severity = none
+dotnet_diagnostic.NSB0005.severity = none
+dotnet_diagnostic.NSB0006.severity = none
+dotnet_diagnostic.NSB0007.severity = none
+dotnet_diagnostic.NSB0008.severity = none
+dotnet_diagnostic.NSB0009.severity = none
+dotnet_diagnostic.NSB0010.severity = none
+dotnet_diagnostic.NSB0011.severity = none
+dotnet_diagnostic.NSB0012.severity = none
+dotnet_diagnostic.NSB0013.severity = none
+dotnet_diagnostic.NSB0014.severity = none
+dotnet_diagnostic.NSB0015.severity = none
+dotnet_diagnostic.NSB0016.severity = none
+dotnet_diagnostic.NSB0017.severity = none

--- a/src/PostgreSqlAcceptanceTests/.editorconfig
+++ b/src/PostgreSqlAcceptanceTests/.editorconfig
@@ -2,3 +2,20 @@
 
 # Justification: Tests don't support cancellation and don't need to forward IMessageHandlerContext.CancellationToken
 dotnet_diagnostic.NSB0002.severity = suggestion
+
+# Justification: No saga analyzers here
+dotnet_diagnostic.NSB0003.severity = none
+dotnet_diagnostic.NSB0004.severity = none
+dotnet_diagnostic.NSB0005.severity = none
+dotnet_diagnostic.NSB0006.severity = none
+dotnet_diagnostic.NSB0007.severity = none
+dotnet_diagnostic.NSB0008.severity = none
+dotnet_diagnostic.NSB0009.severity = none
+dotnet_diagnostic.NSB0010.severity = none
+dotnet_diagnostic.NSB0011.severity = none
+dotnet_diagnostic.NSB0012.severity = none
+dotnet_diagnostic.NSB0013.severity = none
+dotnet_diagnostic.NSB0014.severity = none
+dotnet_diagnostic.NSB0015.severity = none
+dotnet_diagnostic.NSB0016.severity = none
+dotnet_diagnostic.NSB0017.severity = none

--- a/src/ScriptBuilder.Tests/.editorconfig
+++ b/src/ScriptBuilder.Tests/.editorconfig
@@ -2,3 +2,20 @@
 
 # Justification: Tests don't support cancellation and don't need to forward IMessageHandlerContext.CancellationToken
 dotnet_diagnostic.NSB0002.severity = suggestion
+
+# Justification: No saga analyzers here
+dotnet_diagnostic.NSB0003.severity = none
+dotnet_diagnostic.NSB0004.severity = none
+dotnet_diagnostic.NSB0005.severity = none
+dotnet_diagnostic.NSB0006.severity = none
+dotnet_diagnostic.NSB0007.severity = none
+dotnet_diagnostic.NSB0008.severity = none
+dotnet_diagnostic.NSB0009.severity = none
+dotnet_diagnostic.NSB0010.severity = none
+dotnet_diagnostic.NSB0011.severity = none
+dotnet_diagnostic.NSB0012.severity = none
+dotnet_diagnostic.NSB0013.severity = none
+dotnet_diagnostic.NSB0014.severity = none
+dotnet_diagnostic.NSB0015.severity = none
+dotnet_diagnostic.NSB0016.severity = none
+dotnet_diagnostic.NSB0017.severity = none

--- a/src/ScriptBuilderTask.Tests.Target/.editorconfig
+++ b/src/ScriptBuilderTask.Tests.Target/.editorconfig
@@ -1,8 +1,5 @@
 [*.cs]
 
-# Justification: Tests don't support cancellation and don't need to forward IMessageHandlerContext.CancellationToken
-dotnet_diagnostic.NSB0002.severity = suggestion
-
 # Justification: No saga analyzers here
 dotnet_diagnostic.NSB0003.severity = none
 dotnet_diagnostic.NSB0004.severity = none

--- a/src/SqlPersistence.Tests/.editorconfig
+++ b/src/SqlPersistence.Tests/.editorconfig
@@ -8,3 +8,20 @@ dotnet_diagnostic.PS0004.severity = none
 
 # Justification: Tests don't support cancellation and don't need to forward IMessageHandlerContext.CancellationToken
 dotnet_diagnostic.NSB0002.severity = suggestion
+
+# Justification: No saga analyzers here
+dotnet_diagnostic.NSB0003.severity = none
+dotnet_diagnostic.NSB0004.severity = none
+dotnet_diagnostic.NSB0005.severity = none
+dotnet_diagnostic.NSB0006.severity = none
+dotnet_diagnostic.NSB0007.severity = none
+dotnet_diagnostic.NSB0008.severity = none
+dotnet_diagnostic.NSB0009.severity = none
+dotnet_diagnostic.NSB0010.severity = none
+dotnet_diagnostic.NSB0011.severity = none
+dotnet_diagnostic.NSB0012.severity = none
+dotnet_diagnostic.NSB0013.severity = none
+dotnet_diagnostic.NSB0014.severity = none
+dotnet_diagnostic.NSB0015.severity = none
+dotnet_diagnostic.NSB0016.severity = none
+dotnet_diagnostic.NSB0017.severity = none


### PR DESCRIPTION
SQL Persistence tests a lot of weird saga stuff for generation. We can't "fix" these diagnostics, so we have to mute them.