### PR TITLE
Fix packaging problem

### DIFF
--- a/src/NServiceBus.Persistence.Sql.sln
+++ b/src/NServiceBus.Persistence.Sql.sln
@@ -4,9 +4,6 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 VisualStudioVersion = 17.1.32328.378
 MinimumVisualStudioVersion = 15.0.26403.0
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SqlPersistence", "SqlPersistence\SqlPersistence.csproj", "{E3CF4CB1-9F87-4F81-B6B0-B599035C1BCE}"
-	ProjectSection(ProjectDependencies) = postProject
-		{63784399-65AF-424A-B2AD-0C94AE326823} = {63784399-65AF-424A-B2AD-0C94AE326823}
-	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SqlPersistence.Tests", "SqlPersistence.Tests\SqlPersistence.Tests.csproj", "{5FE6F59E-67B8-4B84-8365-67CDFF4145AE}"
 EndProject
@@ -47,15 +44,15 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MsSqlMicrosoftDataClientSql
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MsSqlMicrosoftDataClientAcceptanceTests", "MsSqlMicrosoftDataClientAcceptanceTests\MsSqlMicrosoftDataClientAcceptanceTests.csproj", "{7C16BE00-7198-4B6C-A094-C0B62A539F77}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NServiceBus.Persistence.Sql.CommandLine", "CommandLine\NServiceBus.Persistence.Sql.CommandLine.csproj", "{DC682A5A-3ECD-4FB1-826E-A2BD988F40E3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NServiceBus.Persistence.Sql.CommandLine", "CommandLine\NServiceBus.Persistence.Sql.CommandLine.csproj", "{DC682A5A-3ECD-4FB1-826E-A2BD988F40E3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NServiceBus.Persistence.Sql.TransactionalSession", "NServiceBus.Persistence.Sql.TransactionalSession\NServiceBus.Persistence.Sql.TransactionalSession.csproj", "{67DC5C83-52A4-4C53-8948-A223DE05FF1E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NServiceBus.Persistence.Sql.TransactionalSession", "NServiceBus.Persistence.Sql.TransactionalSession\NServiceBus.Persistence.Sql.TransactionalSession.csproj", "{67DC5C83-52A4-4C53-8948-A223DE05FF1E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TransactionalSession.MsSqlMicrosoftDataClient.AcceptanceTests", "TransactionalSession.MsSqlMicrosoftDataClient.AcceptanceTests\TransactionalSession.MsSqlMicrosoftDataClient.AcceptanceTests.csproj", "{20DA1B6B-651B-480F-BEA9-3E92673C5793}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TransactionalSession.MsSqlMicrosoftDataClient.AcceptanceTests", "TransactionalSession.MsSqlMicrosoftDataClient.AcceptanceTests\TransactionalSession.MsSqlMicrosoftDataClient.AcceptanceTests.csproj", "{20DA1B6B-651B-480F-BEA9-3E92673C5793}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TransactionalSession.Tests", "TransactionalSession.Tests\TransactionalSession.Tests.csproj", "{DE280E3C-E711-4543-BF53-09D7840C3033}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TransactionalSession.Tests", "TransactionalSession.Tests\TransactionalSession.Tests.csproj", "{DE280E3C-E711-4543-BF53-09D7840C3033}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TransactionalSession.MsSqlSystemDataClient.AcceptenceTests", "TransactionalSession.MsSqlSystemDataClient.AcceptenceTests\TransactionalSession.MsSqlSystemDataClient.AcceptenceTests.csproj", "{AB33F7C1-FF29-4958-B176-81AC227451A5}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TransactionalSession.MsSqlSystemDataClient.AcceptenceTests", "TransactionalSession.MsSqlSystemDataClient.AcceptenceTests\TransactionalSession.MsSqlSystemDataClient.AcceptenceTests.csproj", "{AB33F7C1-FF29-4958-B176-81AC227451A5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/SqlPersistence/SqlPersistence.csproj
+++ b/src/SqlPersistence/SqlPersistence.csproj
@@ -8,6 +8,10 @@
     <AssemblyOriginatorKeyFile>$(SolutionDir)NServiceBus.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
+  <ItemGroup Label="Needed for build ordering">
+    <ProjectReference Include="..\ScriptBuilderTask\ScriptBuilderTask.csproj" ReferenceOutputAssembly="false" Private="false" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="[13.0.1, 14.0.0)" />
     <PackageReference Include="NServiceBus" Version="[7.8.0, 8.0.0)" />
@@ -45,11 +49,5 @@
     <None Include="..\ScriptBuilderTask\bin\$(Configuration)\net452\NServiceBus.Persistence.Sql.ScriptBuilderTask.???" Pack="true" PackagePath="netclassic" Visible="false" />
     <None Include="..\ScriptBuilderTask\bin\$(Configuration)\netstandard1.5\NServiceBus.Persistence.Sql.ScriptBuilderTask.???" Pack="true" PackagePath="netstandard" Visible="false" />
   </ItemGroup>
-
-  <!-- Workaround for https://github.com/microsoft/msbuild/issues/4303 -->
-  <PropertyGroup>
-    <AddSyntheticProjectReferencesForSolutionDependencies>false</AddSyntheticProjectReferencesForSolutionDependencies>
-  </PropertyGroup>
-  <!-- End Workaround -->
 
 </Project>

--- a/src/SqlPersistence/SqlPersistence.csproj
+++ b/src/SqlPersistence/SqlPersistence.csproj
@@ -46,8 +46,8 @@
 
   <ItemGroup>
     <None Include="..\ScriptBuilderTask\NServiceBus.Persistence.Sql.targets" Pack="true" PackagePath="build;buildTransitive" Visible="false" />
-    <None Include="..\ScriptBuilderTask\bin\$(Configuration)\net452\NServiceBus.Persistence.Sql.ScriptBuilderTask.???" Pack="true" PackagePath="netclassic" Visible="false" />
-    <None Include="..\ScriptBuilderTask\bin\$(Configuration)\netstandard1.5\NServiceBus.Persistence.Sql.ScriptBuilderTask.???" Pack="true" PackagePath="netstandard" Visible="false" />
+    <None Include="..\ScriptBuilderTask\bin\$(Configuration)\net452\NServiceBus.Persistence.Sql.ScriptBuilderTask.dll" Pack="true" PackagePath="netclassic" Visible="false" />
+    <None Include="..\ScriptBuilderTask\bin\$(Configuration)\netstandard1.5\NServiceBus.Persistence.Sql.ScriptBuilderTask.dll" Pack="true" PackagePath="netstandard" Visible="false" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
When the 6.6.1 package was released, it was broken because it did not the contain the ScriptBuilderTask assemblies.

The items that added the ScriptBuilderTask assemblies to the package had file globbing wildcards. This caused a problem because resolving the globs is dependent on when the project file is evaluated. It appears that the timing of when that happens changed in the .NET 7 SDK. The files no longer exist on disk when the items are evaluated, so they were being skipped.

Removing the globs and instead directly referencing the dll, which is all that is actually needed in the package to work correctly, removes any sort of evaluation timing dependency.

This PR also changes the ScriptBuilderTask solution dependency (which required a workaround) to a project reference.