### PR TITLE
Remove 'tag' parameter from PostgreSQL setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,6 @@ jobs:
         uses: Particular/setup-postgres-action@v2.0.0
         with:
           connection-string-name: PostgreSqlConnectionString
-          tag: SqlPersistence
           registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
           registry-password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Setup MySQL


### PR DESCRIPTION
Removed the 'tag' parameter from the PostgreSQL setup step.