### PR TITLE
Optimize TSQL outbox cleanup by reducing batch size and adding rowlock hint

### DIFF
--- a/src/SqlPersistence.Tests/ApprovalFiles/OutboxCommandTests.Cleanup.MsSql.approved.txt
+++ b/src/SqlPersistence.Tests/ApprovalFiles/OutboxCommandTests.Cleanup.MsSql.approved.txt
@@ -1,4 +1,4 @@
 ﻿
-delete top (@BatchSize) from [TheSchema].[TheTablePrefixOutboxData]
+delete top (@BatchSize) from [TheSchema].[TheTablePrefixOutboxData] with (rowlock)
 where Dispatched = 'true' and
       DispatchedAt < @DispatchedBefore

--- a/src/SqlPersistence/Outbox/OutboxPersister.cs
+++ b/src/SqlPersistence/Outbox/OutboxPersister.cs
@@ -18,7 +18,7 @@ class OutboxPersister : IOutboxStorage
     readonly Func<ISqlOutboxTransaction> outboxTransactionFactory;
 
     public OutboxPersister(IConnectionManager connectionManager, SqlDialect sqlDialect, OutboxCommands outboxCommands,
-        Func<ISqlOutboxTransaction> outboxTransactionFactory) 
+        Func<ISqlOutboxTransaction> outboxTransactionFactory)
     {
         this.connectionManager = connectionManager;
         this.sqlDialect = sqlDialect;

--- a/src/SqlPersistence/Outbox/OutboxPersister.cs
+++ b/src/SqlPersistence/Outbox/OutboxPersister.cs
@@ -20,7 +20,7 @@ class OutboxPersister : IOutboxStorage
 
     public OutboxPersister(IConnectionManager connectionManager, SqlDialect sqlDialect, OutboxCommands outboxCommands,
         Func<ISqlOutboxTransaction> outboxTransactionFactory,
-        int cleanupBatchSize = 10000)
+        int cleanupBatchSize = 4000)
     {
         this.connectionManager = connectionManager;
         this.sqlDialect = sqlDialect;

--- a/src/SqlPersistence/Outbox/OutboxPersister.cs
+++ b/src/SqlPersistence/Outbox/OutboxPersister.cs
@@ -14,16 +14,19 @@ class OutboxPersister : IOutboxStorage
 {
     readonly IConnectionManager connectionManager;
     readonly SqlDialect sqlDialect;
+    readonly int cleanupBatchSize;
     readonly OutboxCommands outboxCommands;
     readonly Func<ISqlOutboxTransaction> outboxTransactionFactory;
 
     public OutboxPersister(IConnectionManager connectionManager, SqlDialect sqlDialect, OutboxCommands outboxCommands,
-        Func<ISqlOutboxTransaction> outboxTransactionFactory)
+        Func<ISqlOutboxTransaction> outboxTransactionFactory,
+        int cleanupBatchSize = 4000) // Keep below 4000 to prevent lock escalation
     {
         this.connectionManager = connectionManager;
         this.sqlDialect = sqlDialect;
         this.outboxCommands = outboxCommands;
         this.outboxTransactionFactory = outboxTransactionFactory;
+        this.cleanupBatchSize = cleanupBatchSize;
     }
 
     public Task<IOutboxTransaction> BeginTransaction(ContextBag context, CancellationToken cancellationToken = default)
@@ -123,8 +126,6 @@ class OutboxPersister : IOutboxStorage
 
     public async Task RemoveEntriesOlderThan(DateTime dateTime, CancellationToken cancellationToken = default)
     {
-        const int CleanupBatchSize = 4000; // Keep below 4000 to prevent lock escalation
-
         using (var connection = await connectionManager.OpenNonContextualConnection(cancellationToken).ConfigureAwait(false))
         {
             var continuePurging = true;
@@ -136,7 +137,7 @@ class OutboxPersister : IOutboxStorage
                 {
                     command.CommandText = outboxCommands.Cleanup;
                     command.AddParameter("DispatchedBefore", dateTime);
-                    command.AddParameter("BatchSize", CleanupBatchSize);
+                    command.AddParameter("BatchSize", cleanupBatchSize);
                     var rowCount = await command.ExecuteNonQueryEx(cancellationToken).ConfigureAwait(false);
                     continuePurging = rowCount != 0;
                 }

--- a/src/SqlPersistence/Outbox/OutboxPersister.cs
+++ b/src/SqlPersistence/Outbox/OutboxPersister.cs
@@ -20,7 +20,7 @@ class OutboxPersister : IOutboxStorage
 
     public OutboxPersister(IConnectionManager connectionManager, SqlDialect sqlDialect, OutboxCommands outboxCommands,
         Func<ISqlOutboxTransaction> outboxTransactionFactory,
-        int cleanupBatchSize = 4000)
+        int cleanupBatchSize = 4000) // Keep below 4000 to prevent lock escalation
     {
         this.connectionManager = connectionManager;
         this.sqlDialect = sqlDialect;

--- a/src/SqlPersistence/Outbox/SqlDialect_MsSqlServer.cs
+++ b/src/SqlPersistence/Outbox/SqlDialect_MsSqlServer.cs
@@ -76,7 +76,7 @@ where MessageId = @MessageId";
             internal override string GetOutboxCleanupCommand(string tableName)
             {
                 return $@"
-delete top (@BatchSize) from {tableName}
+delete top (@BatchSize) from {tableName} with (rowlock)
 where Dispatched = 'true' and
       DispatchedAt < @DispatchedBefore";
             }

--- a/src/SqlPersistence/Outbox/SqlDialect_MsSqlServer.cs
+++ b/src/SqlPersistence/Outbox/SqlDialect_MsSqlServer.cs
@@ -75,6 +75,7 @@ where MessageId = @MessageId";
 
             internal override string GetOutboxCleanupCommand(string tableName)
             {
+                // Rowlock hint to prevent lock escalation which can result in INSERT's and competing cleanup to dead-lock
                 return $@"
 delete top (@BatchSize) from {tableName} with (rowlock)
 where Dispatched = 'true' and


### PR DESCRIPTION
Optimize TSQL outbox cleanup by

1. Reducing batch size to prevent lock escalation to page/table locks 
2. Add hint to prevent escalation from row to page locks to not conflict with regular incoming message outbox operations as DELETE does not have to be efficient and should avoid any lock escalation over performance

To prevent lock escalation to page/table locks the number of rows must not be over 4.000 or 5.000 rows

Google states multiple resources that either going over 4.000 or 5.000 rows results into lock escalation from row to page/table locks:

- https://dba.stackexchange.com/questions/284675/delete-rows-older-than-x-days-without-locking-table
- https://www.sqlservercentral.com/forums/topic/row-locks-not-escalating-to-table-locks-after-5000
- https://www.sqlpassion.at/archive/2016/05/09/lock-escalations-do-they-always-happen/
