### PR TITLE
Make sure default installer settings available

### DIFF
--- a/src/SqlPersistence/SqlPersistence.cs
+++ b/src/SqlPersistence/SqlPersistence.cs
@@ -20,6 +20,7 @@
                     dialect.Name,
                     CustomDiagnostics = diagnostics
                 });
+                s.SetDefault(new InstallerSettings());
             });
 
             Supports<StorageType.Outbox, SqlOutboxFeature>();


### PR DESCRIPTION
If not, we'll get a nullref if installers are enabled. Found when smoketesting sqlp in docs.

The reason the build wasn't failing is that each acceptance test has its own way of creating DB artifacts, so installers were always.Disable() and that causes `InstallerSettings` to always be present.