### PR TITLE
Ensure that scripts use the correct line endings

### DIFF
--- a/src/ScriptBuilder.Tests/ApprovalFiles/SagaScriptBuilderTest.CreateWithCorrelation.ForScenario.PostgreSql.approved.txt
+++ b/src/ScriptBuilder.Tests/ApprovalFiles/SagaScriptBuilderTest.CreateWithCorrelation.ForScenario.PostgreSql.approved.txt
@@ -1,4 +1,4 @@
-﻿
+
 /* TableNameVariable */
 
 /* Initialize */
@@ -65,7 +65,7 @@ for columnToDelete in
         column_name <> 'Correlation_CorrelationProperty'
 )
 loop
-	script = '
+    script = '
 alter table "' || schema || '"."' || tableNameNonQuoted || '"
 drop column "' || columnToDelete || '"';
     execute script;

--- a/src/ScriptBuilder.Tests/ApprovalFiles/SagaScriptBuilderTest.CreateWithCorrelationAndTransitional.ForScenario.PostgreSql.approved.txt
+++ b/src/ScriptBuilder.Tests/ApprovalFiles/SagaScriptBuilderTest.CreateWithCorrelationAndTransitional.ForScenario.PostgreSql.approved.txt
@@ -1,4 +1,4 @@
-﻿
+
 /* TableNameVariable */
 
 /* Initialize */
@@ -89,7 +89,7 @@ for columnToDelete in
         column_name <> 'Correlation_TransitionalProperty'
 )
 loop
-	script = '
+    script = '
 alter table "' || schema || '"."' || tableNameNonQuoted || '"
 drop column "' || columnToDelete || '"';
     execute script;

--- a/src/ScriptBuilder.Tests/OutboxScriptBuilderTest.cs
+++ b/src/ScriptBuilder.Tests/OutboxScriptBuilderTest.cs
@@ -25,6 +25,8 @@ public class OutboxScriptBuilderTest
             SqlValidator.Validate(script);
         }
 
+        Assert.That(script, Is.EqualTo(script.ReplaceLineEndings()), "Line endings are not consistent");
+
         Approver.Verify(script, scenario: "ForScenario." + sqlDialect);
     }
 
@@ -45,6 +47,8 @@ public class OutboxScriptBuilderTest
         {
             SqlValidator.Validate(script);
         }
+
+        Assert.That(script, Is.EqualTo(script.ReplaceLineEndings()), "Line endings are not consistent");
 
         Approver.Verify(script, scenario: "ForScenario." + sqlDialect);
     }

--- a/src/ScriptBuilder.Tests/Saga/SagaScriptBuilderTest.cs
+++ b/src/ScriptBuilder.Tests/Saga/SagaScriptBuilderTest.cs
@@ -36,6 +36,8 @@ public class SagaScriptBuilderTest
             SqlValidator.Validate(script);
         }
 
+        Assert.That(script, Is.EqualTo(script.ReplaceLineEndings()), "Line endings are not consistent");
+
         Approver.Verify(script, scenario: "ForScenario." + sqlDialect);
     }
 
@@ -73,6 +75,8 @@ public class SagaScriptBuilderTest
             SqlValidator.Validate(script);
         }
 
+        Assert.That(script, Is.EqualTo(script.ReplaceLineEndings()), "Line endings are not consistent");
+
         Approver.Verify(script, scenario: "ForScenario." + sqlDialect);
     }
 
@@ -102,6 +106,8 @@ public class SagaScriptBuilderTest
         {
             SqlValidator.Validate(script);
         }
+
+        Assert.That(script, Is.EqualTo(script.ReplaceLineEndings()), "Line endings are not consistent");
 
         Approver.Verify(script, scenario: "ForScenario." + sqlDialect);
     }

--- a/src/ScriptBuilder.Tests/SqlValidator.cs
+++ b/src/ScriptBuilder.Tests/SqlValidator.cs
@@ -21,7 +21,7 @@ public static class SqlValidator
             return;
         }
 
-        var message = $"Sql errors:{string.Join("\r\n", errors.Select(error => error.Message))}";
+        var message = $"Sql errors:{string.Join(Environment.NewLine, errors.Select(error => error.Message))}";
         throw new Exception(message);
     }
 }

--- a/src/ScriptBuilder.Tests/SubscriptionScriptBuilderTest.cs
+++ b/src/ScriptBuilder.Tests/SubscriptionScriptBuilderTest.cs
@@ -25,6 +25,8 @@ public class SubscriptionScriptBuilderTest
             SqlValidator.Validate(script);
         }
 
+        Assert.That(script, Is.EqualTo(script.ReplaceLineEndings()), "Line endings are not consistent");
+
         Approver.Verify(script, scenario: "ForScenario." + sqlDialect);
     }
 
@@ -45,6 +47,8 @@ public class SubscriptionScriptBuilderTest
         {
             SqlValidator.Validate(script);
         }
+
+        Assert.That(script, Is.EqualTo(script.ReplaceLineEndings()), "Line endings are not consistent");
 
         Approver.Verify(script, scenario: "ForScenario." + sqlDialect);
     }

--- a/src/ScriptBuilder.Tests/TimeoutScriptBuilderTest.cs
+++ b/src/ScriptBuilder.Tests/TimeoutScriptBuilderTest.cs
@@ -25,6 +25,8 @@ public class TimeoutScriptBuilderTest
             SqlValidator.Validate(script);
         }
 
+        Assert.That(script, Is.EqualTo(script.ReplaceLineEndings()), "Line endings are not consistent");
+
         Approver.Verify(script, scenario: "ForScenario." + sqlDialect);
     }
 
@@ -45,6 +47,8 @@ public class TimeoutScriptBuilderTest
         {
             SqlValidator.Validate(script);
         }
+
+        Assert.That(script, Is.EqualTo(script.ReplaceLineEndings()), "Line endings are not consistent");
 
         Approver.Verify(script, scenario: "ForScenario." + sqlDialect);
     }

--- a/src/ScriptBuilder/Outbox/OutboxScriptBuilder.cs
+++ b/src/ScriptBuilder/Outbox/OutboxScriptBuilder.cs
@@ -7,31 +7,41 @@
     {
         public static void BuildCreateScript(TextWriter writer, BuildSqlDialect sqlDialect)
         {
-            writer.Write(ResourceReader.ReadResource(sqlDialect, "Outbox.Create"));
+            var resource = ResourceReader.ReadResource(sqlDialect, "Outbox.Create");
+            resource = resource.ReplaceLineEndings();
+
+            writer.Write(resource);
         }
 
         public static string BuildCreateScript(BuildSqlDialect sqlDialect)
         {
             var stringBuilder = new StringBuilder();
+
             using (var stringWriter = new StringWriter(stringBuilder))
             {
                 BuildCreateScript(stringWriter, sqlDialect);
             }
+
             return stringBuilder.ToString();
         }
 
         public static void BuildDropScript(TextWriter writer, BuildSqlDialect sqlDialect)
         {
-            writer.Write(ResourceReader.ReadResource(sqlDialect, "Outbox.Drop"));
+            var resource = ResourceReader.ReadResource(sqlDialect, "Outbox.Drop");
+            resource = resource.ReplaceLineEndings();
+
+            writer.Write(resource);
         }
 
         public static string BuildDropScript(BuildSqlDialect sqlDialect)
         {
             var stringBuilder = new StringBuilder();
+
             using (var stringWriter = new StringWriter(stringBuilder))
             {
                 BuildDropScript(stringWriter, sqlDialect);
             }
+
             return stringBuilder.ToString();
         }
     }

--- a/src/ScriptBuilder/Saga/SagaScriptBuilder.cs
+++ b/src/ScriptBuilder/Saga/SagaScriptBuilder.cs
@@ -71,8 +71,7 @@
 
         static void WriteComment(TextWriter writer, string text)
         {
-            writer.WriteLine($@"
-/* {text} */");
+            writer.WriteLine($"{Environment.NewLine}/* {text} */");
         }
 
         static ISagaScriptWriter GetSqlDialectWriter(BuildSqlDialect sqlDialect, TextWriter textWriter, SagaDefinition saga)

--- a/src/ScriptBuilder/Saga/SagaScriptBuilder.cs
+++ b/src/ScriptBuilder/Saga/SagaScriptBuilder.cs
@@ -6,21 +6,28 @@
 
     public static class SagaScriptBuilder
     {
+        public static void BuildCreateScript(SagaDefinition saga, BuildSqlDialect sqlDialect, TextWriter writer)
+        {
+            writer.Write(BuildCreateScript(saga, sqlDialect));
+        }
+
         public static string BuildCreateScript(SagaDefinition saga, BuildSqlDialect sqlDialect)
         {
             var stringBuilder = new StringBuilder();
+
             using (var stringWriter = new StringWriter(stringBuilder))
             {
-                BuildCreateScript(saga, sqlDialect, stringWriter);
+                WriteCreateScript(saga, sqlDialect, stringWriter);
             }
-            return stringBuilder.ToString();
+
+            var script = stringBuilder.ToString();
+            script = script.ReplaceLineEndings();
+
+            return script;
         }
 
-        public static void BuildCreateScript(SagaDefinition saga, BuildSqlDialect sqlDialect, TextWriter writer)
+        static void WriteCreateScript(SagaDefinition saga, BuildSqlDialect sqlDialect, TextWriter writer)
         {
-            ArgumentNullException.ThrowIfNull(saga, nameof(saga));
-            ArgumentNullException.ThrowIfNull(writer, nameof(writer));
-
             SagaDefinitionValidator.ValidateSagaDefinition(
                 correlationProperty: saga.CorrelationProperty?.Name,
                 sagaName: saga.Name,
@@ -37,6 +44,7 @@
 
             WriteComment(writer, "CreateTable");
             sqlDialectWriter.WriteCreateTable();
+
             if (saga.CorrelationProperty != null)
             {
                 WriteComment(writer, $"AddProperty {saga.CorrelationProperty.Name}");
@@ -48,6 +56,7 @@
                 WriteComment(writer, $"WriteCreateIndex {saga.CorrelationProperty.Name}");
                 sqlDialectWriter.WriteCreateIndex(saga.CorrelationProperty);
             }
+
             if (saga.TransitionalCorrelationProperty != null)
             {
                 WriteComment(writer, $"AddProperty {saga.TransitionalCorrelationProperty.Name}");
@@ -59,6 +68,7 @@
                 WriteComment(writer, $"CreateIndex {saga.TransitionalCorrelationProperty.Name}");
                 sqlDialectWriter.WriteCreateIndex(saga.TransitionalCorrelationProperty);
             }
+
             WriteComment(writer, "PurgeObsoleteIndex");
             sqlDialectWriter.WritePurgeObsoleteIndex();
 
@@ -98,6 +108,26 @@
 
         public static void BuildDropScript(SagaDefinition saga, BuildSqlDialect sqlDialect, TextWriter writer)
         {
+            writer.Write(BuildDropScript(saga, sqlDialect));
+        }
+
+        public static string BuildDropScript(SagaDefinition saga, BuildSqlDialect sqlDialect)
+        {
+            var stringBuilder = new StringBuilder();
+
+            using (var stringWriter = new StringWriter(stringBuilder))
+            {
+                WriteDropScript(saga, sqlDialect, stringWriter);
+            }
+
+            var script = stringBuilder.ToString();
+            script = script.ReplaceLineEndings();
+
+            return script;
+        }
+
+        static void WriteDropScript(SagaDefinition saga, BuildSqlDialect sqlDialect, TextWriter writer)
+        {
             var sqlDialectWriter = GetSqlDialectWriter(sqlDialect, writer, saga);
 
             WriteComment(writer, "TableNameVariable");
@@ -105,16 +135,6 @@
 
             WriteComment(writer, "DropTable");
             sqlDialectWriter.WriteDropTable();
-        }
-
-        public static string BuildDropScript(SagaDefinition saga, BuildSqlDialect sqlDialect)
-        {
-            var stringBuilder = new StringBuilder();
-            using (var stringWriter = new StringWriter(stringBuilder))
-            {
-                BuildDropScript(saga, sqlDialect, stringWriter);
-            }
-            return stringBuilder.ToString();
         }
     }
 }

--- a/src/ScriptBuilder/Saga/Writers/MsSqlServerSagaScriptWriter.cs
+++ b/src/ScriptBuilder/Saga/Writers/MsSqlServerSagaScriptWriter.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Text;
 using NServiceBus.Persistence.Sql.ScriptBuilder;
 
@@ -110,11 +111,11 @@ end
 
         if (saga.CorrelationProperty != null)
         {
-            builder.Append($" and\r\n        column_name <> N'Correlation_{saga.CorrelationProperty.Name}'");
+            builder.Append($" and{Environment.NewLine}        column_name <> N'Correlation_{saga.CorrelationProperty.Name}'");
         }
         if (saga.TransitionalCorrelationProperty != null)
         {
-            builder.Append($" and\r\n        column_name <> N'Correlation_{saga.TransitionalCorrelationProperty.Name}'");
+            builder.Append($" and{Environment.NewLine}        column_name <> N'Correlation_{saga.TransitionalCorrelationProperty.Name}'");
         }
 
         writer.Write($@"
@@ -138,11 +139,11 @@ exec sp_executesql @dropPropertiesQuery
 
         if (saga.CorrelationProperty != null)
         {
-            builder.Append($" and\r\n        Name <> N'Index_Correlation_{saga.CorrelationProperty.Name}'");
+            builder.Append($" and{Environment.NewLine}        Name <> N'Index_Correlation_{saga.CorrelationProperty.Name}'");
         }
         if (saga.TransitionalCorrelationProperty != null)
         {
-            builder.Append($" and\r\n        Name <> N'Index_Correlation_{saga.TransitionalCorrelationProperty.Name}'");
+            builder.Append($" and{Environment.NewLine}        Name <> N'Index_Correlation_{saga.TransitionalCorrelationProperty.Name}'");
         }
 
         writer.Write($@"

--- a/src/ScriptBuilder/Saga/Writers/MySqlSagaScriptWriter.cs
+++ b/src/ScriptBuilder/Saga/Writers/MySqlSagaScriptWriter.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Text;
 using NServiceBus.Persistence.Sql.ScriptBuilder;
 
@@ -115,12 +116,12 @@ deallocate prepare script;
         var correlation = saga.CorrelationProperty;
         if (correlation != null)
         {
-            builder.Append($" and\r\n    index_name <> 'Index_Correlation_{correlation.Name}'");
+            builder.Append($" and{Environment.NewLine}    index_name <> 'Index_Correlation_{correlation.Name}'");
         }
         var transitional = saga.TransitionalCorrelationProperty;
         if (transitional != null)
         {
-            builder.Append($" and\r\n    index_name <> 'Index_Correlation_{transitional.Name}'");
+            builder.Append($" and{Environment.NewLine}    index_name <> 'Index_Correlation_{transitional.Name}'");
         }
 
         writer.Write($@"
@@ -151,12 +152,12 @@ deallocate prepare script;
         var correlation = saga.CorrelationProperty;
         if (correlation != null)
         {
-            builder.Append($" and\r\n    column_name <> 'Correlation_{correlation.Name}'");
+            builder.Append($" and{Environment.NewLine}    column_name <> 'Correlation_{correlation.Name}'");
         }
         var transitional = saga.TransitionalCorrelationProperty;
         if (transitional != null)
         {
-            builder.Append($" and\r\n    column_name <> 'Correlation_{transitional.Name}'");
+            builder.Append($" and{Environment.NewLine}    column_name <> 'Correlation_{transitional.Name}'");
         }
         writer.Write($@"
 select concat('alter table ', table_name, ' drop column ', column_name, ';')

--- a/src/ScriptBuilder/Saga/Writers/OracleSagaScriptWriter.cs
+++ b/src/ScriptBuilder/Saga/Writers/OracleSagaScriptWriter.cs
@@ -111,11 +111,11 @@ end if;
 
         if (saga.CorrelationProperty != null)
         {
-            builder.Append($" and\r\n        column_name <> '{OracleCorrelationPropertyName(saga.CorrelationProperty)}'");
+            builder.Append($" and{Environment.NewLine}        column_name <> '{OracleCorrelationPropertyName(saga.CorrelationProperty)}'");
         }
         if (saga.TransitionalCorrelationProperty != null)
         {
-            builder.Append($" and\r\n        column_name <> '{OracleCorrelationPropertyName(saga.TransitionalCorrelationProperty)}'");
+            builder.Append($" and{Environment.NewLine}        column_name <> '{OracleCorrelationPropertyName(saga.TransitionalCorrelationProperty)}'");
         }
         writer.Write($@"
 select count(*) into n

--- a/src/ScriptBuilder/Saga/Writers/PostgreSqlSagaScriptWriter.cs
+++ b/src/ScriptBuilder/Saga/Writers/PostgreSqlSagaScriptWriter.cs
@@ -93,11 +93,11 @@ class PostgreSqlSagaScriptWriter : ISagaScriptWriter
 
         if (saga.CorrelationProperty != null)
         {
-            builder.Append($" and\r\n        column_name <> 'Correlation_{saga.CorrelationProperty.Name}'");
+            builder.Append($" and{Environment.NewLine}        column_name <> 'Correlation_{saga.CorrelationProperty.Name}'");
         }
         if (saga.TransitionalCorrelationProperty != null)
         {
-            builder.Append($" and\r\n        column_name <> 'Correlation_{saga.TransitionalCorrelationProperty.Name}'");
+            builder.Append($" and{Environment.NewLine}        column_name <> 'Correlation_{saga.TransitionalCorrelationProperty.Name}'");
         }
         writer.Write($@"
 for columnToDelete in
@@ -109,7 +109,7 @@ for columnToDelete in
         column_name LIKE 'Correlation_%'{builder}
 )
 loop
-	script = '
+    script = '
 alter table ""' || schema || '"".""' || tableNameNonQuoted || '""
 drop column ""' || columnToDelete || '""';
     execute script;

--- a/src/ScriptBuilder/Subscription/SubscriptionScriptBuilder.cs
+++ b/src/ScriptBuilder/Subscription/SubscriptionScriptBuilder.cs
@@ -7,31 +7,41 @@
     {
         public static void BuildCreateScript(TextWriter writer, BuildSqlDialect sqlDialect)
         {
-            writer.Write(ResourceReader.ReadResource(sqlDialect, "Subscription.Create"));
+            var resource = ResourceReader.ReadResource(sqlDialect, "Subscription.Create");
+            resource = resource.ReplaceLineEndings();
+
+            writer.Write(resource);
         }
 
         public static string BuildCreateScript(BuildSqlDialect sqlDialect)
         {
             var stringBuilder = new StringBuilder();
+
             using (var stringWriter = new StringWriter(stringBuilder))
             {
                 BuildCreateScript(stringWriter, sqlDialect);
             }
+
             return stringBuilder.ToString();
         }
 
         public static void BuildDropScript(TextWriter writer, BuildSqlDialect sqlDialect)
         {
-            writer.Write(ResourceReader.ReadResource(sqlDialect, "Subscription.Drop"));
+            var resource = ResourceReader.ReadResource(sqlDialect, "Subscription.Drop");
+            resource = resource.ReplaceLineEndings();
+
+            writer.Write(resource);
         }
 
         public static string BuildDropScript(BuildSqlDialect sqlDialect)
         {
             var stringBuilder = new StringBuilder();
+
             using (var stringWriter = new StringWriter(stringBuilder))
             {
                 BuildDropScript(stringWriter, sqlDialect);
             }
+
             return stringBuilder.ToString();
         }
     }

--- a/src/ScriptBuilder/Timeout/TimeoutScriptBuilder.cs
+++ b/src/ScriptBuilder/Timeout/TimeoutScriptBuilder.cs
@@ -7,31 +7,41 @@
     {
         public static void BuildCreateScript(TextWriter writer, BuildSqlDialect sqlDialect)
         {
-            writer.Write(ResourceReader.ReadResource(sqlDialect, "Timeout.Create"));
+            var resource = ResourceReader.ReadResource(sqlDialect, "Timeout.Create");
+            resource = resource.ReplaceLineEndings();
+
+            writer.Write(resource);
         }
 
         public static string BuildCreateScript(BuildSqlDialect sqlDialect)
         {
             var stringBuilder = new StringBuilder();
+
             using (var stringWriter = new StringWriter(stringBuilder))
             {
                 BuildCreateScript(stringWriter, sqlDialect);
             }
+
             return stringBuilder.ToString();
         }
 
         public static void BuildDropScript(TextWriter writer, BuildSqlDialect sqlDialect)
         {
-            writer.Write(ResourceReader.ReadResource(sqlDialect, "Timeout.Drop"));
+            var resource = ResourceReader.ReadResource(sqlDialect, "Timeout.Drop");
+            resource = resource.ReplaceLineEndings();
+
+            writer.Write(resource);
         }
 
         public static string BuildDropScript(BuildSqlDialect sqlDialect)
         {
             var stringBuilder = new StringBuilder();
+
             using (var stringWriter = new StringWriter(stringBuilder))
             {
                 BuildDropScript(stringWriter, sqlDialect);
             }
+
             return stringBuilder.ToString();
         }
     }

--- a/src/SqlPersistence/Saga/SqlDialect_MsSqlServer.cs
+++ b/src/SqlPersistence/Saga/SqlDialect_MsSqlServer.cs
@@ -26,13 +26,13 @@
 
                 if (correlationProperty != null)
                 {
-                    insertBuilder.Append($",\r\n    Correlation_{correlationProperty}");
-                    valuesBuilder.Append(",\r\n    @CorrelationId");
+                    insertBuilder.Append($",{Environment.NewLine}    Correlation_{correlationProperty}");
+                    valuesBuilder.Append($",{Environment.NewLine}    @CorrelationId");
                 }
                 if (transitionalCorrelationProperty != null)
                 {
-                    insertBuilder.Append($",\r\n    Correlation_{transitionalCorrelationProperty}");
-                    valuesBuilder.Append(",\r\n    @TransitionalCorrelationId");
+                    insertBuilder.Append($",{Environment.NewLine}    Correlation_{transitionalCorrelationProperty}");
+                    valuesBuilder.Append($",{Environment.NewLine}    @TransitionalCorrelationId");
                 }
 
                 return $@"
@@ -62,7 +62,7 @@ values
                 var correlationSet = "";
                 if (transitionalCorrelationProperty != null)
                 {
-                    correlationSet = $",\r\n    Correlation_{transitionalCorrelationProperty} = @TransitionalCorrelationId";
+                    correlationSet = $",{Environment.NewLine}    Correlation_{transitionalCorrelationProperty} = @TransitionalCorrelationId";
                 }
 
                 return $@"

--- a/src/SqlPersistence/Saga/SqlDialect_MySql.cs
+++ b/src/SqlPersistence/Saga/SqlDialect_MySql.cs
@@ -19,13 +19,13 @@
 
                 if (correlationProperty != null)
                 {
-                    insertBuilder.Append($",\r\n    Correlation_{correlationProperty}");
-                    valuesBuilder.Append(",\r\n    @CorrelationId");
+                    insertBuilder.Append($",{Environment.NewLine}    Correlation_{correlationProperty}");
+                    valuesBuilder.Append($",{Environment.NewLine}    @CorrelationId");
                 }
                 if (transitionalCorrelationProperty != null)
                 {
-                    insertBuilder.Append($",\r\n    Correlation_{transitionalCorrelationProperty}");
-                    valuesBuilder.Append(",\r\n    @TransitionalCorrelationId");
+                    insertBuilder.Append($",{Environment.NewLine}    Correlation_{transitionalCorrelationProperty}");
+                    valuesBuilder.Append($",{Environment.NewLine}    @TransitionalCorrelationId");
                 }
 
                 return $@"
@@ -55,7 +55,7 @@ values
                 var correlationSet = "";
                 if (transitionalCorrelationProperty != null)
                 {
-                    correlationSet = $",\r\n    Correlation_{transitionalCorrelationProperty} = @TransitionalCorrelationId";
+                    correlationSet = $",{Environment.NewLine}    Correlation_{transitionalCorrelationProperty} = @TransitionalCorrelationId";
                 }
 
                 return $@"

--- a/src/SqlPersistence/Saga/SqlDialect_Oracle.cs
+++ b/src/SqlPersistence/Saga/SqlDialect_Oracle.cs
@@ -27,13 +27,13 @@
 
                 if (correlationProperty != null)
                 {
-                    insertBuilder.Append($",\r\n    {CorrelationPropertyName(correlationProperty)}");
-                    valuesBuilder.Append(",\r\n    :CorrelationId");
+                    insertBuilder.Append($",{Environment.NewLine}    {CorrelationPropertyName(correlationProperty)}");
+                    valuesBuilder.Append($",{Environment.NewLine}    :CorrelationId");
                 }
                 if (transitionalCorrelationProperty != null)
                 {
-                    insertBuilder.Append($",\r\n    {CorrelationPropertyName(transitionalCorrelationProperty)}");
-                    valuesBuilder.Append(",\r\n    :TransitionalCorrelationId");
+                    insertBuilder.Append($",{Environment.NewLine}    {CorrelationPropertyName(transitionalCorrelationProperty)}");
+                    valuesBuilder.Append($",{Environment.NewLine}    :TransitionalCorrelationId");
                 }
 
                 return $@"
@@ -63,7 +63,7 @@ values
                 var correlationSet = "";
                 if (transitionalCorrelationProperty != null)
                 {
-                    correlationSet = $",\r\n    {CorrelationPropertyName(transitionalCorrelationProperty)} = :TransitionalCorrelationId";
+                    correlationSet = $",{Environment.NewLine}    {CorrelationPropertyName(transitionalCorrelationProperty)} = :TransitionalCorrelationId";
                 }
 
                 return $@"

--- a/src/SqlPersistence/Saga/SqlDialect_PostgreSql.cs
+++ b/src/SqlPersistence/Saga/SqlDialect_PostgreSql.cs
@@ -46,13 +46,13 @@
 
                 if (correlationProperty != null)
                 {
-                    insertBuilder.Append($",\r\n    \"Correlation_{correlationProperty}\"");
-                    valuesBuilder.Append(",\r\n    @CorrelationId");
+                    insertBuilder.Append($",{Environment.NewLine}    \"Correlation_{correlationProperty}\"");
+                    valuesBuilder.Append($",{Environment.NewLine}    @CorrelationId");
                 }
                 if (transitionalCorrelationProperty != null)
                 {
-                    insertBuilder.Append($",\r\n    \"Correlation_{transitionalCorrelationProperty}\"");
-                    valuesBuilder.Append(",\r\n    @TransitionalCorrelationId");
+                    insertBuilder.Append($",{Environment.NewLine}    \"Correlation_{transitionalCorrelationProperty}\"");
+                    valuesBuilder.Append($",{Environment.NewLine}    @TransitionalCorrelationId");
                 }
 
                 return $@"
@@ -82,7 +82,7 @@ values
                 var correlationSet = "";
                 if (transitionalCorrelationProperty != null)
                 {
-                    correlationSet = $",\r\n    \"Correlation_{transitionalCorrelationProperty}\" = @TransitionalCorrelationId";
+                    correlationSet = $",{Environment.NewLine}    \"Correlation_{transitionalCorrelationProperty}\" = @TransitionalCorrelationId";
                 }
 
                 return $@"


### PR DESCRIPTION
This PR ensures that when the script files get written, they use the appropriate line endings to match the OS that the project is being built on.

Previously, the resource-based scripts (Outbox, Subscription, Timeout) would always be `CRLF` and the Saga scripts would be a mix of `CRLF` and `LF` on non-Windows.

Fixes #2036

