### PR TITLE
Invoking StorageSession.Dispose can result in race condition

### DIFF
--- a/src/MsSqlMicrosoftDataClientSqlTransportAcceptanceTests/When_using_synchronized_session_via_container.cs
+++ b/src/MsSqlMicrosoftDataClientSqlTransportAcceptanceTests/When_using_synchronized_session_via_container.cs
@@ -16,21 +16,25 @@ public class When_using_synchronized_session_via_container : NServiceBusAcceptan
     {
         // The EndpointsStarted flag is set by acceptance framework
         var context = await Scenario.Define<Context>()
-            .WithEndpoint<Endpoint>(b => b.When(s => s.SendLocal(new MyMessage())).CustomConfig(cfg =>
-            {
-                cfg.ConfigureTransport().TransportTransactionMode = transactionMode;
-            }))
+            .WithEndpoint<Endpoint>(b =>
+                b.When(s =>
+                    s.SendLocal(new MyMessage()))
+                    .CustomConfig(cfg =>
+                    {
+                        cfg.ConfigureTransport().TransportTransactionMode = transactionMode;
+                    }))
             .Done(c => c.Done)
             .Run();
 
-        Assert.That(context.InjectedSession.Connection, Is.Not.Null);
+        Assert.That(context.MessageHandlerSpySpy.ConnectionWasNotNullWhenHandleCalled);
+
         if (transactionMode == TransportTransactionMode.TransactionScope)
         {
-            Assert.That(context.InjectedSession.Transaction, Is.Null);
+            Assert.That(context.MessageHandlerSpySpy.TransactionWasNullWhenHandleCalled);
         }
         else
         {
-            Assert.That(context.InjectedSession.Transaction, Is.Not.Null);
+            Assert.That(context.MessageHandlerSpySpy.TransactionWasNotNullWhenHandleCalled);
         }
     }
 
@@ -38,6 +42,9 @@ public class When_using_synchronized_session_via_container : NServiceBusAcceptan
     {
         public bool Done { get; set; }
         public ISqlStorageSession InjectedSession { get; set; }
+
+        public StorageSessionMessageHandlerSpy MessageHandlerSpySpy { get; set; } = new();
+
     }
 
     public class Endpoint : EndpointConfigurationBuilder
@@ -64,7 +71,12 @@ public class When_using_synchronized_session_via_container : NServiceBusAcceptan
             public Task Handle(MyMessage message, IMessageHandlerContext handlerContext)
             {
                 context.Done = true;
+
                 context.InjectedSession = storageSession;
+
+                context.MessageHandlerSpySpy.ConnectionWasNotNullWhenHandleCalled = context.InjectedSession.Connection != null;
+
+                context.MessageHandlerSpySpy.TransactionWasNotNullWhenHandleCalled = context.InjectedSession.Transaction != null;
                 return Task.CompletedTask;
             }
         }
@@ -73,6 +85,21 @@ public class When_using_synchronized_session_via_container : NServiceBusAcceptan
     public class MyMessage : IMessage
     {
         public string Property { get; set; }
+    }
+
+    public class StorageSessionMessageHandlerSpy
+    {
+        //InjectedSession.Transaction is disposed and set to null after the message hanlder's
+        //Handle method executes, so it is captured when Handle is called
+        public bool TransactionWasNotNullWhenHandleCalled { get; set; }
+
+        public bool TransactionWasNullWhenHandleCalled => !TransactionWasNotNullWhenHandleCalled;
+
+        //InjectedSession.Connection is disposed and set to null after the message hanlder's
+        //Handle method executes, so it is captured when Handle is called
+        public bool ConnectionWasNotNullWhenHandleCalled { get; set; }
+
+        public bool ConnectionWasNullWhenHandleCalled => !ConnectionWasNotNullWhenHandleCalled;
     }
 
 }

--- a/src/PostgreSqlTransportAcceptanceTests/When_using_synchronized_session_via_container.cs
+++ b/src/PostgreSqlTransportAcceptanceTests/When_using_synchronized_session_via_container.cs
@@ -38,7 +38,7 @@ public class When_using_synchronized_session_via_container : NServiceBusAcceptan
         public bool Done { get; set; }
         public ISqlStorageSession InjectedSession { get; set; }
 
-        public StorageSessionMessageHandlerSpy MessageHandlerSpy { get; set; }
+        public StorageSessionMessageHandlerSpy MessageHandlerSpy { get; set; } = new();
     }
 
     public class Endpoint : EndpointConfigurationBuilder

--- a/src/SqlPersistence.PersistenceTests/When_using_storage_sessions_concurrently.cs
+++ b/src/SqlPersistence.PersistenceTests/When_using_storage_sessions_concurrently.cs
@@ -1,0 +1,95 @@
+﻿namespace NServiceBus.PersistenceTesting.Sagas;
+
+using System;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Persistence;
+
+public class When_using_storage_sessions_concurrently(TestVariant param) : SagaPersisterTests(param)
+{
+    [Test]
+    public async Task It_should_not_throw_when_being_disposed_more_than_once()
+    {
+        // 1 : Open
+        // 1 : Commit
+        // 1 : Dispose
+        // 2 : Open
+        // 1 : Dispose
+        // 2 : Commit
+
+        Assert.DoesNotThrowAsync(async () =>
+        {
+            var correlationPropertyData = Guid.NewGuid().ToString();
+            var sagaData = new TestSagaData { SomeId = correlationPropertyData, DateTimeProperty = DateTime.UtcNow };
+            await SaveSaga(sagaData);
+            var generatedSagaId = sagaData.Id;
+
+            var persister = configuration.SagaStorage;
+
+            //  1: Open
+            var session1Context = configuration.GetContextBagForSagaStorage();
+
+            ICompletableSynchronizedStorageSession session1StorageSession;
+
+            using (session1StorageSession = configuration.CreateStorageSession())
+            {
+                await session1StorageSession.Open(session1Context);
+
+                var record = await persister.Get<TestSagaData>(generatedSagaId, session1StorageSession, session1Context);
+
+                record.DateTimeProperty = DateTime.UtcNow;
+
+                await persister.Update(record, session1StorageSession, session1Context);
+                // 1:  Commit
+                await session1StorageSession.CompleteAsync();
+            }  //dispose session1StorageSession
+
+
+            var session2Context = configuration.GetContextBagForSagaStorage();
+
+            using (var session2StorageSession = configuration.CreateStorageSession())
+            {
+                // 2: Open
+                await session2StorageSession.Open(session2Context);
+
+                // 1: Dispose:
+                session1StorageSession.Dispose();
+
+                var staleRecord = await persister.Get<TestSagaData>("SomeId", correlationPropertyData,
+                    session2StorageSession, session2Context);
+                staleRecord.DateTimeProperty = DateTime.UtcNow.AddHours(1);
+
+                // 2: Commit
+                await persister.Update(staleRecord, session2StorageSession, session2Context);
+                await session2StorageSession.CompleteAsync();
+            } //dispose session2StorageSession 
+
+        });
+    }
+
+    // Needed to satisfy
+    public class TestSaga : Saga<TestSagaData>, IAmStartedByMessages<StartMessage>
+    {
+        public Task Handle(StartMessage message, IMessageHandlerContext context)
+        {
+            throw new NotSupportedException();
+        }
+
+        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TestSagaData> mapper)
+        {
+            mapper.ConfigureMapping<StartMessage>(msg => msg.SomeId).ToSaga(saga => saga.SomeId);
+        }
+    }
+
+    public class StartMessage
+    {
+        public string SomeId { get; set; }
+    }
+
+    public class TestSagaData : ContainSagaData
+    {
+        public string SomeId { get; set; } = "Test";
+
+        public DateTime DateTimeProperty { get; set; }
+    }
+}

--- a/src/SqlPersistence.PersistenceTests/When_using_storage_sessions_concurrently.cs
+++ b/src/SqlPersistence.PersistenceTests/When_using_storage_sessions_concurrently.cs
@@ -8,15 +8,13 @@ using Persistence;
 public class When_using_storage_sessions_concurrently(TestVariant param) : SagaPersisterTests(param)
 {
     [Test]
-    public async Task It_should_not_throw_when_being_disposed_more_than_once()
-    {
+    public void It_should_not_throw_when_being_disposed_more_than_once() =>
         // 1 : Open
         // 1 : Commit
         // 1 : Dispose
         // 2 : Open
         // 1 : Dispose
         // 2 : Commit
-
         Assert.DoesNotThrowAsync(async () =>
         {
             var correlationPropertyData = Guid.NewGuid().ToString();
@@ -65,7 +63,6 @@ public class When_using_storage_sessions_concurrently(TestVariant param) : SagaP
             } //dispose session2StorageSession 
 
         });
-    }
 
     // Needed to satisfy
     public class TestSaga : Saga<TestSagaData>, IAmStartedByMessages<StartMessage>

--- a/src/SqlPersistence/SynchronizedStorage/StorageSession.cs
+++ b/src/SqlPersistence/SynchronizedStorage/StorageSession.cs
@@ -114,19 +114,17 @@ sealed class StorageSession : ICompletableSynchronizedStorageSession, ISqlStorag
         {
             return;
         }
-        
+
         if (ownsTransaction)
         {
             if (Transaction != null)
             {
-                //DbTransaction is required to implement IAsyncDisposable
                 await Transaction.DisposeAsync().ConfigureAwait(false);
                 Transaction = null;
             }
 
             if (Connection != null)
             {
-                //DbConnect is required to implement IAsyncDisposable
                 await Connection.DisposeAsync().ConfigureAwait(false);
                 Connection = null;
             }

--- a/src/SqlPersistence/SynchronizedStorage/StorageSession.cs
+++ b/src/SqlPersistence/SynchronizedStorage/StorageSession.cs
@@ -87,6 +87,9 @@ sealed class StorageSession : ICompletableSynchronizedStorageSession, ISqlStorag
         {
             await Transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
         }
+
+        // Required, as NServiceBus 9.2 will invoke Dispose, and not DisposeAsync
+        await DisposeAsync().ConfigureAwait(false);
     }
 
     public void Dispose()

--- a/src/SqlPersistence/SynchronizedStorage/StorageSession.cs
+++ b/src/SqlPersistence/SynchronizedStorage/StorageSession.cs
@@ -96,7 +96,7 @@ class StorageSession : ICompletableSynchronizedStorageSession, ISqlStorageSessio
     {
         Dispose(true);
 
-        GC.SuppressFinalize(true);
+        GC.SuppressFinalize(this);
     }
 
     protected virtual void Dispose(bool disposing)

--- a/src/SqlPersistence/SynchronizedStorage/StorageSession.cs
+++ b/src/SqlPersistence/SynchronizedStorage/StorageSession.cs
@@ -94,7 +94,7 @@ class StorageSession : ICompletableSynchronizedStorageSession, ISqlStorageSessio
 
     public void Dispose()
     {
-        Dispose(true);
+        Dispose(disposing: true);
 
         GC.SuppressFinalize(this);
     }
@@ -125,7 +125,7 @@ class StorageSession : ICompletableSynchronizedStorageSession, ISqlStorageSessio
     {
         await DisposeAsyncCore().ConfigureAwait(false);
 
-        Dispose(disposing:true);
+        Dispose(disposing: true);
 
         GC.SuppressFinalize(this);
     }

--- a/src/SqlPersistence/SynchronizedStorage/StorageSession.cs
+++ b/src/SqlPersistence/SynchronizedStorage/StorageSession.cs
@@ -130,7 +130,9 @@ class StorageSession : ICompletableSynchronizedStorageSession, ISqlStorageSessio
         GC.SuppressFinalize(this);
     }
 
+#pragma warning disable PS0018
     protected virtual async ValueTask DisposeAsyncCore()
+#pragma warning restore PS0018
     {
         if (ownsTransaction)
         {

--- a/src/SqlPersistence/SynchronizedStorage/StorageSession.cs
+++ b/src/SqlPersistence/SynchronizedStorage/StorageSession.cs
@@ -86,9 +86,6 @@ class StorageSession : ICompletableSynchronizedStorageSession, ISqlStorageSessio
         if (ownsTransaction && Transaction != null)
         {
             await Transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
-            await Transaction.DisposeAsync().ConfigureAwait(false);
-
-            await Connection.DisposeAsync().ConfigureAwait(false);
         }
     }
 
@@ -111,11 +108,11 @@ class StorageSession : ICompletableSynchronizedStorageSession, ISqlStorageSessio
             if (ownsTransaction)
             {
                 Transaction?.Dispose();
-                Connection?.Dispose();
-            }
+                Transaction = null;
 
-            Transaction = null;
-            Connection = null;
+                Connection?.Dispose();
+                Connection = null;
+            }
         }
 
         disposed = false;
@@ -140,16 +137,15 @@ class StorageSession : ICompletableSynchronizedStorageSession, ISqlStorageSessio
             {
                 //DbTransaction is required to implement IAsyncDisposable
                 await Transaction.DisposeAsync().ConfigureAwait(false);
+                Transaction = null;
             }
 
             if (Connection != null)
             {
                 //DbConnect is required to implement IAsyncDisposable
                 await Connection.DisposeAsync().ConfigureAwait(false);
+                Connection = null;
             }
-
-            Transaction = null;
-            Connection = null;
         }
     }
 }


### PR DESCRIPTION
- Resolves #1235

Dispose is invoked multiple times:

- By `CompleteAsync` in StorageSession
- By `LoadHandlersConnector` its using in Core
- By `MainPipelineExecutor` its childScope dispose in Core

This can result in a race condition on the Npgsql if the connection is already in use by another concurrent operation


