### PR TITLE
Saga scripts generation improvement - release-6.5

### DIFF
--- a/src/ScriptBuilder.Tests/ApprovalFiles/SagaDefinitionReaderTest.CorrelationIdInBaseClassRegularSaga.approved.txt
+++ b/src/ScriptBuilder.Tests/ApprovalFiles/SagaDefinitionReaderTest.CorrelationIdInBaseClassRegularSaga.approved.txt
@@ -1,0 +1,9 @@
+{
+  "TableSuffix": "TheTableSuffix",
+  "CorrelationProperty": {
+    "Type": "String",
+    "Name": "MyId"
+  },
+  "TransitionalCorrelationProperty": null,
+  "Name": "SagaDefinitionReaderTest/SagaWithDataBaseClass"
+}

--- a/src/ScriptBuilder.Tests/ApprovalFiles/SagaDefinitionReaderTest.CorrelationIdInBaseClassSqlSaga.approved.txt
+++ b/src/ScriptBuilder.Tests/ApprovalFiles/SagaDefinitionReaderTest.CorrelationIdInBaseClassSqlSaga.approved.txt
@@ -1,0 +1,9 @@
+{
+  "TableSuffix": "TheTableSuffix",
+  "CorrelationProperty": {
+    "Type": "String",
+    "Name": "MyId"
+  },
+  "TransitionalCorrelationProperty": null,
+  "Name": "SagaDefinitionReaderTest/SqlSagaWithDataBaseClass"
+}

--- a/src/ScriptBuilder.Tests/ApprovalFiles/SagaDefinitionReaderTest.CorrelationIdInTwoLevelsDeepBaseClassSqlSaga.approved.txt
+++ b/src/ScriptBuilder.Tests/ApprovalFiles/SagaDefinitionReaderTest.CorrelationIdInTwoLevelsDeepBaseClassSqlSaga.approved.txt
@@ -1,0 +1,9 @@
+{
+  "TableSuffix": "TheTableSuffix",
+  "CorrelationProperty": {
+    "Type": "String",
+    "Name": "MyId"
+  },
+  "TransitionalCorrelationProperty": null,
+  "Name": "SagaDefinitionReaderTest/SqlSagaWithTwoLevelsDeepDataBaseClass"
+}

--- a/src/ScriptBuilder/CecilExtensions.cs
+++ b/src/ScriptBuilder/CecilExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
@@ -7,6 +8,20 @@ using NServiceBus.Persistence.Sql;
 
 static class CecilExtensions
 {
+    public static T FindInTypeHierarchy<T>(this TypeDefinition type, Func<TypeDefinition, T> search)
+    {
+        var inspectingType = type;
+        T result = search(inspectingType);
+
+        while (result == null && inspectingType.BaseType != null && inspectingType.BaseType.FullName != "NServiceBus.ContainSagaData")
+        {
+            inspectingType = inspectingType.BaseType.Resolve();
+            result = search(inspectingType);
+        }
+
+        return result;
+    }
+
     public static string GetStringProperty(this ICustomAttribute attribute, string name)
     {
         return (string)attribute.Properties

--- a/src/ScriptBuilder/Saga/SagaDefinitionReader.cs
+++ b/src/ScriptBuilder/Saga/SagaDefinitionReader.cs
@@ -117,7 +117,8 @@ static class SagaDefinitionReader
             throw new ErrorsException("Unable to determine Saga correlation property because an unexpected method call was detected in the ConfigureHowToFindSaga method.");
         }
 
-        var correlationId = InstructionAnalyzer.GetCorrelationId(instructions, sagaDataType.FullName);
+        var correlationId = sagaDataType.FindInTypeHierarchy(t => InstructionAnalyzer.GetCorrelationId(instructions, t.FullName));
+
         return correlationId;
     }
 
@@ -205,7 +206,8 @@ For example: protected override string TableSuffix => ""TheCustomTableSuffix"";"
         {
             return null;
         }
-        var propertyDefinition = sagaDataTypeDefinition.Properties.SingleOrDefault(x => x.Name == propertyName);
+
+        var propertyDefinition = sagaDataTypeDefinition.FindInTypeHierarchy(t => t.Properties.SingleOrDefault(x => x.Name == propertyName));
 
         if (propertyDefinition == null)
         {


### PR DESCRIPTION
Prevents saga scripts generation from failing if correlation property is defined on a base class.