### PR TITLE
Correctly clean all dialects if none selected

### DIFF
--- a/src/ScriptBuilder/ScriptGenerator.cs
+++ b/src/ScriptBuilder/ScriptGenerator.cs
@@ -129,7 +129,7 @@ public class ScriptGenerator
 
     IEnumerable<string> GetSelectedDialects()
     {
-        return dialectOptions.Any() ? dialectOptions.Select(d => d.ToString()) : Enum.GetNames(typeof(BuildSqlDialect));
+        return dialectOptions.Count == 0 ? Enum.GetNames(typeof(BuildSqlDialect)) : dialectOptions.Select(d => d.ToString());
     }
 
     static IEnumerable<string> GetKnownScripts(string dialectDirectory)

--- a/src/ScriptBuilder/ScriptGenerator.cs
+++ b/src/ScriptBuilder/ScriptGenerator.cs
@@ -129,7 +129,7 @@ public class ScriptGenerator
 
     IEnumerable<string> GetSelectedDialects()
     {
-        return dialectOptions != null ? dialectOptions.Select(d => d.ToString()) : Enum.GetNames(typeof(BuildSqlDialect));
+        return dialectOptions.Any() ? dialectOptions.Select(d => d.ToString()) : Enum.GetNames(typeof(BuildSqlDialect));
     }
 
     static IEnumerable<string> GetKnownScripts(string dialectDirectory)


### PR DESCRIPTION
- Fixes #848 

When we generate scripts, we clean out the folder to remove any scripts generated from a previous run. We limit this to only specified dialects. If you don't specify a dialect (which is the case for MSBuild) it _should_ clean out all of the dialects. Note that this is a different selection of dialects than the ones exposed via the assembly attribute.

Unfortunately, this is was broken in https://github.com/Particular/NServiceBus.Persistence.Sql/commit/04999bcd14759a003d1071361477000fec6abbcd

This change fixes the cleanup so we go back to the prior behavior. If no dialect is specified, then all dialects are cleaned up.

## Backporting

- 7.x (This PR)
- 6.6.x ...
