### PR TITLE
Obsolete SqlSaga with warning ahead of NServiceBus 10 release

### DIFF
--- a/src/SqlPersistence.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/SqlPersistence.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -8,7 +8,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"TransactionalSession.MsSqlSystemDataClient.AcceptanceTests, PublicKey=00240000048000009400000006020000002400005253413100040000010001007f16e21368ff041183fab592d9e8ed37e7be355e93323147a1d29983d6e591b04282e4da0c9e18bd901e112c0033925eb7d7872c2f1706655891c5c9d57297994f707d16ee9a8f40d978f064ee1ffc73c0db3f4712691b23bf596f75130f4ec978cf78757ec034625a5f27e6bb50c618931ea49f6f628fd74271c32959efb1c5")]
 namespace NServiceBus.Persistence.Sql
 {
-    [System.Obsolete(@"The SqlSaga base class is no longer supported, use 'NServiceBus.Saga<T>' with the 'mapper.MapSaga(…).ToMessage(…)' API. Other SqlSaga features can be added applying the 'SqlSagaAttribute' the saga class. Will be treated as an error from version 9.0.0. Will be removed in version 10.0.0.", false)]
+    [System.Obsolete(@"The SqlSaga base class is deprecated. Use 'NServiceBus.Saga<T>' with the 'mapper.MapSaga(…).ToMessage(…)' API. Other SqlSaga features can be added applying the 'SqlSagaAttribute' the saga class. Will be treated as an error from version 9.0.0. Will be removed in version 10.0.0.", false)]
     public interface IMessagePropertyMapper
     {
         void ConfigureMapping<TMessage>(System.Linq.Expressions.Expression<System.Func<TMessage, object>> messageProperty);
@@ -54,7 +54,7 @@ namespace NServiceBus.Persistence.Sql
         public string TableSuffix { get; }
         public string TransitionalCorrelationProperty { get; }
     }
-    [System.Obsolete(@"The SqlSaga base class is no longer supported, use 'NServiceBus.Saga<T>' with the 'mapper.MapSaga(…).ToMessage(…)' API. Other SqlSaga features can be added applying the 'SqlSagaAttribute' the saga class. Will be treated as an error from version 9.0.0. Will be removed in version 10.0.0.", false)]
+    [System.Obsolete(@"The SqlSaga base class is deprecated. Use 'NServiceBus.Saga<T>' with the 'mapper.MapSaga(…).ToMessage(…)' API. Other SqlSaga features can be added applying the 'SqlSagaAttribute' the saga class. Will be treated as an error from version 9.0.0. Will be removed in version 10.0.0.", false)]
     public abstract class SqlSaga<TSagaData> : NServiceBus.Saga
         where TSagaData : NServiceBus.IContainSagaData, new ()
     {

--- a/src/SqlPersistence/Saga/IMessagePropertyMapper.cs
+++ b/src/SqlPersistence/Saga/IMessagePropertyMapper.cs
@@ -7,7 +7,7 @@
     /// For mapping saga correlation properties by using a <see cref="SqlSaga{TSagaData}.CorrelationPropertyName"/>. Used by <see cref="SqlSaga{TSagaData}.ConfigureHowToFindSaga"/>.
     /// </summary>
     [ObsoleteEx(
-        Message = "The SqlSaga base class is no longer supported, use 'NServiceBus.Saga<T>' with the 'mapper.MapSaga(…).ToMessage(…)' API. Other SqlSaga features can be added applying the 'SqlSagaAttribute' the saga class",
+        Message = "The SqlSaga base class is deprecated. Use 'NServiceBus.Saga<T>' with the 'mapper.MapSaga(…).ToMessage(…)' API. Other SqlSaga features can be added applying the 'SqlSagaAttribute' the saga class",
         RemoveInVersion = "10",
         TreatAsErrorFromVersion = "9")]
     public interface IMessagePropertyMapper

--- a/src/SqlPersistence/Saga/SqlSaga.cs
+++ b/src/SqlPersistence/Saga/SqlSaga.cs
@@ -8,7 +8,7 @@
     /// Base class for all sagas being stored by the SQL Persistence. Replaces <see cref="Saga{TSagaData}"/>.
     /// </summary>
     [ObsoleteEx(
-        Message = "The SqlSaga base class is no longer supported, use 'NServiceBus.Saga<T>' with the 'mapper.MapSaga(…).ToMessage(…)' API. Other SqlSaga features can be added applying the 'SqlSagaAttribute' the saga class",
+        Message = "The SqlSaga base class is deprecated. Use 'NServiceBus.Saga<T>' with the 'mapper.MapSaga(…).ToMessage(…)' API. Other SqlSaga features can be added applying the 'SqlSagaAttribute' the saga class",
         RemoveInVersion = "10",
         TreatAsErrorFromVersion = "9")]
     public abstract class SqlSaga<TSagaData> : Saga


### PR DESCRIPTION
Backports the obsoletes as errors from https://github.com/Particular/NServiceBus.Persistence.Sql/blob/master/src/SqlPersistence/obsoletes-v9.cs for version 9 (for NServiceBus 10) to version 8 (for NServiceBus 9) except for the SqlPersistence feature class.

This will give users advance warning that SqlSaga is being deprecated before updating to NServiceBus 10 where they will find it fully removed.