### PR TITLE
[Release 9.0] CVE fix for Amazon.CDK.Lib

### DIFF
--- a/src/AuroraSetup/AuroraSetup.csproj
+++ b/src/AuroraSetup/AuroraSetup.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.235.1" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="2.253.0" />
     <PackageReference Include="Amazon.Jsii.Analyzers" Version="1.125.0" />
-    <PackageReference Include="Constructs" Version="10.4.5" />
+    <PackageReference Include="Constructs" Version="10.5.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
-  This PR addresses https://github.com/particular/NServiceBus.Persistence.Sql/issues/2052