### PR TITLE
Sagas script generation fix

### DIFF
--- a/src/OracleAcceptanceTests/OracleAcceptanceTests.csproj
+++ b/src/OracleAcceptanceTests/OracleAcceptanceTests.csproj
@@ -13,13 +13,17 @@
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="8.0.0-alpha.1900" />
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="8.0.0-alpha.1900" GeneratePathProperty="True" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
   </ItemGroup>
 
   <ItemGroup>
     <Compile Include="..\AcceptanceTestsShared\**\*.cs" Link="Shared\%(RecursiveDir)\%(Filename).%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup Label="Flaky tests on Oracle">
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\Sagas\When_handling_concurrent_messages.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/ScriptBuilder.Tests/ApprovalFiles/SagaDefinitionReaderTest.CorrelationIdInBaseClassRegularSaga.approved.txt
+++ b/src/ScriptBuilder.Tests/ApprovalFiles/SagaDefinitionReaderTest.CorrelationIdInBaseClassRegularSaga.approved.txt
@@ -1,0 +1,9 @@
+{
+  "TableSuffix": "TheTableSuffix",
+  "CorrelationProperty": {
+    "Type": "String",
+    "Name": "MyId"
+  },
+  "TransitionalCorrelationProperty": null,
+  "Name": "SagaDefinitionReaderTest/SagaWithDataBaseClass"
+}

--- a/src/ScriptBuilder.Tests/ApprovalFiles/SagaDefinitionReaderTest.CorrelationIdInBaseClassSqlSaga.approved.txt
+++ b/src/ScriptBuilder.Tests/ApprovalFiles/SagaDefinitionReaderTest.CorrelationIdInBaseClassSqlSaga.approved.txt
@@ -1,0 +1,9 @@
+{
+  "TableSuffix": "TheTableSuffix",
+  "CorrelationProperty": {
+    "Type": "String",
+    "Name": "MyId"
+  },
+  "TransitionalCorrelationProperty": null,
+  "Name": "SagaDefinitionReaderTest/SqlSagaWithDataBaseClass"
+}

--- a/src/ScriptBuilder.Tests/ApprovalFiles/SagaDefinitionReaderTest.CorrelationIdInTwoLevelsDeepBaseClassSqlSaga.approved.txt
+++ b/src/ScriptBuilder.Tests/ApprovalFiles/SagaDefinitionReaderTest.CorrelationIdInTwoLevelsDeepBaseClassSqlSaga.approved.txt
@@ -1,0 +1,9 @@
+{
+  "TableSuffix": "TheTableSuffix",
+  "CorrelationProperty": {
+    "Type": "String",
+    "Name": "MyId"
+  },
+  "TransitionalCorrelationProperty": null,
+  "Name": "SagaDefinitionReaderTest/SqlSagaWithTwoLevelsDeepDataBaseClass"
+}

--- a/src/ScriptBuilder/CecilExtensions.cs
+++ b/src/ScriptBuilder/CecilExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
@@ -7,6 +8,20 @@ using NServiceBus.Persistence.Sql;
 
 static class CecilExtensions
 {
+    public static T FindInTypeHierarchy<T>(this TypeDefinition type, Func<TypeDefinition, T> search)
+    {
+        var inspectingType = type;
+        T result = search(inspectingType);
+
+        while (result == null && inspectingType.BaseType != null && inspectingType.BaseType.FullName != "NServiceBus.ContainSagaData")
+        {
+            inspectingType = inspectingType.BaseType.Resolve();
+            result = search(inspectingType);
+        }
+
+        return result;
+    }
+
     public static string GetStringProperty(this ICustomAttribute attribute, string name)
     {
         return (string)attribute.Properties

--- a/src/ScriptBuilder/Saga/SagaDefinitionReader.cs
+++ b/src/ScriptBuilder/Saga/SagaDefinitionReader.cs
@@ -117,7 +117,8 @@ static class SagaDefinitionReader
             throw new ErrorsException("Unable to determine Saga correlation property because an unexpected method call was detected in the ConfigureHowToFindSaga method.");
         }
 
-        var correlationId = InstructionAnalyzer.GetCorrelationId(instructions, sagaDataType.FullName);
+        var correlationId = sagaDataType.FindInTypeHierarchy(t => InstructionAnalyzer.GetCorrelationId(instructions, t.FullName));
+
         return correlationId;
     }
 
@@ -205,7 +206,8 @@ For example: protected override string TableSuffix => ""TheCustomTableSuffix"";"
         {
             return null;
         }
-        var propertyDefinition = sagaDataTypeDefinition.Properties.SingleOrDefault(x => x.Name == propertyName);
+
+        var propertyDefinition = sagaDataTypeDefinition.FindInTypeHierarchy(t => t.Properties.SingleOrDefault(x => x.Name == propertyName));
 
         if (propertyDefinition == null)
         {


### PR DESCRIPTION
Prevents saga scripts generation from failing if correlation property is defined on a base class.