### PR TITLE
Replace connection factory on the test variant

### DIFF
--- a/src/SqlPersistence.PersistenceTests/PersistenceTestsConfiguration.cs
+++ b/src/SqlPersistence.PersistenceTests/PersistenceTestsConfiguration.cs
@@ -52,22 +52,22 @@
 
             if (!string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("SQLServerConnectionString")))
             {
-                variants.Add(CreateVariant(new SqlDialect.MsSqlServer(), BuildSqlDialect.MsSqlServer, MsSqlMicrosoftDataClientConnectionBuilder.Build));
+                variants.Add(CreateVariant(new SqlDialect.MsSqlServer(), BuildSqlDialect.MsSqlServer));
             }
 
             if (!string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("PostgreSqlConnectionString")))
             {
-                variants.Add(CreateVariant(postgreSql, BuildSqlDialect.PostgreSql, PostgreSqlConnectionBuilder.Build));
+                variants.Add(CreateVariant(postgreSql, BuildSqlDialect.PostgreSql));
             }
 
             if (!string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("MySQLConnectionString")))
             {
-                variants.Add(CreateVariant(new SqlDialect.MySql(), BuildSqlDialect.MySql, MySqlConnectionBuilder.Build));
+                variants.Add(CreateVariant(new SqlDialect.MySql(), BuildSqlDialect.MySql));
             }
 
             if (!string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("OracleConnectionString")))
             {
-                variants.Add(CreateVariant(new SqlDialect.Oracle(), BuildSqlDialect.Oracle, OracleConnectionBuilder.Build));
+                variants.Add(CreateVariant(new SqlDialect.Oracle(), BuildSqlDialect.Oracle));
             }
 
             SagaVariants = variants.ToArray();

--- a/src/SqlPersistence.PersistenceTests/SqlTestVariant.cs
+++ b/src/SqlPersistence.PersistenceTests/SqlTestVariant.cs
@@ -1,27 +1,20 @@
 ﻿namespace NServiceBus.PersistenceTesting
 {
-    using System;
-    using System.Data.Common;
     using Persistence.Sql.ScriptBuilder;
 
     class SqlTestVariant
     {
-        public SqlTestVariant(SqlDialect dialect, BuildSqlDialect buildDialect, Func<DbConnection> connectionFactory, bool usePessimisticMode)
+        public SqlTestVariant(SqlDialect dialect, BuildSqlDialect buildDialect, bool usePessimisticMode)
         {
             Dialect = dialect;
             BuildDialect = buildDialect;
-            ConnectionFactory = connectionFactory;
             UsePessimisticMode = usePessimisticMode;
         }
 
         public SqlDialect Dialect { get; }
         public BuildSqlDialect BuildDialect { get; }
-        public Func<DbConnection> ConnectionFactory { get; }
         public bool UsePessimisticMode { get; set; }
 
-        public override string ToString()
-        {
-            return $"{Dialect.GetType().Name}-pessimistic={UsePessimisticMode}";
-        }
+        public override string ToString() => $"{Dialect.GetType().Name}-pessimistic={UsePessimisticMode}";
     }
 }

--- a/src/SqlPersistence.PersistenceTests/SqlTestVariantExtensions.cs
+++ b/src/SqlPersistence.PersistenceTests/SqlTestVariantExtensions.cs
@@ -14,7 +14,7 @@ namespace NServiceBus.PersistenceTesting
                 BuildSqlDialect.Oracle => OracleConnectionBuilder.Build(),
                 BuildSqlDialect.PostgreSql => PostgreSqlConnectionBuilder.Build(),
                 _ => throw new ArgumentOutOfRangeException(
-                    $"BuildSQL dialect '{variant.BuildDialect}' is not supported yet as a test variant.")
+                    $"{nameof(SqlTestVariant.BuildDialect)} '{variant.BuildDialect}' is not supported yet as a test variant.")
             };
     }
 }

--- a/src/SqlPersistence.PersistenceTests/SqlTestVariantExtensions.cs
+++ b/src/SqlPersistence.PersistenceTests/SqlTestVariantExtensions.cs
@@ -1,0 +1,20 @@
+namespace NServiceBus.PersistenceTesting
+{
+    using System;
+    using System.Data.Common;
+    using Persistence.Sql.ScriptBuilder;
+
+    static class SqlTestVariantExtensions
+    {
+        public static DbConnection Open(this SqlTestVariant variant) =>
+            variant.BuildDialect switch
+            {
+                BuildSqlDialect.MsSqlServer => MsSqlMicrosoftDataClientConnectionBuilder.Build(),
+                BuildSqlDialect.MySql => MySqlConnectionBuilder.Build(),
+                BuildSqlDialect.Oracle => OracleConnectionBuilder.Build(),
+                BuildSqlDialect.PostgreSql => PostgreSqlConnectionBuilder.Build(),
+                _ => throw new ArgumentOutOfRangeException(
+                    $"BuildSQL dialect '{variant.BuildDialect}' is not supported yet as a test variant.")
+            };
+    }
+}


### PR DESCRIPTION
Due to the static nature of how test case variants are managed in NUnit core does [deep copy the test variants](https://github.com/Particular/NServiceBus/pull/6303#issuecomment-1098231727).

The deep copy mechanism does skip function delegates by returning null. [While it is possible to deep copy delegates as well as their related closures too](https://github.com/Particular/NServiceBus/pull/6303#issuecomment-1098511418), this approach here is far less risky and easier to reason about.