### PR TITLE
Fallback to PassParametersByName when BindByName is not available to support DevArt.

### DIFF
--- a/src/SqlPersistence/Extensions.cs
+++ b/src/SqlPersistence/Extensions.cs
@@ -72,15 +72,20 @@ static class Extensions
     public static async Task<bool> GetBoolAsync(this DbDataReader reader, int position, CancellationToken cancellationToken = default)
     {
         var type = reader.GetFieldType(position);
-        // MySql stores bools as ints
+        // MySql stores bools as longs (ulong)
         if (type == typeof(ulong))
         {
             return Convert.ToBoolean(await reader.GetFieldValueAsync<ulong>(position, cancellationToken).ConfigureAwait(false));
         }
-        // In Oracle we store bools as NUMBER(1,0) (short).
+        // In Oracle default driver store bools as NUMBER(1,0) (short).
         if (type == typeof(short))
         {
             return Convert.ToBoolean(await reader.GetFieldValueAsync<short>(position, cancellationToken).ConfigureAwait(false));
+        }
+        // or it might be stored as ints.
+        if (type == typeof(int))
+        {
+            return Convert.ToBoolean(await reader.GetFieldValueAsync<int>(position, cancellationToken).ConfigureAwait(false));
         }
         return await reader.GetFieldValueAsync<bool>(position, cancellationToken).ConfigureAwait(false);
     }


### PR DESCRIPTION
Requires https://github.com/Particular/NServiceBus.Persistence.Sql/pull/1405

See https://discuss.particular.net/t/sql-dialect-for-oracle-seems-data-provider-specific/3862/1

Enables support for DevArt Oracle. Currently, the code is supposed to be independent of the provider but has `Oracle.ManagedDataAccess.Core` specific reflection. If you are trying to use it with a different provider like DevArt the reflection code breaks. The equivalent of `BindByName` in DevArt is [`PassParametersByName`](https://docs.devart.com/dotconnect/oracle/Devart.Data.Oracle~Devart.Data.Oracle.OracleCommand~PassParametersByName.html)

I have attempted to get the acceptance tests working but DevArt requires a full license to run on .NET. 
