### PR TITLE
SQL Persistence manifest reports wrong table names, ignoring TableSuffix, NameFilter and TablePrefix

### DIFF
--- a/src/SqlPersistence.Tests/Outbox/SqlOutboxFeatureTests.cs
+++ b/src/SqlPersistence.Tests/Outbox/SqlOutboxFeatureTests.cs
@@ -1,0 +1,41 @@
+using NServiceBus.Settings;
+using NUnit.Framework;
+
+[TestFixture]
+public class SqlOutboxFeatureTests
+{
+    [Test]
+    public void Outbox_table_prefix_cleans_endpoint_name()
+    {
+        var settings = SettingsFor("My.Endpoint");
+
+        Assert.That(SqlOutboxFeature.GetTablePrefix(settings), Is.EqualTo("My_Endpoint_"));
+    }
+
+    [Test]
+    public void Outbox_table_prefix_honours_custom_table_prefix()
+    {
+        var settings = SettingsFor("My.Endpoint");
+        settings.Set("SqlPersistence.TablePrefix", "Foo_");
+
+        Assert.That(SqlOutboxFeature.GetTablePrefix(settings), Is.EqualTo("Foo_"));
+    }
+
+    [Test]
+    public void Outbox_table_prefix_honours_processor_endpoint()
+    {
+        var settings = SettingsFor("My.Endpoint");
+        settings.Set(SqlOutboxFeature.ProcessorEndpointKey, "Processor.Endpoint");
+
+        // The outbox may run against a processor endpoint, so the prefix has to follow that
+        // endpoint's name rather than this endpoint's.
+        Assert.That(SqlOutboxFeature.GetTablePrefix(settings), Is.EqualTo("Processor_Endpoint_"));
+    }
+
+    static SettingsHolder SettingsFor(string endpointName)
+    {
+        var settings = new SettingsHolder();
+        settings.Set("NServiceBus.Routing.EndpointName", endpointName);
+        return settings;
+    }
+}

--- a/src/SqlPersistence.Tests/Saga/SqlSagaFeatureTests.cs
+++ b/src/SqlPersistence.Tests/Saga/SqlSagaFeatureTests.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using NServiceBus;
+using NServiceBus.Persistence.Sql;
+using NServiceBus.Sagas;
+using NUnit.Framework;
+
+[TestFixture]
+public class SqlSagaFeatureTests
+{
+    [Test]
+    public void Saga_manifest_uses_sql_saga_table_suffix_for_oracle()
+    {
+        var manifest = SqlSagaFeature.BuildSagaManifests(
+            MetadataFor(typeof(SagaWithEntityNameLongerThanOracleAllows)),
+            new SqlDialect.Oracle(),
+            "Endpoint_",
+            sagaName => sagaName).Single();
+
+        Assert.That(manifest.TableName, Is.EqualTo("\"SHORTSAGATABLE\""));
+        Assert.That(manifest.Indexes.Single().Name, Is.EqualTo("Index_Correlation_CorrelationProperty"));
+        Assert.That(manifest.Indexes.Single().Columns, Is.EqualTo("CorrelationProperty"));
+    }
+
+    [Test]
+    public void Saga_manifest_uses_sql_saga_table_suffix()
+    {
+        var manifest = SqlSagaFeature.BuildSagaManifests(
+            MetadataFor(typeof(SagaWithEntityNameLongerThanOracleAllows)),
+            new SqlDialect.MsSqlServer(),
+            "Endpoint_",
+            sagaName => sagaName).Single();
+
+        Assert.That(manifest.TableName, Is.EqualTo("[dbo].[Endpoint_ShortSagaTable]"));
+    }
+
+    [Test]
+    public void Saga_manifest_uses_saga_name_not_saga_data_name()
+    {
+        var manifest = SqlSagaFeature.BuildSagaManifests(
+            MetadataFor(typeof(PlainSaga)),
+            new SqlDialect.MsSqlServer(),
+            "Endpoint_",
+            sagaName => sagaName).Single();
+
+        Assert.That(manifest.TableName, Is.EqualTo("[dbo].[Endpoint_PlainSaga]"));
+    }
+
+    [Test]
+    public void Saga_manifest_index_honours_attribute_correlation_property_override()
+    {
+        var manifest = SqlSagaFeature.BuildSagaManifests(
+            MetadataFor(typeof(SagaWithOverriddenCorrelationProperty)),
+            new SqlDialect.MsSqlServer(),
+            "Endpoint_",
+            sagaName => sagaName).Single();
+
+        // The [SqlSaga] attribute overrides the correlation property, so the manifest index must
+        // follow the attribute (as the runtime does) rather than the property inferred from the mapper.
+        Assert.That(manifest.Indexes.Single().Name, Is.EqualTo("Index_Correlation_AttributeChosenProperty"));
+        Assert.That(manifest.Indexes.Single().Columns, Is.EqualTo("AttributeChosenProperty"));
+    }
+
+    [Test]
+    public void Saga_manifest_applies_name_filter_to_table_suffix()
+    {
+        // The filter runs against the table suffix, not the saga name, matching the runtime.
+        var manifest = SqlSagaFeature.BuildSagaManifests(
+            MetadataFor(typeof(SagaWithEntityNameLongerThanOracleAllows)),
+            new SqlDialect.MsSqlServer(),
+            "Endpoint_",
+            sagaName => sagaName == "ShortSagaTable" ? "Filtered" : sagaName).Single();
+
+        Assert.That(manifest.TableName, Is.EqualTo("[dbo].[Endpoint_Filtered]"));
+    }
+
+    static SagaMetadataCollection MetadataFor(params Type[] sagaTypes)
+    {
+        var metadata = new SagaMetadataCollection();
+        metadata.AddRange(SagaMetadata.CreateMany(sagaTypes));
+        return metadata;
+    }
+
+    [SqlSaga(correlationProperty: "AttributeChosenProperty")]
+    public class SagaWithOverriddenCorrelationProperty :
+        Saga<SagaWithOverriddenCorrelationProperty.SagaData>, IAmStartedByMessages<StartMessage>
+    {
+        public Task Handle(StartMessage message, IMessageHandlerContext context) => Task.CompletedTask;
+
+        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper) =>
+            mapper.MapSaga(saga => saga.MapperChosenProperty).ToMessage<StartMessage>(message => message.CorrelationProperty);
+
+        public class SagaData : ContainSagaData
+        {
+            public string MapperChosenProperty { get; set; }
+            public string AttributeChosenProperty { get; set; }
+        }
+    }
+
+    [SqlSaga(tableSuffix: "ShortSagaTable")]
+    public class SagaWithEntityNameLongerThanOracleAllows :
+        Saga<SagaWithEntityNameLongerThanOracleAllows.SagaDataWithEntityNameLongerThanOracleAllows>,
+        IAmStartedByMessages<StartMessage>
+    {
+        public Task Handle(StartMessage message, IMessageHandlerContext context) => Task.CompletedTask;
+
+        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaDataWithEntityNameLongerThanOracleAllows> mapper) =>
+            mapper.MapSaga(saga => saga.CorrelationProperty).ToMessage<StartMessage>(message => message.CorrelationProperty);
+
+        public class SagaDataWithEntityNameLongerThanOracleAllows : ContainSagaData
+        {
+            public string CorrelationProperty { get; set; }
+        }
+    }
+
+    public class PlainSaga :
+        Saga<PlainSaga.SagaData>, IAmStartedByMessages<StartMessage>
+    {
+        public Task Handle(StartMessage message, IMessageHandlerContext context) => Task.CompletedTask;
+
+        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper) =>
+            mapper.MapSaga(saga => saga.CorrelationProperty).ToMessage<StartMessage>(message => message.CorrelationProperty);
+
+        public class SagaData : ContainSagaData
+        {
+            public string CorrelationProperty { get; set; }
+        }
+    }
+
+    public class StartMessage : IMessage
+    {
+        public string CorrelationProperty { get; set; }
+    }
+}

--- a/src/SqlPersistence/Outbox/SqlOutboxFeature.cs
+++ b/src/SqlPersistence/Outbox/SqlOutboxFeature.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using NServiceBus;
 using NServiceBus.Features;
 using NServiceBus.Outbox;
+using NServiceBus.Settings;
 
 sealed class SqlOutboxFeature : Feature
 {
@@ -19,8 +20,7 @@ sealed class SqlOutboxFeature : Feature
     {
         var settings = context.Settings;
         var connectionManager = settings.GetConnectionBuilder<StorageType.Outbox>();
-        var endpointName = settings.GetOrDefault<string>(ProcessorEndpointKey) ?? settings.EndpointName();
-        var tablePrefix = settings.GetTablePrefix(endpointName);
+        var tablePrefix = GetTablePrefix(settings);
         var sqlDialect = settings.GetSqlDialect();
 
         var pessimisticMode = context.Settings.GetOrDefault<bool>(ConcurrencyMode);
@@ -59,9 +59,11 @@ sealed class SqlOutboxFeature : Feature
 
         if (settings.TryGet<ManifestOutput.PersistenceManifest>(out var manifest))
         {
+            // Uses the same prefix as the commands above, so the manifest cannot report a
+            // different table to the one the outbox reads and writes.
             manifest.SetOutbox(() => new ManifestOutput.PersistenceManifest.OutboxManifest
             {
-                TableName = sqlDialect.GetOutboxTableName($"{manifest.Prefix}_")
+                TableName = sqlDialect.GetOutboxTableName(tablePrefix)
             });
         }
 
@@ -93,6 +95,11 @@ sealed class SqlOutboxFeature : Feature
         context.RegisterStartupTask(b =>
             new OutboxCleaner(outboxPersister.RemoveEntriesOlderThan, b.GetRequiredService<CriticalError>().Raise, timeToKeepDeduplicationData, frequencyToRunCleanup, new AsyncTimer()));
     }
+
+    // The outbox may run against a processor endpoint rather than this endpoint, so the
+    // prefix is derived from that endpoint name where one is configured.
+    internal static string GetTablePrefix(IReadOnlySettings settings) =>
+        settings.GetTablePrefix(settings.GetOrDefault<string>(ProcessorEndpointKey) ?? settings.EndpointName());
 
     internal const string TimeToKeepDeduplicationData = "Persistence.Sql.Outbox.TimeToKeepDeduplicationData";
     internal const string FrequencyToRunDeduplicationDataCleanup = "Persistence.Sql.Outbox.FrequencyToRunDeduplicationDataCleanup";

--- a/src/SqlPersistence/Saga/SqlSagaFeature.cs
+++ b/src/SqlPersistence/Saga/SqlSagaFeature.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
 using NServiceBus;
@@ -30,7 +31,12 @@ sealed class SqlSagaFeature : Feature
         var sqlDialect = settings.GetSqlDialect();
         var services = context.Services;
 
-        services.AddSingleton(BuildSagaInfoCache(sqlDialect, settings));
+        // Resolved once and shared by the persister and the manifest so the two cannot report
+        // different tables for the same saga.
+        var tablePrefix = settings.GetTablePrefix(settings.EndpointName());
+        Func<string, string> nameFilter = SagaSettings.GetNameFilter(settings) ?? (sagaName => sagaName);
+
+        services.AddSingleton(BuildSagaInfoCache(sqlDialect, settings, tablePrefix, nameFilter));
         services.AddSingleton<ISagaPersister>(provider => new SagaPersister(provider.GetRequiredService<SagaInfoCache>(), sqlDialect));
 
         var installerSettings = settings.GetOrDefault<InstallerSettings>();
@@ -55,27 +61,46 @@ sealed class SqlSagaFeature : Feature
 
         if (settings.TryGet<ManifestOutput.PersistenceManifest>(out var manifest))
         {
-            manifest.SetSagas(() => settings.Get<SagaMetadataCollection>().Select(saga => GetSagaTableSchema(saga.Name, saga.EntityName, saga.TryGetCorrelationProperty(out var correlationProperty) ? correlationProperty.Name : null)).ToArray());
+            manifest.SetSagas(() => BuildSagaManifests(
+                settings.Get<SagaMetadataCollection>(),
+                sqlDialect,
+                tablePrefix,
+                nameFilter));
+        }
+    }
 
-            ManifestOutput.PersistenceManifest.SagaManifest GetSagaTableSchema(string sagaName, string entityName, string correlationProperty) => new()
+    internal static ManifestOutput.PersistenceManifest.SagaManifest[] BuildSagaManifests(
+        SagaMetadataCollection metadataCollection,
+        SqlDialect sqlDialect,
+        string tablePrefix,
+        Func<string, string> nameFilter) =>
+        metadataCollection.Select(metadata =>
+        {
+            // Resolve suffix and correlation property the same way the runtime does, so the manifest
+            // can't drift from it, including honouring an explicit [SqlSaga(correlationProperty: ...)].
+            var typeData = SqlSagaTypeDataReader.GetTypeData(metadata);
+            return new ManifestOutput.PersistenceManifest.SagaManifest
             {
-                Name = sagaName,
-                TableName = sqlDialect.GetSagaTableName($"{manifest.Prefix}_", entityName),
-                Indexes = !string.IsNullOrEmpty(correlationProperty)
+                Name = metadata.Name,
+                TableName = sqlDialect.GetSagaTableName(tablePrefix, nameFilter(typeData.TableSuffix)),
+                Indexes = !string.IsNullOrEmpty(typeData.CorrelationProperty)
                     ?
                     [
                         new()
                         {
-                            Name = $"Index_Correlation_{correlationProperty}",
-                            Columns = correlationProperty
+                            Name = $"Index_Correlation_{typeData.CorrelationProperty}",
+                            Columns = typeData.CorrelationProperty
                         }
                     ]
                     : []
             };
-        }
-    }
+        }).ToArray();
 
-    static SagaInfoCache BuildSagaInfoCache(SqlDialect sqlDialect, IReadOnlySettings settings)
+    static SagaInfoCache BuildSagaInfoCache(
+        SqlDialect sqlDialect,
+        IReadOnlySettings settings,
+        string tablePrefix,
+        Func<string, string> nameFilter)
     {
         var jsonSerializerSettings = SagaSettings.GetJsonSerializerSettings(settings);
         var jsonSerializer = BuildJsonSerializer(jsonSerializerSettings);
@@ -84,10 +109,7 @@ sealed class SqlSagaFeature : Feature
         readerCreator ??= reader => new JsonTextReader(reader);
         var writerCreator = SagaSettings.GetWriterCreator(settings);
         writerCreator ??= writer => new JsonTextWriter(writer);
-        var nameFilter = SagaSettings.GetNameFilter(settings);
-        nameFilter ??= sagaName => sagaName;
         var versionDeserializeBuilder = SagaSettings.GetVersionSettings(settings);
-        var tablePrefix = settings.GetTablePrefix(settings.EndpointName());
         return new SagaInfoCache(
             versionSpecificSettings: versionDeserializeBuilder,
             jsonSerializer: jsonSerializer,

--- a/src/SqlPersistence/Subscription/SqlSubscriptionFeature.cs
+++ b/src/SqlPersistence/Subscription/SqlSubscriptionFeature.cs
@@ -18,7 +18,7 @@ sealed class SqlSubscriptionFeature : Feature
         var settings = context.Settings;
 
         var connectionManager = settings.GetConnectionBuilder<StorageType.Subscriptions>();
-        var tablePrefix = settings.GetTablePrefix(context.Settings.EndpointName());
+        var tablePrefix = settings.GetTablePrefix(settings.EndpointName());
         var sqlDialect = settings.GetSqlDialect();
         var cacheFor = SubscriptionSettings.GetCacheFor(settings);
         var persister = new SubscriptionPersister(connectionManager, tablePrefix, sqlDialect, cacheFor);
@@ -43,9 +43,11 @@ sealed class SqlSubscriptionFeature : Feature
 
         if (settings.TryGet<ManifestOutput.PersistenceManifest>(out var manifest))
         {
+            // Uses the same prefix as the persister above, so the manifest cannot report a
+            // different table to the one subscriptions are read from and written to.
             manifest.SetSqlSubscriptions(() => new ManifestOutput.PersistenceManifest.SubscriptionManifest
             {
-                TableName = sqlDialect.GetSubscriptionTableName($"{manifest.Prefix}_")
+                TableName = sqlDialect.GetSubscriptionTableName(tablePrefix)
             });
         }
     }


### PR DESCRIPTION
Backport of:
-  https://github.com/Particular/NServiceBus.Persistence.Sql/pull/2049

Which fixes for the `release-9.0` branch:
- https://github.com/Particular/NServiceBus.Persistence.Sql/issues/2042