### PR TITLE
Make passing endpoint name explicit

### DIFF
--- a/src/SqlPersistence/Config/SqlPersistenceConfig_TablePrefix.cs
+++ b/src/SqlPersistence/Config/SqlPersistenceConfig_TablePrefix.cs
@@ -18,21 +18,14 @@ namespace NServiceBus
                 .Set("SqlPersistence.TablePrefix", tablePrefix);
         }
 
-        internal static string GetTablePrefix(this IReadOnlySettings settings, string endpointName = null)
+        internal static string GetTablePrefix(this IReadOnlySettings settings, string endpointName)
         {
             if (settings.TryGet("SqlPersistence.TablePrefix", out string overriddenTablePrefix))
             {
                 return overriddenTablePrefix;
             }
 
-            if (!string.IsNullOrEmpty(endpointName))
-            {
-                return $"{TableNameCleaner.Clean(endpointName)}_";
-            }
-
-            var endpointNameFromSettings = settings.EndpointName();
-            var clean = TableNameCleaner.Clean(endpointNameFromSettings);
-            return $"{clean}_";
+            return $"{TableNameCleaner.Clean(endpointName)}_";
         }
     }
 }

--- a/src/SqlPersistence/InstallerFeature.cs
+++ b/src/SqlPersistence/InstallerFeature.cs
@@ -19,7 +19,7 @@ class InstallerFeature : Feature
         settings.ConnectionBuilder = storageType => context.Settings.GetConnectionBuilder(storageType).BuildNonContextual();
         settings.Dialect = context.Settings.GetSqlDialect();
         settings.ScriptDirectory = ScriptLocation.FindScriptDirectory(context.Settings);
-        settings.TablePrefix = context.Settings.GetTablePrefix();
+        settings.TablePrefix = context.Settings.GetTablePrefix(context.Settings.EndpointName());
         settings.IsMultiTenant = context.Settings.EndpointIsMultiTenant();
 
         settings.Dialect.ValidateTablePrefix(settings.TablePrefix);

--- a/src/SqlPersistence/Saga/SqlSagaFeature.cs
+++ b/src/SqlPersistence/Saga/SqlSagaFeature.cs
@@ -56,7 +56,7 @@ class SqlSagaFeature : Feature
         var nameFilter = SagaSettings.GetNameFilter(settings);
         nameFilter ??= sagaName => sagaName;
         var versionDeserializeBuilder = SagaSettings.GetVersionSettings(settings);
-        var tablePrefix = settings.GetTablePrefix();
+        var tablePrefix = settings.GetTablePrefix(settings.EndpointName());
         return new SagaInfoCache(
             versionSpecificSettings: versionDeserializeBuilder,
             jsonSerializer: jsonSerializer,

--- a/src/SqlPersistence/Subscription/SqlSubscriptionFeature.cs
+++ b/src/SqlPersistence/Subscription/SqlSubscriptionFeature.cs
@@ -16,7 +16,7 @@ class SqlSubscriptionFeature : Feature
         var settings = context.Settings;
 
         var connectionManager = settings.GetConnectionBuilder<StorageType.Subscriptions>();
-        var tablePrefix = settings.GetTablePrefix();
+        var tablePrefix = settings.GetTablePrefix(context.Settings.EndpointName());
         var sqlDialect = settings.GetSqlDialect();
         var cacheFor = SubscriptionSettings.GetCacheFor(settings);
         var persister = new SubscriptionPersister(connectionManager, tablePrefix, sqlDialect, cacheFor);

--- a/src/TransactionalSession.MsSqlMicrosoftDataClient.AcceptanceTests/When_using_outbox_send_only.cs
+++ b/src/TransactionalSession.MsSqlMicrosoftDataClient.AcceptanceTests/When_using_outbox_send_only.cs
@@ -13,7 +13,7 @@ public class When_using_outbox_send_only : NServiceBusAcceptanceTest
     [Test()]
     public async Task Should_send_messages_on_transactional_session_commit()
     {
-        //await OutboxHelpers.CreateOutboxTable<SendOnlyEndpoint>();
+        await OutboxHelpers.CreateOutboxTable<ProcessorEndpoint>();
 
         var context = await Scenario.Define<Context>()
             .WithEndpoint<SendOnlyEndpoint>(s => s.When(async (_, ctx) =>


### PR DESCRIPTION
@poornimanayar even though this touches more files, I like that the code is now more explicit and you can see how all the peristers are making use of the  endpoint name and where the outbox has the new "special override".

What do you think?