### PR TITLE
Do not call dispose during CompleteAsync

### DIFF
--- a/src/SqlPersistence/SynchronizedStorage/StorageSession.cs
+++ b/src/SqlPersistence/SynchronizedStorage/StorageSession.cs
@@ -101,10 +101,8 @@ sealed class StorageSession
         {
 #if NET
             await Transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
-            await DisposeAsync().ConfigureAwait(false);
 #else
             Transaction.Commit();
-            Dispose();
 #endif
         }
     }


### PR DESCRIPTION
Removing calls to Dispose from the CompleteAsync call as it shouldn't be called directly in the class