### PR TITLE
Introduce an outbox pessimistic test for the transactional session

### DIFF
--- a/src/TransactionalSession.MsSqlMicrosoftDataClient.AcceptanceTests/OutboxHelpers.cs
+++ b/src/TransactionalSession.MsSqlMicrosoftDataClient.AcceptanceTests/OutboxHelpers.cs
@@ -1,0 +1,22 @@
+namespace NServiceBus.TransactionalSession.AcceptanceTests
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting.Customization;
+    using Persistence.Sql.ScriptBuilder;
+
+    static class OutboxHelpers
+    {
+        public static async Task CreateOutboxTable<TEndpoint>()
+            => await CreateOutboxTable(Conventions.EndpointNamingConvention(typeof(TEndpoint)));
+
+        public static async Task CreateOutboxTable(string endpointName)
+        {
+            string tablePrefix = TestTableNameCleaner.Clean(endpointName);
+            using var connection = MsSqlMicrosoftDataClientConnectionBuilder.Build();
+            await connection.OpenAsync().ConfigureAwait(false);
+
+            connection.ExecuteCommand(OutboxScriptBuilder.BuildDropScript(BuildSqlDialect.MsSqlServer), tablePrefix);
+            connection.ExecuteCommand(OutboxScriptBuilder.BuildCreateScript(BuildSqlDialect.MsSqlServer), tablePrefix);
+        }
+    }
+}

--- a/src/TransactionalSession.MsSqlMicrosoftDataClient.AcceptanceTests/When_using_transactional_session.cs
+++ b/src/TransactionalSession.MsSqlMicrosoftDataClient.AcceptanceTests/When_using_transactional_session.cs
@@ -3,12 +3,10 @@
     using System;
     using System.Threading.Tasks;
     using AcceptanceTesting;
-    using AcceptanceTesting.Customization;
     using Microsoft.Data.SqlClient;
     using Microsoft.Extensions.DependencyInjection;
     using NUnit.Framework;
     using Persistence.Sql;
-    using Persistence.Sql.ScriptBuilder;
 
     public class When_using_transactional_session : NServiceBusAcceptanceTest
     {
@@ -26,7 +24,7 @@
         {
             if (outboxEnabled)
             {
-                await CreateOutboxTable(Conventions.EndpointNamingConvention(typeof(AnEndpoint)));
+                await OutboxHelpers.CreateOutboxTable<AnEndpoint>();
             }
 
             string rowId = Guid.NewGuid().ToString();
@@ -79,7 +77,7 @@
         {
             if (outboxEnabled)
             {
-                await CreateOutboxTable(Conventions.EndpointNamingConvention(typeof(AnEndpoint)));
+                await OutboxHelpers.CreateOutboxTable<AnEndpoint>();
             }
 
             string rowId = Guid.NewGuid().ToString();
@@ -131,7 +129,7 @@
         {
             if (outboxEnabled)
             {
-                await CreateOutboxTable(Conventions.EndpointNamingConvention(typeof(AnEndpoint)));
+                await OutboxHelpers.CreateOutboxTable<AnEndpoint>();
             }
 
             var result = await Scenario.Define<Context>()
@@ -162,7 +160,7 @@
         {
             if (outboxEnabled)
             {
-                await CreateOutboxTable(Conventions.EndpointNamingConvention(typeof(AnEndpoint)));
+                await OutboxHelpers.CreateOutboxTable<AnEndpoint>();
             }
 
             var result = await Scenario.Define<Context>()
@@ -184,16 +182,6 @@
                 .Run();
 
             Assert.True(result.MessageReceived);
-        }
-
-        static async Task CreateOutboxTable(string endpointName)
-        {
-            string tablePrefix = TestTableNameCleaner.Clean(endpointName);
-            using var connection = MsSqlMicrosoftDataClientConnectionBuilder.Build();
-            await connection.OpenAsync().ConfigureAwait(false);
-
-            connection.ExecuteCommand(OutboxScriptBuilder.BuildDropScript(BuildSqlDialect.MsSqlServer), tablePrefix);
-            connection.ExecuteCommand(OutboxScriptBuilder.BuildCreateScript(BuildSqlDialect.MsSqlServer), tablePrefix);
         }
 
         class Context : ScenarioContext, IInjectServiceProvider

--- a/src/TransactionalSession.MsSqlMicrosoftDataClient.AcceptanceTests/When_using_transactional_session_with_transactionscope.cs
+++ b/src/TransactionalSession.MsSqlMicrosoftDataClient.AcceptanceTests/When_using_transactional_session_with_transactionscope.cs
@@ -4,11 +4,9 @@
     using System.Threading.Tasks;
     using System.Transactions;
     using AcceptanceTesting;
-    using AcceptanceTesting.Customization;
     using Microsoft.Data.SqlClient;
     using Microsoft.Extensions.DependencyInjection;
     using NUnit.Framework;
-    using Persistence.Sql.ScriptBuilder;
 
     public class When_using_transactional_session_with_transactionscope : NServiceBusAcceptanceTest
     {
@@ -22,7 +20,7 @@
         [Test]
         public async Task Should_provide_ambient_transactionscope()
         {
-            await CreateOutboxTable(Conventions.EndpointNamingConvention(typeof(AnEndpoint)));
+            await OutboxHelpers.CreateOutboxTable<AnEndpoint>();
 
             string rowId = Guid.NewGuid().ToString();
 
@@ -76,17 +74,6 @@
             object result = await queryCommand.ExecuteScalarAsync();
 
             Assert.AreEqual(rowId, result);
-        }
-
-
-        static async Task CreateOutboxTable(string endpointName)
-        {
-            string tablePrefix = TestTableNameCleaner.Clean(endpointName);
-            using var connection = MsSqlMicrosoftDataClientConnectionBuilder.Build();
-            await connection.OpenAsync().ConfigureAwait(false);
-
-            connection.ExecuteCommand(OutboxScriptBuilder.BuildDropScript(BuildSqlDialect.MsSqlServer), tablePrefix);
-            connection.ExecuteCommand(OutboxScriptBuilder.BuildCreateScript(BuildSqlDialect.MsSqlServer), tablePrefix);
         }
 
         class Context : ScenarioContext, IInjectServiceProvider

--- a/src/TransactionalSession.MsSqlSystemDataClient.AcceptanceTests/OutboxHelpers.cs
+++ b/src/TransactionalSession.MsSqlSystemDataClient.AcceptanceTests/OutboxHelpers.cs
@@ -1,0 +1,22 @@
+namespace NServiceBus.TransactionalSession.AcceptanceTests
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting.Customization;
+    using Persistence.Sql.ScriptBuilder;
+
+    static class OutboxHelpers
+    {
+        public static async Task CreateOutboxTable<TEndpoint>()
+            => await CreateOutboxTable(Conventions.EndpointNamingConvention(typeof(TEndpoint)));
+
+        public static async Task CreateOutboxTable(string endpointName)
+        {
+            string tablePrefix = TestTableNameCleaner.Clean(endpointName);
+            using var connection = MsSqlSystemDataClientConnectionBuilder.Build();
+            await connection.OpenAsync().ConfigureAwait(false);
+
+            connection.ExecuteCommand(OutboxScriptBuilder.BuildDropScript(BuildSqlDialect.MsSqlServer), tablePrefix);
+            connection.ExecuteCommand(OutboxScriptBuilder.BuildCreateScript(BuildSqlDialect.MsSqlServer), tablePrefix);
+        }
+    }
+}

--- a/src/TransactionalSession.MsSqlSystemDataClient.AcceptanceTests/When_using_transactional_session_with_pessimistic_locking.cs
+++ b/src/TransactionalSession.MsSqlSystemDataClient.AcceptanceTests/When_using_transactional_session_with_pessimistic_locking.cs
@@ -8,7 +8,7 @@
     using NUnit.Framework;
     using Persistence.Sql;
 
-    public class When_using_transactional_session : NServiceBusAcceptanceTest
+    public class When_using_transactional_session_with_pessimistic_locking : NServiceBusAcceptanceTest
     {
         [OneTimeSetUp]
         public void OneTimeSetup()
@@ -17,16 +17,13 @@
             MsSqlSystemDataClientConnectionBuilder.CreateDbIfNotExists();
         }
 
-        [TestCase(true)]
-        [TestCase(false)]
-        public async Task Should_send_messages_and_insert_rows_in_synchronized_session_on_transactional_session_commit(
-            bool outboxEnabled)
-        {
-            if (outboxEnabled)
-            {
-                await OutboxHelpers.CreateOutboxTable<AnEndpoint>();
-            }
+        [SetUp]
+        public async Task Setup() =>
+            await OutboxHelpers.CreateOutboxTable<AnEndpoint>();
 
+        [Test]
+        public async Task Should_send_messages_and_insert_rows_in_synchronized_session_on_transactional_session_commit()
+        {
             string rowId = Guid.NewGuid().ToString();
 
             await Scenario.Define<Context>()
@@ -70,16 +67,9 @@
             Assert.AreEqual(rowId, result);
         }
 
-        [TestCase(true)]
-        [TestCase(false)]
-        public async Task Should_send_messages_and_insert_rows_in_sql_session_on_transactional_session_commit(
-            bool outboxEnabled)
+        [Test]
+        public async Task Should_send_messages_and_insert_rows_in_sql_session_on_transactional_session_commit()
         {
-            if (outboxEnabled)
-            {
-                await OutboxHelpers.CreateOutboxTable<AnEndpoint>();
-            }
-
             string rowId = Guid.NewGuid().ToString();
 
             await Scenario.Define<Context>()
@@ -123,15 +113,9 @@
             Assert.AreEqual(rowId, result);
         }
 
-        [TestCase(true)]
-        [TestCase(false)]
-        public async Task Should_not_send_messages_if_session_is_not_committed(bool outboxEnabled)
+        [Test]
+        public async Task Should_not_send_messages_if_session_is_not_committed()
         {
-            if (outboxEnabled)
-            {
-                await OutboxHelpers.CreateOutboxTable<AnEndpoint>();
-            }
-
             var result = await Scenario.Define<Context>()
                 .WithEndpoint<AnEndpoint>(s => s.When(async (statelessSession, ctx) =>
                 {
@@ -154,15 +138,9 @@
             Assert.False(result.MessageReceived);
         }
 
-        [TestCase(true)]
-        [TestCase(false)]
-        public async Task Should_send_immediate_dispatch_messages_even_if_session_is_not_committed(bool outboxEnabled)
+        [Test]
+        public async Task Should_send_immediate_dispatch_messages_even_if_session_is_not_committed()
         {
-            if (outboxEnabled)
-            {
-                await OutboxHelpers.CreateOutboxTable<AnEndpoint>();
-            }
-
             var result = await Scenario.Define<Context>()
                 .WithEndpoint<AnEndpoint>(s => s.When(async (_, ctx) =>
                 {
@@ -193,18 +171,7 @@
 
         class AnEndpoint : EndpointConfigurationBuilder
         {
-            public AnEndpoint()
-            {
-                var useOutbox = (bool)TestContext.CurrentContext.Test.Arguments[0];
-                if (useOutbox)
-                {
-                    EndpointSetup<TransactionSessionWithOutboxEndpoint>();
-                }
-                else
-                {
-                    EndpointSetup<TransactionSessionDefaultServer>();
-                }
-            }
+            public AnEndpoint() => EndpointSetup<TransactionSessionWithOutboxEndpoint>(c => c.EnableOutbox().UsePessimisticConcurrencyControl());
 
             class SampleHandler : IHandleMessages<SampleMessage>
             {

--- a/src/TransactionalSession.MsSqlSystemDataClient.AcceptanceTests/When_using_transactional_session_with_transactionscope.cs
+++ b/src/TransactionalSession.MsSqlSystemDataClient.AcceptanceTests/When_using_transactional_session_with_transactionscope.cs
@@ -4,11 +4,9 @@
     using System.Threading.Tasks;
     using System.Transactions;
     using AcceptanceTesting;
-    using AcceptanceTesting.Customization;
     using System.Data.SqlClient;
     using Microsoft.Extensions.DependencyInjection;
     using NUnit.Framework;
-    using Persistence.Sql.ScriptBuilder;
 
     public class When_using_transactional_session_with_transactionscope : NServiceBusAcceptanceTest
     {
@@ -22,7 +20,7 @@
         [Test]
         public async Task Should_provide_ambient_transactionscope()
         {
-            await CreateOutboxTable(Conventions.EndpointNamingConvention(typeof(AnEndpoint)));
+            await OutboxHelpers.CreateOutboxTable<AnEndpoint>();
 
             string rowId = Guid.NewGuid().ToString();
 
@@ -76,17 +74,6 @@
             object result = await queryCommand.ExecuteScalarAsync();
 
             Assert.AreEqual(rowId, result);
-        }
-
-
-        static async Task CreateOutboxTable(string endpointName)
-        {
-            string tablePrefix = TestTableNameCleaner.Clean(endpointName);
-            using var connection = MsSqlSystemDataClientConnectionBuilder.Build();
-            await connection.OpenAsync().ConfigureAwait(false);
-
-            connection.ExecuteCommand(OutboxScriptBuilder.BuildDropScript(BuildSqlDialect.MsSqlServer), tablePrefix);
-            connection.ExecuteCommand(OutboxScriptBuilder.BuildCreateScript(BuildSqlDialect.MsSqlServer), tablePrefix);
         }
 
         class Context : ScenarioContext, IInjectServiceProvider


### PR DESCRIPTION
Adds test coverage for the scenarios mentioned in https://github.com/Particular/NServiceBus.Persistence.Sql/issues/1194