### PR TITLE
Respect TableSuffix property of the SqlSaga attribute when generating the persistence manifest

### DIFF
--- a/src/SqlPersistence.Tests/Saga/SqlSagaFeatureTests.cs
+++ b/src/SqlPersistence.Tests/Saga/SqlSagaFeatureTests.cs
@@ -1,0 +1,47 @@
+using System.Linq;
+using System.Threading.Tasks;
+using NServiceBus;
+using NServiceBus.Persistence.Sql;
+using NServiceBus.Sagas;
+using NUnit.Framework;
+
+[TestFixture]
+public class SqlSagaFeatureTests
+{
+    [Test]
+    public void Saga_manifest_uses_sql_saga_table_suffix_for_oracle()
+    {
+        var metadata = SagaMetadata.CreateMany([typeof(SagaWithEntityNameLongerThanOracleAllows)]).Single();
+
+        var manifest = SqlSagaFeature.CreateSagaManifest(
+            metadata,
+            new SqlDialect.Oracle(),
+            "Endpoint_",
+            sagaName => sagaName);
+
+        Assert.That(manifest.TableName, Is.EqualTo("\"SHORTSAGATABLE\""));
+        Assert.That(manifest.Indexes.Single().Name, Is.EqualTo("Index_Correlation_CorrelationProperty"));
+        Assert.That(manifest.Indexes.Single().Columns, Is.EqualTo("CorrelationProperty"));
+    }
+
+    [SqlSaga(tableSuffix: "ShortSagaTable")]
+    public class SagaWithEntityNameLongerThanOracleAllows :
+        Saga<SagaWithEntityNameLongerThanOracleAllows.SagaDataWithEntityNameLongerThanOracleAllows>,
+        IAmStartedByMessages<StartMessage>
+    {
+        public Task Handle(StartMessage message, IMessageHandlerContext context) => Task.CompletedTask;
+
+        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaDataWithEntityNameLongerThanOracleAllows> mapper) =>
+            mapper.MapSaga(saga => saga.CorrelationProperty).ToMessage<StartMessage>(message => message.CorrelationProperty);
+
+        public class SagaDataWithEntityNameLongerThanOracleAllows : ContainSagaData
+        {
+            public string CorrelationProperty { get; set; }
+        }
+    }
+
+    public class StartMessage : IMessage
+    {
+        public string CorrelationProperty { get; set; }
+    }
+}

--- a/src/SqlPersistence/Saga/SqlSagaFeature.cs
+++ b/src/SqlPersistence/Saga/SqlSagaFeature.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
 using NServiceBus;
@@ -55,24 +56,36 @@ sealed class SqlSagaFeature : Feature
 
         if (settings.TryGet<ManifestOutput.PersistenceManifest>(out var manifest))
         {
-            manifest.SetSagas(() => settings.Get<SagaMetadataCollection>().Select(saga => GetSagaTableSchema(saga.Name, saga.EntityName, saga.TryGetCorrelationProperty(out var correlationProperty) ? correlationProperty.Name : null)).ToArray());
-
-            ManifestOutput.PersistenceManifest.SagaManifest GetSagaTableSchema(string sagaName, string entityName, string correlationProperty) => new()
-            {
-                Name = sagaName,
-                TableName = sqlDialect.GetSagaTableName($"{manifest.Prefix}_", entityName),
-                Indexes = !string.IsNullOrEmpty(correlationProperty)
-                    ?
-                    [
-                        new()
-                        {
-                            Name = $"Index_Correlation_{correlationProperty}",
-                            Columns = correlationProperty
-                        }
-                    ]
-                    : []
-            };
+            var nameFilter = GetNameFilter(settings);
+            manifest.SetSagas(() => settings.Get<SagaMetadataCollection>().Select(saga => CreateSagaManifest(saga, sqlDialect, $"{manifest.Prefix}_", nameFilter)).ToArray());
         }
+    }
+
+    internal static ManifestOutput.PersistenceManifest.SagaManifest CreateSagaManifest(SagaMetadata sagaMetadata, SqlDialect sqlDialect, string tablePrefix, Func<string, string> nameFilter)
+    {
+        var sqlSagaData = SqlSagaTypeDataReader.GetTypeData(sagaMetadata);
+        var tableSuffix = nameFilter(sqlSagaData.TableSuffix);
+
+        return new()
+        {
+            Name = sagaMetadata.Name,
+            TableName = sqlDialect.GetSagaTableName(tablePrefix, tableSuffix),
+            Indexes = !string.IsNullOrEmpty(sqlSagaData.CorrelationProperty)
+                ?
+                [
+                    new()
+                    {
+                        Name = $"Index_Correlation_{sqlSagaData.CorrelationProperty}",
+                        Columns = sqlSagaData.CorrelationProperty
+                    }
+                ]
+                : []
+        };
+    }
+
+    static Func<string, string> GetNameFilter(IReadOnlySettings settings)
+    {
+        return SagaSettings.GetNameFilter(settings) ?? (sagaName => sagaName);
     }
 
     static SagaInfoCache BuildSagaInfoCache(SqlDialect sqlDialect, IReadOnlySettings settings)
@@ -84,8 +97,7 @@ sealed class SqlSagaFeature : Feature
         readerCreator ??= reader => new JsonTextReader(reader);
         var writerCreator = SagaSettings.GetWriterCreator(settings);
         writerCreator ??= writer => new JsonTextWriter(writer);
-        var nameFilter = SagaSettings.GetNameFilter(settings);
-        nameFilter ??= sagaName => sagaName;
+        var nameFilter = GetNameFilter(settings);
         var versionDeserializeBuilder = SagaSettings.GetVersionSettings(settings);
         var tablePrefix = settings.GetTablePrefix(settings.EndpointName());
         return new SagaInfoCache(


### PR DESCRIPTION
This ensures that the same name is used in the manifest as in other places. Prevents exceptions in case of long names when using Oracle.

Fixes #2042 