### PR TITLE
Update Microsoft.Build.Utilities.Core

### DIFF
--- a/src/ScriptBuilderTask/ScriptBuilderTask.csproj
+++ b/src/ScriptBuilderTask/ScriptBuilderTask.csproj
@@ -20,8 +20,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- Package needs to stay on 17.14.28 until we no longer need to ensure we run on the 10.0.10x SDK and Visual Studio 17.14 -->
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.14.28" PrivateAssets="All" />
+    <!-- Package needs to stay on 18.0.x to ensure we run on the 10.0.10x SDK and Visual Studio 18.0 -->
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="18.0.2" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR updates the MSBuild task package to the version that corresponds to the .NET 10.0.100 SDK and Visual Studio 2026 (18.0).