### PR TITLE
Update release to use Windows for building

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ env:
   DOTNET_NOLOGO: true
 jobs:
   release:
-    runs-on: ubuntu-20.04
+    runs-on: windows-2019
     steps:
       - name: Checkout
         uses: actions/checkout@v3.0.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ env:
   DOTNET_NOLOGO: true
 jobs:
   release:
-    runs-on: windows-2019
+    runs-on: windows-2019 # Windows required for ILMerge to work in ScriptBuilderTask
     steps:
       - name: Checkout
         uses: actions/checkout@v3.0.2


### PR DESCRIPTION
Using Windows will allow the IL Merge to work on when building ScriptBuilderTask 