### PR TITLE
Prepare for NServiceBus 10 - Remove LangVersion

### DIFF
--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <MinVerMinimumMajorMinor>9.0</MinVerMinimumMajorMinor>
     <MinVerAutoIncrement>minor</MinVerAutoIncrement>
-    
   </PropertyGroup>
 
   <!-- MSBuild tasks require a .NET Framework version to work in Visual Studo, so we have to multi-target. -->


### PR DESCRIPTION
Now that .NET 10 RC1 has been released, we don't need to set the language anymore.