### PR TITLE
Revert "Bump OctopusDeploy/push-package-action from 1.1.1 to 1.1.2"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,7 @@ jobs:
           path: octopus-package/*
           retention-days: 1
       - name: Push package to Octopus Deploy
-        uses: OctopusDeploy/push-package-action@v1.1.2
+        uses: OctopusDeploy/push-package-action@v1.1.1
         with:
           server: https://deploy.particular.net
           api_key: ${{ secrets.OCTOPUS_DEPLOY_API_KEY }}


### PR DESCRIPTION
Reverts Particular/NServiceBus.Persistence.Sql#911

I saw that master was failing on Windows Oracle since this one was merged. Trying a revert