### PR TITLE
Use graph build in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,18 +13,17 @@ defaults:
     shell: pwsh
 jobs:
   build:
-    name: ${{ matrix.os-name }}-${{ matrix.engine }}
+    name: ${{ matrix.name }}-${{ matrix.engine }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [windows-2022, ubuntu-22.04]
         engine: [SqlServer, MySql, PostgreSql, Oracle]
         include:
-          # Add os-name alias for job name
           - os: windows-2022
-            os-name: Windows
+            name: Windows
           - os: ubuntu-22.04
-            os-name: Linux
+            name: Linux
       fail-fast: false
     steps:
       - name: Check for secrets
@@ -49,7 +48,7 @@ jobs:
           retention-days: 7
       - name: Azure login
         uses: azure/login@v2.0.0
-        if: matrix.engine == 'PostgreSQL' || (matrix.engine == 'Oracle' && matrix.os-name == 'Windows')
+        if: matrix.engine == 'PostgreSQL' || (matrix.engine == 'Oracle' && matrix.name == 'Windows')
         with:
           creds: ${{ secrets.AZURE_ACI_CREDENTIALS }}
       - name: Setup SQL Server

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           dotnet-version: 8.0.x
       - name: Build
-        run: dotnet build src --configuration Release
+        run: dotnet build src --configuration Release -graph
       - name: Upload packages
         uses: actions/upload-artifact@v3.1.3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           dotnet-version: 8.0.x
       - name: Build
-        run: dotnet build src --configuration Release
+        run: dotnet build src --configuration Release -graph
       - name: Sign NuGet packages
         uses: Particular/sign-nuget-packages-action@v1.0.0
         with:


### PR DESCRIPTION
The `-graph` command line ensures a more consistent build ordering by telling MSBuild to construct a [static dependency graph](https://github.com/dotnet/msbuild/blob/main/documentation/specs/static-graph.md) and use that to schedule builds.