### PR TITLE
Remove support email from json patch tool

### DIFF
--- a/tools/sagajsonstatepatch/Program.cs
+++ b/tools/sagajsonstatepatch/Program.cs
@@ -9,7 +9,7 @@ const string RED = "\u001b[31m";
 const string YELLOW = "\u001b[33m";
 const string RESET = "\u001b[0m";
 
-Console.WriteLine(UNDERLINE + "\nPlease contact Particular support at <support@particular.net> if assistance is required.\n" + RESET);
+Console.WriteLine(UNDERLINE + "\nPlease contact Particular support if assistance is required.\n" + RESET);
 
 if (args.Length < 2)
 {

--- a/tools/sagajsonstatepatch/README.md
+++ b/tools/sagajsonstatepatch/README.md
@@ -40,7 +40,7 @@ Create a `patch.sql` file:
 ## Output example
 
 ```txt
-Please contact Particular support at <support@particular.net> if assistance is required.
+Please contact Particular support if assistance is required.
 
 Connection string: data source=localhost;Database=nservicebus;persist security info=True;User Id=sa;Password=yourStrong(!)Password;Encrypt=false
 Table name       : NsbSamplesSqlPersistence.dbo.Samples_SqlPersistence_EndpointSqlServer_OrderSaga


### PR DESCRIPTION
The support@particular.net email can no longer be used to create support cases.