### PR TITLE
Optimize TSQL outbox cleanup by reducing batch size and adding rowlock hint - 7.0

### DIFF
--- a/src/SqlPersistence.Tests/ApprovalFiles/OutboxCommandTests.Cleanup.MsSql.approved.txt
+++ b/src/SqlPersistence.Tests/ApprovalFiles/OutboxCommandTests.Cleanup.MsSql.approved.txt
@@ -1,4 +1,4 @@
 ﻿
-delete top (@BatchSize) from [TheSchema].[TheTablePrefixOutboxData]
+delete top (@BatchSize) from [TheSchema].[TheTablePrefixOutboxData] with (rowlock)
 where Dispatched = 'true' and
       DispatchedAt < @DispatchedBefore

--- a/src/SqlPersistence/Outbox/OutboxPersister.cs
+++ b/src/SqlPersistence/Outbox/OutboxPersister.cs
@@ -20,7 +20,7 @@ class OutboxPersister : IOutboxStorage
 
     public OutboxPersister(IConnectionManager connectionManager, SqlDialect sqlDialect, OutboxCommands outboxCommands,
         Func<ISqlOutboxTransaction> outboxTransactionFactory,
-        int cleanupBatchSize = 10000)
+        int cleanupBatchSize = 4000) // Keep below 4000 to prevent lock escalation
     {
         this.connectionManager = connectionManager;
         this.sqlDialect = sqlDialect;

--- a/src/SqlPersistence/Outbox/SqlDialect_MsSqlServer.cs
+++ b/src/SqlPersistence/Outbox/SqlDialect_MsSqlServer.cs
@@ -75,8 +75,9 @@ where MessageId = @MessageId";
 
             internal override string GetOutboxCleanupCommand(string tableName)
             {
+                // Rowlock hint to prevent lock escalation which can result in INSERT's and competing cleanup to dead-lock
                 return $@"
-delete top (@BatchSize) from {tableName}
+delete top (@BatchSize) from {tableName} with (rowlock)
 where Dispatched = 'true' and
       DispatchedAt < @DispatchedBefore";
             }


### PR DESCRIPTION
Resolves:

- https://github.com/Particular/NServiceBus.Persistence.Sql/issues/778

Backport of:

- https://github.com/Particular/NServiceBus.Persistence.Sql/pull/1249