### PR TITLE
remove timeout reference since timeout manager is no longer supported

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
           echo "::add-mask::$password"
 
           echo "Creating PostgreSQL container $name (This can take a while)"
-          $details = az container create --image postgres:15 --name $name --location $region --dns-name-label $name --resource-group GitHubActions-RG --cpu 2 --memory 8 --ports 5432 --ip-address public --environment-variables POSTGRES_PASSWORD="$password" | ConvertFrom-Json
+          $details = az container create --image postgres:15 --name $name --location $region --dns-name-label $name --resource-group GitHubActions-RG --cpu 2 --memory 8 --ports 5432 --ip-address public --registry-login-server index.docker.io --registry-username ${{ secrets.DOCKERHUB_USERNAME }} --registry-password ${{ secrets.DOCKERHUB_TOKEN }} --environment-variables POSTGRES_PASSWORD="$password" | ConvertFrom-Json
           echo "name=$name" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf-8 -Append
 
           echo "Tagging container"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
       - name: Setup Oracle
         id: setup-oracle
         if: matrix.engine == 'Oracle'
-        uses: Particular/setup-oracle-action@57e8cc0cbac87f01123883c1f44702b1e92c7e48
+        uses: Particular/setup-oracle-action@v1.5.0
         with:
           connection-string-name: OracleConnectionString
           init-script: ./.github/workflows/scripts/setup-oracle-database-users-and-permissions.sql

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,11 +146,13 @@ jobs:
       - name: Setup Oracle
         id: setup-oracle
         if: matrix.engine == 'Oracle'
-        uses: Particular/setup-oracle-action@v1.4.0
+        uses: Particular/setup-oracle-action@57e8cc0cbac87f01123883c1f44702b1e92c7e48
         with:
           connection-string-name: OracleConnectionString
           init-script: ./.github/workflows/scripts/setup-oracle-database-users-and-permissions.sql
           tag: SqlPersistence
+          registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          registry-password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Prepare Connection Strings for Oracle
         if: matrix.engine == 'Oracle'
         run: |

--- a/src/SqlPersistence/Config/SqlPersistenceConfig_Connection.cs
+++ b/src/SqlPersistence/Config/SqlPersistenceConfig_Connection.cs
@@ -76,7 +76,7 @@ namespace NServiceBus
 
             if (settings.EndpointIsMultiTenant())
             {
-                exceptionMessage += $" When in multi-tenant mode with `{nameof(MultiTenantConnectionBuilder)}`, you must still use `{nameof(ConnectionBuilder)}` to provide a database connection for subscriptions/timeouts on message transports that don't support those features natively.";
+                exceptionMessage += $" When in multi-tenant mode with `{nameof(MultiTenantConnectionBuilder)}`, you must still use `{nameof(ConnectionBuilder)}` to provide a database connection for subscriptions on message transports that don't support this feature natively.";
             }
 
             throw new Exception(exceptionMessage);


### PR DESCRIPTION
The part of updating CI / CD was necessary to make sure the builds pass without running into docker registry throttling and is not relevant for release notes.