### PR TITLE
Reduce outbox cleanup dead locks for SQL Server

### DIFF
--- a/src/SqlPersistence.Tests/ApprovalFiles/OutboxCommandTests.Cleanup.MsSql.approved.txt
+++ b/src/SqlPersistence.Tests/ApprovalFiles/OutboxCommandTests.Cleanup.MsSql.approved.txt
@@ -1,5 +1,5 @@
 ﻿
 delete top (@BatchSize) from [TheSchema].[TheTablePrefixOutboxData] with (rowlock, readpast)
-where Dispatched = 'true' and
+where Dispatched = true and
       DispatchedAt < @DispatchedBefore
 option (maxdop 1)

--- a/src/SqlPersistence.Tests/ApprovalFiles/OutboxCommandTests.Cleanup.MsSql.approved.txt
+++ b/src/SqlPersistence.Tests/ApprovalFiles/OutboxCommandTests.Cleanup.MsSql.approved.txt
@@ -1,4 +1,5 @@
 ﻿
-delete top (@BatchSize) from [TheSchema].[TheTablePrefixOutboxData] with (rowlock)
+delete top (@BatchSize) from [TheSchema].[TheTablePrefixOutboxData] with (rowlock, readpast)
 where Dispatched = 'true' and
       DispatchedAt < @DispatchedBefore
+option (maxdop 1)

--- a/src/SqlPersistence.Tests/ApprovalFiles/OutboxCommandTests.Cleanup.MsSql.approved.txt
+++ b/src/SqlPersistence.Tests/ApprovalFiles/OutboxCommandTests.Cleanup.MsSql.approved.txt
@@ -1,5 +1,5 @@
 ﻿
 delete top (@BatchSize) from [TheSchema].[TheTablePrefixOutboxData] with (rowlock, readpast)
-where Dispatched = true and
+where Dispatched = 1 and
       DispatchedAt < @DispatchedBefore
 option (maxdop 1)

--- a/src/SqlPersistence/Outbox/SqlDialect_MsSqlServer.cs
+++ b/src/SqlPersistence/Outbox/SqlDialect_MsSqlServer.cs
@@ -77,9 +77,11 @@ where MessageId = @MessageId";
             {
                 // Rowlock hint to prevent lock escalation which can result in INSERT's and competing cleanup to dead-lock
                 return $@"
-delete top (@BatchSize) from {tableName} with (rowlock)
+delete top (@BatchSize) from {tableName} with (rowlock, readpast)
 where Dispatched = 'true' and
-      DispatchedAt < @DispatchedBefore";
+      DispatchedAt < @DispatchedBefore
+options (maxdop 1)";
+
             }
 
             internal override string AddOutboxPadding(string json)

--- a/src/SqlPersistence/Outbox/SqlDialect_MsSqlServer.cs
+++ b/src/SqlPersistence/Outbox/SqlDialect_MsSqlServer.cs
@@ -80,7 +80,7 @@ where MessageId = @MessageId";
 delete top (@BatchSize) from {tableName} with (rowlock, readpast)
 where Dispatched = 'true' and
       DispatchedAt < @DispatchedBefore
-options (maxdop 1)";
+option (maxdop 1)";
 
             }
 
@@ -89,8 +89,8 @@ options (maxdop 1)";
                 //We need to ensure the outbox content is at least 8000 bytes long because otherwise SQL Server will attempt to
                 //store is inside the data page which will result in low space utilization after the outgoing messages are dispatched.
 
-                //We tried using *varchar values out of the row* table option but while it did improve situation on on-premises 
-                //SQL Server it didn't work as expected in SQL Azure where it caused LOB pages to be allocated (one for each record) 
+                //We tried using *varchar values out of the row* table option but while it did improve situation on on-premises
+                //SQL Server it didn't work as expected in SQL Azure where it caused LOB pages to be allocated (one for each record)
                 //but never de-allocated after the messages data is supposed to be removed.
 
                 //We use 4000 instead of 8000 in the condition because the SQL Persistence uses nvarchar data type which encodes

--- a/src/SqlPersistence/Outbox/SqlDialect_MsSqlServer.cs
+++ b/src/SqlPersistence/Outbox/SqlDialect_MsSqlServer.cs
@@ -78,7 +78,7 @@ where MessageId = @MessageId";
                 // Rowlock hint to prevent lock escalation which can result in INSERT's and competing cleanup to dead-lock
                 return $@"
 delete top (@BatchSize) from {tableName} with (rowlock, readpast)
-where Dispatched = true and
+where Dispatched = 1 and
       DispatchedAt < @DispatchedBefore
 option (maxdop 1)";
 

--- a/src/SqlPersistence/Outbox/SqlDialect_MsSqlServer.cs
+++ b/src/SqlPersistence/Outbox/SqlDialect_MsSqlServer.cs
@@ -78,7 +78,7 @@ where MessageId = @MessageId";
                 // Rowlock hint to prevent lock escalation which can result in INSERT's and competing cleanup to dead-lock
                 return $@"
 delete top (@BatchSize) from {tableName} with (rowlock, readpast)
-where Dispatched = 'true' and
+where Dispatched = true and
       DispatchedAt < @DispatchedBefore
 option (maxdop 1)";
 


### PR DESCRIPTION
Added 'readpast' hint and 'maxdop 1' option to outbox cleanup command.

- READPAST: Rows that are locked are ignored. If any are expired these will be deleted next interval

- MAXDOP 1: Get more predictable locking


Combination should reduce the probability or dead locks.