### PR TITLE
Use property to control assembly package path

### DIFF
--- a/src/AnalyzerTests/AnalyzerTests.csproj
+++ b/src/AnalyzerTests/AnalyzerTests.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(RoslynPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -11,4 +11,10 @@
     <AnalyzerTargetFramework>netstandard2.0</AnalyzerTargetFramework>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!-- Package needs to stay on 5.0.x to ensure we run on the 10.0.10x SDK and Visual Studio 18.0 -->
+    <RoslynPackageVersion>5.0.0</RoslynPackageVersion>
+    <RoslynPackagePathVersion>$(RoslynPackageVersion.Split(`.`)[0]).$(RoslynPackageVersion.Split(`.`)[1])</RoslynPackagePathVersion>
+  </PropertyGroup>
+
 </Project>

--- a/src/NServiceBus.Persistence.Sql.Analyzer/NServiceBus.Persistence.Sql.Analyzer.csproj
+++ b/src/NServiceBus.Persistence.Sql.Analyzer/NServiceBus.Persistence.Sql.Analyzer.csproj
@@ -13,8 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Package needs to stay on 5.0.x to ensure we run on the 10.0.10x SDK and Visual Studio 18.0 -->
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(RoslynPackageVersion)" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="4.5.0" PrivateAssets="All" />
     <PackageReference Include="PolySharp" Version="1.15.0" PrivateAssets="All" />
   </ItemGroup>

--- a/src/SqlPersistence/SqlPersistence.csproj
+++ b/src/SqlPersistence/SqlPersistence.csproj
@@ -29,7 +29,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="Analyzer">
-    <None Include="..\NServiceBus.Persistence.Sql.Analyzer\bin\$(Configuration)\$(AnalyzerTargetFramework)\NServiceBus.Persistence.Sql.Analyzer.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn5.0/cs/NServiceBus.Persistence.Sql.Analyzer.dll" Visible="false" />
+    <None Include="..\NServiceBus.Persistence.Sql.Analyzer\bin\$(Configuration)\$(AnalyzerTargetFramework)\NServiceBus.Persistence.Sql.Analyzer.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn$(RoslynPackagePathVersion)/cs/NServiceBus.Persistence.Sql.Analyzer.dll" Visible="false" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR introduces properties to control the version of the Microsoft.CodeAnalysis packages and to calculate the resulting package path for the analyzer assemblies.