### PR TITLE
Add .net7 to CommandLine tool

### DIFF
--- a/src/CommandLine/NServiceBus.Persistence.Sql.CommandLine.csproj
+++ b/src/CommandLine/NServiceBus.Persistence.Sql.CommandLine.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <ToolCommandName>sql-persistence</ToolCommandName>
     <PackAsTool>True</PackAsTool>


### PR DESCRIPTION
This should make it possible to run the `sql-persistence`tool on a machine with .net7 only