### PR TITLE
Stored json gets corrupted on SqlServer after an update with a smaller sized payload

### DIFF
--- a/src/SqlPersistence.PersistenceTests/When_updating_saga.cs
+++ b/src/SqlPersistence.PersistenceTests/When_updating_saga.cs
@@ -1,0 +1,91 @@
+﻿namespace NServiceBus.PersistenceTesting.Sagas
+{
+    using System;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using NUnit.Framework;
+
+    public class When_updating_saga : SagaPersisterTests
+    {
+        [Test]
+        public async Task It_should_trim_state_when_storing_smaller_payload()
+        {
+            // When updating an existing saga where the serialized state is smaller in length than the previous the column value should not have any left over data from the previous value.
+            // The deserializer ignores any trailing 
+
+            if (param.Values[0] is not SqlTestVariant sqlVariant)
+            {
+                Assert.Ignore("Only relevant for SQL Server");
+                return; // Satisfy compiler
+            }
+
+            var sagaData = new SagaState
+            {
+                CorrelationProperty = Guid.NewGuid().ToString(),
+                Payload = "very long state"
+            };
+
+            await SaveSaga(sagaData);
+
+            SagaState retrieved;
+            var context = configuration.GetContextBagForSagaStorage();
+            var persister = configuration.SagaStorage;
+
+            using (var completeSession = configuration.CreateStorageSession())
+            {
+                await completeSession.Open(context);
+
+                retrieved = await persister.Get<SagaState>("CorrelationProperty", sagaData.CorrelationProperty, completeSession, context);
+
+                retrieved.Payload = "short";
+
+                await persister.Update(retrieved, completeSession, context);
+                await completeSession.CompleteAsync();
+            }
+
+            Assert.LessOrEqual(retrieved.Payload, sagaData.Payload); // No real need, but here to prevent accidental updates
+
+            var retrieved2 = await GetById<SagaState>(sagaData.Id);
+
+            Assert.AreEqual(retrieved.Payload, retrieved2.Payload);
+
+            await using var con = sqlVariant.Open();
+            await con.OpenAsync();
+            var cmd = con.CreateCommand();
+            cmd.CommandText = $"SELECT Data FROM [PersistenceTests_TS] WHERE Id = '{retrieved.Id}'";
+            var data = (string)await cmd.ExecuteScalarAsync();
+
+            var countClosingBrackets = data.ToCharArray().Count(x => x == '}');
+
+            Assert.AreEqual(1, countClosingBrackets);
+        }
+
+        public class TestSaga : Saga<SagaState>, IAmStartedByMessages<StartMessage>
+        {
+            public Task Handle(StartMessage message, IMessageHandlerContext context)
+            {
+                throw new NotImplementedException();
+            }
+
+            protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaState> mapper)
+            {
+                mapper.ConfigureMapping<StartMessage>(msg => msg.SomeId).ToSaga(saga => saga.CorrelationProperty);
+            }
+        }
+
+        public class SagaState : ContainSagaData
+        {
+            public string CorrelationProperty { get; set; }
+            public string Payload { get; set; }
+        }
+
+        public class StartMessage
+        {
+            public string SomeId { get; set; }
+        }
+
+        public When_updating_saga(TestVariant param) : base(param)
+        {
+        }
+    }
+}

--- a/src/SqlPersistence.PersistenceTests/When_updating_saga_with_smaller_state.cs
+++ b/src/SqlPersistence.PersistenceTests/When_updating_saga_with_smaller_state.cs
@@ -5,15 +5,17 @@
     using System.Threading.Tasks;
     using NUnit.Framework;
 
-    public class When_updating_saga : SagaPersisterTests
+    public class When_updating_saga_with_smaller_state : SagaPersisterTests
     {
         [Test]
-        public async Task It_should_trim_state_when_storing_smaller_payload()
+        public async Task It_should_truncate_the_stored_state()
         {
             // When updating an existing saga where the serialized state is smaller in length than the previous the column value should not have any left over data from the previous value.
             // The deserializer ignores any trailing 
 
-            if (param.Values[0] is not SqlTestVariant sqlVariant)
+            var sqlVariant = (SqlTestVariant)param.Values[0];
+
+            if (sqlVariant.Dialect is not SqlDialect.MsSqlServer)
             {
                 Assert.Ignore("Only relevant for SQL Server");
                 return; // Satisfy compiler
@@ -84,7 +86,7 @@
             public string SomeId { get; set; }
         }
 
-        public When_updating_saga(TestVariant param) : base(param)
+        public When_updating_saga_with_smaller_state(TestVariant param) : base(param)
         {
         }
     }

--- a/src/SqlPersistence/CommandWrapper.cs
+++ b/src/SqlPersistence/CommandWrapper.cs
@@ -64,12 +64,14 @@ class CommandWrapper : IDisposable
 
     public Task<DbDataReader> ExecuteReaderAsync(CancellationToken cancellationToken = default)
     {
+        dialect.OptimizeForReads(command);
         return command.ExecuteReaderAsync(cancellationToken);
     }
 
     public Task<DbDataReader> ExecuteReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken = default)
     {
         var resultingBehavior = dialect.ModifyBehavior(command.Connection, behavior);
+        dialect.OptimizeForReads(command);
         return command.ExecuteReaderAsync(resultingBehavior, cancellationToken);
     }
 

--- a/src/SqlPersistence/Config/SqlDialect.cs
+++ b/src/SqlPersistence/Config/SqlDialect.cs
@@ -62,5 +62,9 @@ namespace NServiceBus
         }
 
         internal abstract object GetCustomDialectDiagnosticsInfo();
+
+        internal virtual void OptimizeForReads(DbCommand command)
+        {
+        }
     }
 }


### PR DESCRIPTION
When updating saga state where the serialized json is smaller than whats already present in the database the updated payload is corrupted.

## Expected Behavior 

When string or array values are updated with shorted values that there will be not data left from previous versions:
```
First : `111111`
Second: `2222`
```
## Observed Behavior 

In version 7.0.3 data of the previous version will remain in the database column for SQL server.
```
First:  `111111`
Second: `222211` // Trailing `11` from previous value
```
## How to reproduce

1. Design a saga that has an array or string value
2. Create a saga instance that has a value with size X (i.e. `111`)
3. Update the saga value with a value that is less than X (i.e. `11`)
4. Query the SQL Server database table and observe that the value will have some trailing data from the previous value

## Cause

7.0.3 introduced logic to set the SQL command parameter length to either 4000 or -1 for strings and arrays. This to ensure that SQL server will not create a new query plan so it will use the query cache.

Unfortunately, this has a side effect that SQL Server does not remove trailing data in an existing column for INSERT/UPDATE if the new value is shorter than the previous.

## Resolution

The length should only be set to 4000/-1 for SELECT queries

#### Versions

`NServiceBus.Persistence.Sql` 7.0.3

### Additional Information

- Introduced by #1254 
- Only version 7.0.3 is affected when using SQL Server