### PR TITLE
Add transaction timeout duration configuration for TransactionOptions in Outbox feature

### DIFF
--- a/src/SqlPersistence.PersistenceTests/PersistenceTestsConfiguration.cs
+++ b/src/SqlPersistence.PersistenceTests/PersistenceTestsConfiguration.cs
@@ -175,7 +175,7 @@
             ISqlOutboxTransaction transactionFactory()
             {
                 return transactionScopeMode
-                   ? new TransactionScopeSqlOutboxTransaction(concurrencyControlStrategy, connectionManager, IsolationLevel.ReadCommitted)
+                   ? new TransactionScopeSqlOutboxTransaction(concurrencyControlStrategy, connectionManager, IsolationLevel.ReadCommitted, TimeSpan.Zero)
                    : new AdoNetSqlOutboxTransaction(concurrencyControlStrategy, connectionManager, System.Data.IsolationLevel.ReadCommitted);
             }
 

--- a/src/SqlPersistence.Tests/Outbox/OutboxPersisterTests.cs
+++ b/src/SqlPersistence.Tests/Outbox/OutboxPersisterTests.cs
@@ -54,7 +54,7 @@ public abstract class OutboxPersisterTests
                 }
 
                 return transactionScope
-                    ? new TransactionScopeSqlOutboxTransaction(behavior, connectionManager, IsolationLevel.ReadCommitted)
+                    ? new TransactionScopeSqlOutboxTransaction(behavior, connectionManager, IsolationLevel.ReadCommitted, TimeSpan.Zero)
                     : new AdoNetSqlOutboxTransaction(behavior, connectionManager, System.Data.IsolationLevel.ReadCommitted);
             },
             cleanupBatchSize: 5);

--- a/src/SqlPersistence/Outbox/SqlOutboxFeature.cs
+++ b/src/SqlPersistence/Outbox/SqlOutboxFeature.cs
@@ -28,6 +28,7 @@ class SqlOutboxFeature : Feature
             adoTransactionIsolationLevel = System.Data.IsolationLevel.ReadCommitted;
         }
         var transactionScopeIsolationLevel = context.Settings.GetOrDefault<System.Transactions.IsolationLevel>(TransactionScopeIsolationLevel);
+        var transactionScopeTimeout = context.Settings.GetOrDefault<TimeSpan>(TransactionScopeTimeout);
 
         var outboxCommands = OutboxCommandBuilder.Build(sqlDialect, tablePrefix);
 
@@ -44,7 +45,7 @@ class SqlOutboxFeature : Feature
         ISqlOutboxTransaction transactionFactory()
         {
             return transactionScopeMode
-                ? (ISqlOutboxTransaction)new TransactionScopeSqlOutboxTransaction(concurrencyControlStrategy, connectionManager, transactionScopeIsolationLevel)
+                ? (ISqlOutboxTransaction)new TransactionScopeSqlOutboxTransaction(concurrencyControlStrategy, connectionManager, transactionScopeIsolationLevel, transactionScopeTimeout)
                 : new AdoNetSqlOutboxTransaction(concurrencyControlStrategy, connectionManager, adoTransactionIsolationLevel);
         }
 
@@ -87,4 +88,5 @@ class SqlOutboxFeature : Feature
     internal const string UseTransactionScope = "Persistence.Sql.Outbox.TransactionScopeMode";
     internal const string AdoTransactionIsolationLevel = "Persistence.Sql.Outbox.AdoTransactionIsolationLevel";
     internal const string TransactionScopeIsolationLevel = "Persistence.Sql.Outbox.TransactionScopeIsolationLevel";
+    internal const string TransactionScopeTimeout = "Persistence.Sql.Outbox.TransactionScopeTimeout";
 }

--- a/src/SqlPersistence/Outbox/SqlPersistenceOutboxSettingsExtensions.cs
+++ b/src/SqlPersistence/Outbox/SqlPersistenceOutboxSettingsExtensions.cs
@@ -118,6 +118,10 @@
         /// <param name="timeout">timeout period for the transaction.</param>
         public static void UseTransactionScope(this OutboxSettings outboxSettings, IsolationLevel isolationLevel, TimeSpan timeout)
         {
+            if (timeout > TransactionManager.MaximumTimeout)
+            {
+                throw new Exception("Timeout requested is longer than the maximum value for this machine. Override using the maxTimeout setting of the system.transactions section in machine.config");
+            }
             outboxSettings.UseTransactionScope(isolationLevel);
             outboxSettings.GetSettings().Set(SqlOutboxFeature.TransactionScopeTimeout, timeout);
         }

--- a/src/SqlPersistence/Outbox/SqlPersistenceOutboxSettingsExtensions.cs
+++ b/src/SqlPersistence/Outbox/SqlPersistenceOutboxSettingsExtensions.cs
@@ -107,5 +107,19 @@
             outboxSettings.GetSettings().Set(SqlOutboxFeature.UseTransactionScope, true);
             outboxSettings.GetSettings().Set(SqlOutboxFeature.TransactionScopeIsolationLevel, isolationLevel);
         }
+
+        /// <summary>
+        /// Configures the outbox to use TransactionScope instead of SqlTransaction. This allows wrapping the
+        /// the outbox transaction (and synchronized storage session it manages) and other database transactions in a single scope - provided that
+        /// Distributed Transaction Coordinator (DTC) infrastructure is configured.
+        /// </summary>
+        /// <param name="outboxSettings">Outbox settings.</param>
+        /// <param name="isolationLevel">Isolation level to use. Only levels Read Committed, Repeatable Read and Serializable are supported.</param>
+        /// <param name="timeout">timeout period for the transaction.</param>
+        public static void UseTransactionScope(this OutboxSettings outboxSettings, IsolationLevel isolationLevel, TimeSpan timeout)
+        {
+            outboxSettings.UseTransactionScope(isolationLevel);
+            outboxSettings.GetSettings().Set(SqlOutboxFeature.TransactionScopeTimeout, timeout);
+        }
     }
 }

--- a/src/SqlPersistence/Outbox/TransactionScopeSqlOutboxTransaction.cs
+++ b/src/SqlPersistence/Outbox/TransactionScopeSqlOutboxTransaction.cs
@@ -20,7 +20,7 @@ class TransactionScopeSqlOutboxTransaction : ISqlOutboxTransaction
     TimeSpan transactionTimeout;
 
     public TransactionScopeSqlOutboxTransaction(ConcurrencyControlStrategy concurrencyControlStrategy,
-        IConnectionManager connectionManager, IsolationLevel isolationLevel, TimeSpan transactionTimeout = default)
+        IConnectionManager connectionManager, IsolationLevel isolationLevel, TimeSpan transactionTimeout)
     {
         this.connectionManager = connectionManager;
         this.isolationLevel = isolationLevel;
@@ -37,7 +37,7 @@ class TransactionScopeSqlOutboxTransaction : ISqlOutboxTransaction
         var options = new TransactionOptions
         {
             IsolationLevel = isolationLevel,
-            Timeout = transactionTimeout; // TimeSpan.Zero is default of `TransactionOptions.Timeout`
+            Timeout = transactionTimeout // TimeSpan.Zero is default of `TransactionOptions.Timeout`
         };
 
         transactionScope = new TransactionScope(TransactionScopeOption.RequiresNew, options, TransactionScopeAsyncFlowOption.Enabled);

--- a/src/SqlPersistence/Outbox/TransactionScopeSqlOutboxTransaction.cs
+++ b/src/SqlPersistence/Outbox/TransactionScopeSqlOutboxTransaction.cs
@@ -37,7 +37,7 @@ class TransactionScopeSqlOutboxTransaction : ISqlOutboxTransaction
         var options = new TransactionOptions
         {
             IsolationLevel = isolationLevel,
-            Timeout = transactionTimeout
+            Timeout = transactionTimeout; // TimeSpan.Zero is default of `TransactionOptions.Timeout`
         };
 
         transactionScope = new TransactionScope(TransactionScopeOption.RequiresNew, options, TransactionScopeAsyncFlowOption.Enabled);

--- a/src/SqlPersistence/Outbox/TransactionScopeSqlOutboxTransaction.cs
+++ b/src/SqlPersistence/Outbox/TransactionScopeSqlOutboxTransaction.cs
@@ -1,4 +1,5 @@
-﻿using System.Data.Common;
+﻿using System;
+using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Transactions;
@@ -16,13 +17,15 @@ class TransactionScopeSqlOutboxTransaction : ISqlOutboxTransaction
     TransactionScope transactionScope;
     Transaction ambientTransaction;
     bool commit;
+    TimeSpan transactionTimeout;
 
     public TransactionScopeSqlOutboxTransaction(ConcurrencyControlStrategy concurrencyControlStrategy,
-        IConnectionManager connectionManager, IsolationLevel isolationLevel)
+        IConnectionManager connectionManager, IsolationLevel isolationLevel, TimeSpan transactionTimeout = default)
     {
         this.connectionManager = connectionManager;
         this.isolationLevel = isolationLevel;
         this.concurrencyControlStrategy = concurrencyControlStrategy;
+        this.transactionTimeout = transactionTimeout;
     }
 
     public DbTransaction Transaction => null;
@@ -33,7 +36,8 @@ class TransactionScopeSqlOutboxTransaction : ISqlOutboxTransaction
     {
         var options = new TransactionOptions
         {
-            IsolationLevel = isolationLevel
+            IsolationLevel = isolationLevel,
+            Timeout = transactionTimeout
         };
 
         transactionScope = new TransactionScope(TransactionScopeOption.RequiresNew, options, TransactionScopeAsyncFlowOption.Enabled);


### PR DESCRIPTION
Added timeout configuration for TransactionScope in SqlOutboxFeature.
Would resolve issue #654

Currently outbox transaction scope always uses `System.Transactions.Configuration.DefaultTimeout` (1 minute) under .net core.