### PR TITLE
Align feature dependency with other persisters

### DIFF
--- a/src/SqlPersistence/Outbox/SqlOutboxFeature.cs
+++ b/src/SqlPersistence/Outbox/SqlOutboxFeature.cs
@@ -8,7 +8,12 @@ class SqlOutboxFeature : Feature
 {
     SqlOutboxFeature()
     {
+        Defaults(s =>
+        {
+            s.EnableFeatureByDefault<SqlStorageSessionFeature>();
+        });
         DependsOn<Outbox>();
+        DependsOn<SqlStorageSessionFeature>();
     }
 
     protected override void Setup(FeatureConfigurationContext context)

--- a/src/SqlPersistence/Saga/SqlSagaFeature.cs
+++ b/src/SqlPersistence/Saga/SqlSagaFeature.cs
@@ -6,7 +6,13 @@ class SqlSagaFeature : Feature
 {
     SqlSagaFeature()
     {
+        Defaults(s =>
+        {
+            s.EnableFeatureByDefault<SqlStorageSessionFeature>();
+            s.AddUnrecoverableException(typeof(SerializationException));
+        });
         DependsOn<Sagas>();
+        DependsOn<SqlStorageSessionFeature>();
     }
 
     protected override void Setup(FeatureConfigurationContext context)

--- a/src/SqlPersistence/Saga/SqlSagaFeature.cs
+++ b/src/SqlPersistence/Saga/SqlSagaFeature.cs
@@ -1,6 +1,11 @@
-﻿using NServiceBus;
+﻿using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
+using NServiceBus;
 using NServiceBus.Features;
 using NServiceBus.Persistence.Sql;
+using NServiceBus.Sagas;
+using NServiceBus.Settings;
+using SagaSettings = NServiceBus.Persistence.Sql.SagaSettings;
 
 class SqlSagaFeature : Feature
 {
@@ -19,6 +24,12 @@ class SqlSagaFeature : Feature
     {
         var settings = context.Settings;
 
+        var sqlDialect = settings.GetSqlDialect();
+        var services = context.Services;
+
+        services.AddSingleton(BuildSagaInfoCache(sqlDialect, settings));
+        services.AddSingleton<ISagaPersister>(provider => new SagaPersister(provider.GetRequiredService<SagaInfoCache>(), sqlDialect));
+
         var customJsonSettings = SagaSettings.GetJsonSerializerSettings(settings);
         var versionSpecificJsonSettings = SagaSettings.GetVersionSettings(settings);
         var customSagaWriter = SagaSettings.GetWriterCreator(settings);
@@ -31,5 +42,47 @@ class SqlSagaFeature : Feature
             CustomSagaWriter = customSagaWriter != null,
             CustomSagaReader = customSagaReader != null
         });
+    }
+
+    static SagaInfoCache BuildSagaInfoCache(SqlDialect sqlDialect, IReadOnlySettings settings)
+    {
+        var jsonSerializerSettings = SagaSettings.GetJsonSerializerSettings(settings);
+        var jsonSerializer = BuildJsonSerializer(jsonSerializerSettings);
+        sqlDialect.ValidateJsonSettings(jsonSerializer);
+        var readerCreator = SagaSettings.GetReaderCreator(settings);
+        if (readerCreator == null)
+        {
+            readerCreator = reader => new JsonTextReader(reader);
+        }
+        var writerCreator = SagaSettings.GetWriterCreator(settings);
+        if (writerCreator == null)
+        {
+            writerCreator = writer => new JsonTextWriter(writer);
+        }
+        var nameFilter = SagaSettings.GetNameFilter(settings);
+        if (nameFilter == null)
+        {
+            nameFilter = sagaName => sagaName;
+        }
+        var versionDeserializeBuilder = SagaSettings.GetVersionSettings(settings);
+        var tablePrefix = settings.GetTablePrefix();
+        return new SagaInfoCache(
+            versionSpecificSettings: versionDeserializeBuilder,
+            jsonSerializer: jsonSerializer,
+            readerCreator: readerCreator,
+            writerCreator: writerCreator,
+            tablePrefix: tablePrefix,
+            sqlDialect: sqlDialect,
+            metadataCollection: settings.Get<SagaMetadataCollection>(),
+            name => nameFilter(name));
+    }
+
+    static JsonSerializer BuildJsonSerializer(JsonSerializerSettings jsonSerializerSettings)
+    {
+        if (jsonSerializerSettings == null)
+        {
+            return Serializer.JsonSerializer;
+        }
+        return JsonSerializer.Create(jsonSerializerSettings);
     }
 }

--- a/src/SqlPersistence/SqlPersistence.cs
+++ b/src/SqlPersistence/SqlPersistence.cs
@@ -2,8 +2,6 @@
 {
     using Features;
     using Persistence;
-    using Persistence.Sql;
-    using Settings;
 
     /// <summary>
     /// The <see cref="PersistenceDefinition"/> for the SQL Persistence.
@@ -15,21 +13,6 @@
         /// </summary>
         public SqlPersistence()
         {
-            Supports<StorageType.Outbox>(s =>
-            {
-                EnableSession(s);
-                s.EnableFeatureByDefault<SqlOutboxFeature>();
-            });
-            Supports<StorageType.Sagas>(s =>
-            {
-                EnableSession(s);
-                s.EnableFeatureByDefault<SqlSagaFeature>();
-                s.AddUnrecoverableException(typeof(SerializationException));
-            });
-            Supports<StorageType.Subscriptions>(s =>
-            {
-                s.EnableFeatureByDefault<SqlSubscriptionFeature>();
-            });
             Defaults(s =>
             {
                 var defaultsAppliedSettingsKey = "NServiceBus.Persistence.Sql.DefaultsApplied";
@@ -52,11 +35,10 @@
 
                 s.Set(defaultsAppliedSettingsKey, true);
             });
-        }
 
-        static void EnableSession(SettingsHolder s)
-        {
-            s.EnableFeatureByDefault<StorageSessionFeature>();
+            Supports<StorageType.Outbox>(s => s.EnableFeatureByDefault<SqlOutboxFeature>());
+            Supports<StorageType.Sagas>(s => s.EnableFeatureByDefault<SqlSagaFeature>());
+            Supports<StorageType.Subscriptions>(s => s.EnableFeatureByDefault<SqlSubscriptionFeature>());
         }
     }
 }

--- a/src/SqlPersistence/SqlValidateStorageTypeCombinationFeature.cs
+++ b/src/SqlPersistence/SqlValidateStorageTypeCombinationFeature.cs
@@ -1,0 +1,37 @@
+using System;
+using NServiceBus.Features;
+using NServiceBus.Settings;
+
+sealed class SqlValidateStorageTypeCombinationFeature : Feature
+{
+    public SqlValidateStorageTypeCombinationFeature()
+    {
+        EnableByDefault();
+        DependsOnAtLeastOne(typeof(SqlOutboxFeature), typeof(SqlSagaFeature));
+    }
+
+    protected override void Setup(FeatureConfigurationContext context)
+    {
+        var settings = context.Settings;
+        ValidateSagaOutboxCombo(settings);
+    }
+
+    // This check should normally be handled by Core but unfortunately there is a bug that prevents the check from executing
+    // https://github.com/Particular/NServiceBus/issues/6378
+    static void ValidateSagaOutboxCombo(IReadOnlySettings settings)
+    {
+        var isOutboxEnabled = settings.IsFeatureActive(typeof(Outbox));
+        var isSagasEnabled = settings.IsFeatureActive(typeof(Sagas));
+        if (!isOutboxEnabled || !isSagasEnabled)
+        {
+            return;
+        }
+        var isSagasEnabledForSqlPersistence = settings.IsFeatureActive(typeof(SqlSagaFeature));
+        var isOutboxEnabledForSqlPersistence = settings.IsFeatureActive(typeof(SqlOutboxFeature));
+        if (isSagasEnabledForSqlPersistence && isOutboxEnabledForSqlPersistence)
+        {
+            return;
+        }
+        throw new Exception("Sql Persistence must be enabled for either both Sagas and Outbox, or neither.");
+    }
+}

--- a/src/SqlPersistence/SqlValidateStorageTypeCombinationFeature.cs
+++ b/src/SqlPersistence/SqlValidateStorageTypeCombinationFeature.cs
@@ -7,7 +7,8 @@ sealed class SqlValidateStorageTypeCombinationFeature : Feature
     public SqlValidateStorageTypeCombinationFeature()
     {
         EnableByDefault();
-        DependsOnAtLeastOne(typeof(SqlOutboxFeature), typeof(SqlSagaFeature));
+        DependsOnOptionally<SqlOutboxFeature>();
+        DependsOnOptionally<SqlSagaFeature>();
     }
 
     protected override void Setup(FeatureConfigurationContext context)

--- a/src/SqlPersistence/SynchronizedStorage/SqlStorageSessionFeature.cs
+++ b/src/SqlPersistence/SynchronizedStorage/SqlStorageSessionFeature.cs
@@ -26,6 +26,8 @@ class SqlStorageSessionFeature : Feature
         context.Pipeline.Register(new CurrentSessionBehavior(sessionHolder), "Manages the lifecycle of the current session holder.");
     }
 
+    // This check should normally be handled by Core but unfortunately there is a bug that prevents the check from executing
+    // https://github.com/Particular/NServiceBus/issues/6378
     static void ValidateSagaOutboxCombo(IReadOnlySettings settings)
     {
         var isOutboxEnabled = settings.IsFeatureActive(typeof(Outbox));

--- a/src/SqlPersistence/SynchronizedStorage/SqlStorageSessionFeature.cs
+++ b/src/SqlPersistence/SynchronizedStorage/SqlStorageSessionFeature.cs
@@ -1,13 +1,9 @@
 ﻿using System;
 using Microsoft.Extensions.DependencyInjection;
-using Newtonsoft.Json;
 using NServiceBus;
 using NServiceBus.Features;
 using NServiceBus.Persistence;
-using NServiceBus.Sagas;
 using NServiceBus.Settings;
-using JsonSerializer = Newtonsoft.Json.JsonSerializer;
-using SagaSettings = NServiceBus.Persistence.Sql.SagaSettings;
 
 class SqlStorageSessionFeature : Feature
 {
@@ -20,28 +16,14 @@ class SqlStorageSessionFeature : Feature
         var services = context.Services;
         var connectionManager = settings.GetConnectionBuilder<StorageType.Sagas>();
 
-        var sqlSagaPersistenceActivated = settings.IsFeatureActive(typeof(SqlSagaFeature));
-
-        SagaInfoCache infoCache = null;
-        if (sqlSagaPersistenceActivated)
-        {
-            infoCache = BuildSagaInfoCache(sqlDialect, settings);
-        }
-
         var sessionHolder = new CurrentSessionHolder();
 
         //Info cache can be null if Outbox is enabled but Sagas are disabled.
-        services.AddSingleton<ISynchronizedStorage>(new SynchronizedStorage(connectionManager, infoCache, sessionHolder));
-        services.AddSingleton<ISynchronizedStorageAdapter>(new StorageAdapter(connectionManager, infoCache, sqlDialect, sessionHolder));
+        services.AddSingleton<ISynchronizedStorage>(provider => new SynchronizedStorage(connectionManager, provider.GetService<SagaInfoCache>(), sessionHolder));
+        services.AddSingleton<ISynchronizedStorageAdapter>(provider => new StorageAdapter(connectionManager, provider.GetService<SagaInfoCache>(), sqlDialect, sessionHolder));
 
         services.AddTransient(_ => sessionHolder.Current);
         context.Pipeline.Register(new CurrentSessionBehavior(sessionHolder), "Manages the lifecycle of the current session holder.");
-
-        if (sqlSagaPersistenceActivated)
-        {
-            var sagaPersister = new SagaPersister(infoCache, sqlDialect);
-            services.AddSingleton<ISagaPersister>(sagaPersister);
-        }
     }
 
     static void ValidateSagaOutboxCombo(IReadOnlySettings settings)
@@ -59,47 +41,5 @@ class SqlStorageSessionFeature : Feature
             return;
         }
         throw new Exception("Sql Persistence must be enabled for either both Sagas and Outbox, or neither.");
-    }
-
-    static SagaInfoCache BuildSagaInfoCache(SqlDialect sqlDialect, IReadOnlySettings settings)
-    {
-        var jsonSerializerSettings = SagaSettings.GetJsonSerializerSettings(settings);
-        var jsonSerializer = BuildJsonSerializer(jsonSerializerSettings);
-        sqlDialect.ValidateJsonSettings(jsonSerializer);
-        var readerCreator = SagaSettings.GetReaderCreator(settings);
-        if (readerCreator == null)
-        {
-            readerCreator = reader => new JsonTextReader(reader);
-        }
-        var writerCreator = SagaSettings.GetWriterCreator(settings);
-        if (writerCreator == null)
-        {
-            writerCreator = writer => new JsonTextWriter(writer);
-        }
-        var nameFilter = SagaSettings.GetNameFilter(settings);
-        if (nameFilter == null)
-        {
-            nameFilter = sagaName => sagaName;
-        }
-        var versionDeserializeBuilder = SagaSettings.GetVersionSettings(settings);
-        var tablePrefix = settings.GetTablePrefix();
-        return new SagaInfoCache(
-            versionSpecificSettings: versionDeserializeBuilder,
-            jsonSerializer: jsonSerializer,
-            readerCreator: readerCreator,
-            writerCreator: writerCreator,
-            tablePrefix: tablePrefix,
-            sqlDialect: sqlDialect,
-            metadataCollection: settings.Get<SagaMetadataCollection>(),
-            name => nameFilter(name));
-    }
-
-    static JsonSerializer BuildJsonSerializer(JsonSerializerSettings jsonSerializerSettings)
-    {
-        if (jsonSerializerSettings == null)
-        {
-            return Serializer.JsonSerializer;
-        }
-        return JsonSerializer.Create(jsonSerializerSettings);
     }
 }

--- a/src/SqlPersistence/SynchronizedStorage/SqlStorageSessionFeature.cs
+++ b/src/SqlPersistence/SynchronizedStorage/SqlStorageSessionFeature.cs
@@ -9,7 +9,7 @@ using NServiceBus.Settings;
 using JsonSerializer = Newtonsoft.Json.JsonSerializer;
 using SagaSettings = NServiceBus.Persistence.Sql.SagaSettings;
 
-class StorageSessionFeature : Feature
+class SqlStorageSessionFeature : Feature
 {
     protected override void Setup(FeatureConfigurationContext context)
     {

--- a/src/SqlPersistence/SynchronizedStorage/SqlStorageSessionFeature.cs
+++ b/src/SqlPersistence/SynchronizedStorage/SqlStorageSessionFeature.cs
@@ -1,17 +1,13 @@
-﻿using System;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using NServiceBus;
 using NServiceBus.Features;
 using NServiceBus.Persistence;
-using NServiceBus.Settings;
 
 class SqlStorageSessionFeature : Feature
 {
     protected override void Setup(FeatureConfigurationContext context)
     {
         var settings = context.Settings;
-        ValidateSagaOutboxCombo(settings);
-
         var sqlDialect = settings.GetSqlDialect();
         var services = context.Services;
         var connectionManager = settings.GetConnectionBuilder<StorageType.Sagas>();
@@ -24,24 +20,5 @@ class SqlStorageSessionFeature : Feature
 
         services.AddTransient(_ => sessionHolder.Current);
         context.Pipeline.Register(new CurrentSessionBehavior(sessionHolder), "Manages the lifecycle of the current session holder.");
-    }
-
-    // This check should normally be handled by Core but unfortunately there is a bug that prevents the check from executing
-    // https://github.com/Particular/NServiceBus/issues/6378
-    static void ValidateSagaOutboxCombo(IReadOnlySettings settings)
-    {
-        var isOutboxEnabled = settings.IsFeatureActive(typeof(Outbox));
-        var isSagasEnabled = settings.IsFeatureActive(typeof(Sagas));
-        if (!isOutboxEnabled || !isSagasEnabled)
-        {
-            return;
-        }
-        var isSagasEnabledForSqlPersistence = settings.IsFeatureActive(typeof(SqlSagaFeature));
-        var isOutboxEnabledForSqlPersistence = settings.IsFeatureActive(typeof(SqlOutboxFeature));
-        if (isSagasEnabledForSqlPersistence && isOutboxEnabledForSqlPersistence)
-        {
-            return;
-        }
-        throw new Exception("Sql Persistence must be enabled for either both Sagas and Outbox, or neither.");
     }
 }


### PR DESCRIPTION
This PR aligns the feature dependencies with other persisters and moves the saga/outbox persistence check to a feature that depends on the SqlOutbox and the SqlSaga features